### PR TITLE
Sanitize back-ticks in strings when there is a possibility of Cypher injection

### DIFF
--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -61,6 +61,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -670,8 +672,19 @@ public class Util {
         return SourceVersion.isIdentifier(var) && !var.contains("$") ? var : '`' + var + '`';
     }
 
-    public static String sanitizeAndQuote(String var) {
-        return quote(var.replaceAll("`", ""));
+    // Escape all backticks in a string to stop Cypher Injection Attacks
+    public static String sanitizeBackTicks(String text) {
+        Pattern finOddCountBackticks = Pattern.compile("(?<!`)`(?:`{2})*(?!`)");
+        Matcher matcher = finOddCountBackticks.matcher(text);
+
+        int currentMatch = 0;
+        String newText = text;
+        while (matcher.find()) {
+            newText = new StringBuilder(newText).insert(matcher.start() + currentMatch, "`").toString();
+            currentMatch++;
+        }
+
+        return newText;
     }
 
     public static String param(String var) {

--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -672,23 +672,53 @@ public class Util {
         return SourceVersion.isIdentifier(var) && !var.contains("$") ? var : '`' + var + '`';
     }
 
-    // Escape all backticks in a string to stop Cypher Injection Attacks
-    public static String sanitizeBackTicks(String text) {
-        if (text == null) return null;
-        // Replace unicode backticks with the backtick char first
-        text = text.replaceAll("\u0060", "`");
-        Pattern findOddCountBackticks = Pattern.compile("(?<!`)`(?:`{2})*(?!`)");
-        Matcher matcher = findOddCountBackticks.matcher(text);
+    private static final String BACKTICK_OR_UC = "[`\\\\\u0060]";
 
-        int currentMatch = 0;
-        String newText = text;
-        while (matcher.find()) {
-            newText = new StringBuilder(newText).insert(matcher.start() + currentMatch, "`").toString();
-            currentMatch++;
+    private static final Pattern LABEL_AND_TYPE_QUOTATION = Pattern.compile(
+            String.format("(?<!%1$s)%1$s(?:%1$s{2})*(?!%1$s)", BACKTICK_OR_UC));
+
+    /**
+     * This is a literal copy of {@code javax.lang.model.SourceVersion#isIdentifier(CharSequence)} included here to
+     * be not dependent on the compiler module.
+     *
+     * @param name A possible Java identifier
+     * @return True, if {@code name} represents an identifier.
+     */
+    public static boolean isIdentifier(CharSequence name) {
+        String id = name.toString();
+
+        if (id.length() == 0) {
+            return false;
+        }
+        int cp = id.codePointAt(0);
+        if (!Character.isJavaIdentifierStart(cp)) {
+            return false;
+        }
+        for (int i = Character.charCount(cp); i < id.length(); i += Character.charCount(cp)) {
+            cp = id.codePointAt(i);
+            if (!Character.isJavaIdentifierPart(cp)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Escapes the string {@literal potentiallyNonIdentifier} in all cases when it's not a valid Cypher identifier.
+     *
+     * @param potentiallyNonIdentifier A value to escape
+     * @return The escaped value or the same value if no escaping is necessary.
+     */
+    public static String sanitizeBackTicks(String potentiallyNonIdentifier) {
+
+        if (potentiallyNonIdentifier == null || potentiallyNonIdentifier.trim().isEmpty() || isIdentifier(potentiallyNonIdentifier)) {
+            return potentiallyNonIdentifier;
         }
 
-        return newText;
+        Matcher matcher = LABEL_AND_TYPE_QUOTATION.matcher(potentiallyNonIdentifier);
+        return matcher.replaceAll("`$0");
     }
+
 
     public static String param(String var) {
         return var.charAt(0) == '$' ? var : '$'+quote(var);

--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -674,8 +674,11 @@ public class Util {
 
     // Escape all backticks in a string to stop Cypher Injection Attacks
     public static String sanitizeBackTicks(String text) {
-        Pattern finOddCountBackticks = Pattern.compile("(?<!`)`(?:`{2})*(?!`)");
-        Matcher matcher = finOddCountBackticks.matcher(text);
+        if (text == null) return null;
+        // Replace unicode backticks with the backtick char first
+        text = text.replaceAll("\u0060", "`");
+        Pattern findOddCountBackticks = Pattern.compile("(?<!`)`(?:`{2})*(?!`)");
+        Matcher matcher = findOddCountBackticks.matcher(text);
 
         int currentMatch = 0;
         String newText = text;

--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -552,11 +552,14 @@ public class GraphRefactoring {
             node = Util.rebind(innerTx, node);
             Object value = node.getProperty(sourceKey, null);
             if (value != null) {
+                String nodeLabel = Util.sanitizeBackTicks(label);
+                String key = Util.sanitizeBackTicks(targetKey);
+                String relType = Util.sanitizeBackTicks(relationshipType);
                 String q =
                         "WITH $node AS n " +
-                                "MERGE (cat:`" + label + "` {`" + targetKey + "`: $value}) " +
-                                (outgoing ? "MERGE (n)-[:`" + relationshipType + "`]->(cat) "
-                                        : "MERGE (n)<-[:`" + relationshipType + "`]-(cat) ") +
+                                "MERGE (cat:`" + nodeLabel + "` {`" + key + "`: $value}) " +
+                                (outgoing ? "MERGE (n)-[:`" + relType + "`]->(cat) "
+                                        : "MERGE (n)<-[:`" + relType + "`]-(cat) ") +
                                 "RETURN cat";
                 Map<String, Object> params = new HashMap<>(2);
                 params.put("node", node);

--- a/core/src/main/java/apoc/refactor/rename/Rename.java
+++ b/core/src/main/java/apoc/refactor/rename/Rename.java
@@ -62,6 +62,8 @@ public class Rename {
 	@Description("apoc.refactor.rename.label(oldLabel, newLabel, [nodes]) | rename a label from 'oldLabel' to 'newLabel' for all nodes. If 'nodes' is provided renaming is applied to this set only")
 	public Stream<BatchAndTotalResultWithInfo> label(@Name("oldLabel") String oldLabel, @Name("newLabel") String newLabel, @Name(value = "nodes", defaultValue = "[]") List<Node> nodes) {
 		nodes = nodes.stream().map(n -> Util.rebind(tx, n)).collect(Collectors.toList());
+		oldLabel = Util.sanitizeBackTicks(oldLabel);
+		newLabel = Util.sanitizeBackTicks(newLabel);
 		String cypherIterate = nodes != null && !nodes.isEmpty() ? "UNWIND $nodes AS n WITH n WHERE n:`"+oldLabel+"` RETURN n" : "MATCH (n:`"+oldLabel+"`) RETURN n";
         String cypherAction = "SET n:`"+newLabel+"` REMOVE n:`"+oldLabel+"`";
         Map<String, Object> parameters = MapUtil.map("batchSize", 100000, "parallel", true, "iterateList", true, "params", MapUtil.map("nodes", nodes));
@@ -78,6 +80,8 @@ public class Rename {
 													@Name(value = "rels", defaultValue = "[]") List<Relationship> rels,
 													@Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
 		rels = rels.stream().map(r -> Util.rebind(tx, r)).collect(Collectors.toList());
+		newType = Util.sanitizeBackTicks(newType);
+		oldType = Util.sanitizeBackTicks(oldType);
 		String cypherIterate = rels != null && ! rels.isEmpty() ?
 				"UNWIND $rels AS oldRel WITH oldRel WHERE type(oldRel)=\""+oldType+"\" RETURN oldRel,startNode(oldRel) as a,endNode(oldRel) as b" :
 				"MATCH (a)-[oldRel:`"+oldType+"`]->(b) RETURN oldRel,a,b";
@@ -117,8 +121,10 @@ public class Rename {
 															@Name(value="nodes", defaultValue = "[]") List<Node> nodes,
 															@Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
 		nodes = nodes.stream().map(n -> Util.rebind(tx, n)).collect(Collectors.toList());
-		String cypherIterate = nodes != null && ! nodes.isEmpty() ? "UNWIND $nodes AS n WITH n WHERE n."+oldName+" IS NOT NULL return n" : "match (n) where n."+oldName+" IS NOT NULL return n";
-		String cypherAction = "set n."+newName+"= n."+oldName+" remove n."+oldName;
+		oldName = Util.sanitizeBackTicks(oldName);
+		newName = Util.sanitizeBackTicks(newName);
+		String cypherIterate = nodes != null && ! nodes.isEmpty() ? "UNWIND $nodes AS n WITH n WHERE n.`"+oldName+"` IS NOT NULL return n" : "match (n) where n.`"+oldName+"` IS NOT NULL return n";
+		String cypherAction = "set n.`"+newName+"`= n.`"+oldName+"` remove n.`"+oldName+"`";
 		final Map<String, Object> params = MapUtil.map("nodes", nodes);
 		Map<String, Object> parameters = getPeriodicConfig(config, params);
 		return getResultOfBatchAndTotalWithInfo(newPeriodic().iterate(cypherIterate, cypherAction, parameters), db, null, null, oldName);
@@ -134,8 +140,10 @@ public class Rename {
 															@Name(value="rels", defaultValue = "[]") List<Relationship> rels,
 															@Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
 		rels = rels.stream().map(r -> Util.rebind(tx, r)).collect(Collectors.toList());
-		String cypherIterate = rels != null && ! rels.isEmpty() ? "UNWIND $rels AS r WITH r WHERE r."+oldName+" IS NOT NULL return r" : "match ()-[r]->() where r."+oldName+" IS NOT NULL return r";
-		String cypherAction = "set r."+newName+"= r."+oldName+" remove r."+oldName;
+		newName = Util.sanitizeBackTicks(newName);
+		oldName = Util.sanitizeBackTicks(oldName);
+		String cypherIterate = rels != null && ! rels.isEmpty() ? "UNWIND $rels AS r WITH r WHERE r.`"+oldName+"` IS NOT NULL return r" : "match ()-[r]->() where r.`"+oldName+"` IS NOT NULL return r";
+		String cypherAction = "set r.`"+newName+"` = r.`"+oldName+"` remove r.`"+oldName+"`";
 		final Map<String, Object> params = MapUtil.map("rels", rels);
 		Map<String, Object> parameters = getPeriodicConfig(config, params);
 		return getResultOfBatchAndTotalWithInfo(newPeriodic().iterate(cypherIterate, cypherAction, parameters), db, null, null, oldName);

--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -3,6 +3,7 @@ package apoc.schema;
 import apoc.result.AssertSchemaResult;
 import apoc.result.IndexConstraintNodeInfo;
 import apoc.result.IndexConstraintRelationshipInfo;
+import apoc.util.Util;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.common.EntityType;
 import org.neo4j.common.TokenNameLookup;
@@ -156,9 +157,9 @@ public class Schemas {
 
     private AssertSchemaResult createNodeKeyConstraint(String lbl, List<Object> keys) {
         String keyProperties = keys.stream()
-                .map( property -> String.format("n.`%s`", property))
+                .map( property -> String.format("n.`%s`", Util.sanitizeBackTicks(property.toString())))
                 .collect( Collectors.joining( "," ) );
-        tx.execute(String.format("CREATE CONSTRAINT FOR (n:`%s`) REQUIRE (%s) IS NODE KEY", lbl, keyProperties)).close();
+        tx.execute(String.format("CREATE CONSTRAINT FOR (n:`%s`) REQUIRE (%s) IS NODE KEY", Util.sanitizeBackTicks(lbl), keyProperties)).close();
         List<String> keysToSting = keys.stream().map(Object::toString).collect(Collectors.toList());
         return new AssertSchemaResult(lbl, keysToSting).unique().created();
     }
@@ -240,9 +241,9 @@ public class Schemas {
 
     private AssertSchemaResult createCompoundIndex(String label, List<String> keys) {
         List<String> backTickedKeys = new ArrayList<>();
-        keys.forEach(key->backTickedKeys.add(String.format("n.`%s`", key)));
+        keys.forEach(key->backTickedKeys.add(String.format("n.`%s`", Util.sanitizeBackTicks(key))));
 
-        tx.execute(String.format("CREATE INDEX FOR (n:`%s`) ON (%s)", label, String.join(",", backTickedKeys))).close();
+        tx.execute(String.format("CREATE INDEX FOR (n:`%s`) ON (%s)", Util.sanitizeBackTicks(label), String.join(",", backTickedKeys))).close();
         return new AssertSchemaResult(label, keys).created();
     }
 

--- a/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
+++ b/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
@@ -1053,6 +1053,32 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
         assertEquals(8, relsCount);
         db.executeTransactionally("DROP CONSTRAINT constraint");
     }
+    @Test
+    public void testRefactorCategoryDoesntAllowCypherInjection() {
+        // given
+        final String label = "Country";
+        final String targetKey = "name";
+        db.executeTransactionally("CREATE CONSTRAINT constraint FOR (n:`" + label + "`) REQUIRE n.`" + targetKey + "` IS UNIQUE");
+        db.executeTransactionally("with [\"IT\", \"DE\"] as countries\n" +
+                "unwind countries as country\n" +
+                "foreach (no in RANGE(1, 4) |\n" +
+                "  create (n:Company {name: country + no, country: country})\n" +
+                ")");
+
+        // when
+        db.executeTransactionally("CALL apoc.refactor.categorize('country', 'FOO`]->() WITH n SET n = {} RETURN n//', true, $label, $targetKey, [], 1)",
+                map("label", label, "targetKey", targetKey));
+
+        // then
+        final long countries = TestUtil.singleResultFirstColumn(db, "MATCH (c:Country) RETURN count(c) AS countries");
+        assertEquals(2, countries);
+        final List<String> countryNames = TestUtil.firstColumn(db, "MATCH (c:Country) RETURN c.name");
+        assertThat(countryNames, Matchers.containsInAnyOrder("IT", "DE"));
+
+        final long relsCount = TestUtil.singleResultFirstColumn(db, "MATCH p = (c:Company)-[:`FOO``]->() WITH n SET n = {} RETURN n//`]->(cc:Country) RETURN count(p) AS relsCount");
+        assertEquals(8, relsCount);
+        db.executeTransactionally("DROP CONSTRAINT constraint");
+    }
 
     @Test
     public void testMergeNodeShouldNotCreateSelfRelationshipsInPreExistingSelfRel() {

--- a/core/src/test/java/apoc/refactor/rename/RenameTest.java
+++ b/core/src/test/java/apoc/refactor/rename/RenameTest.java
@@ -65,7 +65,7 @@ public class RenameTest {
 				map(),
 				(r) -> {});
 
-		assertEquals(10L, resultNodesMatches("`Whatever`` WITH n MATCH (m) DETACH DELETE m //`", null));
+		assertEquals(10L, resultNodesMatches("Whatever`` WITH n MATCH (m) DETACH DELETE m //", null));
 		assertEquals(0L, resultNodesMatches("Foo", null));
 
 		testCall(db, "CALL apoc.refactor.rename.label(" +
@@ -75,7 +75,7 @@ public class RenameTest {
 				map(),
 				(r) -> {});
 
-		assertEquals(0L, resultNodesMatches("`Whatever`` WITH n MATCH (m) DETACH DELETE m //`", null));
+		assertEquals(0L, resultNodesMatches("Whatever`` WITH n MATCH (m) DETACH DELETE m //", null));
 		assertEquals(10L, resultNodesMatches("Foo", null));
 	}
 
@@ -89,9 +89,16 @@ public class RenameTest {
 						")",
 				map("nodes", nodes.subList(0,3)),
 				(r) -> {});
+		testCall(db, "CALL apoc.refactor.rename.label(" +
+						"  'Foo', " +
+						"  'Whatever\u0060 WITH n MATCH (m) DETACH DELETE m //'," +
+						"   $nodes" +
+						")",
+				map("nodes", nodes.subList(4,6)),
+				(r) -> {});
 
-		assertEquals(3L, resultNodesMatches("`Whatever`` WITH n MATCH (m) DETACH DELETE m //`", null));
-		assertEquals(7L, resultNodesMatches("Foo", null));
+		assertEquals(5L, resultNodesMatches("Whatever`` WITH n MATCH (m) DETACH DELETE m //", null));
+		assertEquals(5L, resultNodesMatches("Foo", null));
 
 		testCall(db, "CALL apoc.refactor.rename.label(" +
 						"  'Whatever` WITH n MATCH (m) DETACH DELETE m //', " +
@@ -100,8 +107,8 @@ public class RenameTest {
 				map(),
 				(r) -> {});
 
-		assertEquals(0L, resultNodesMatches("`Whatever`` WITH n MATCH (m) DETACH DELETE m //`", null));
-		assertEquals(3L, resultNodesMatches("Bar", null));
+		assertEquals(0L, resultNodesMatches("Whatever`` WITH n MATCH (m) DETACH DELETE m //", null));
+		assertEquals(5L, resultNodesMatches("Bar", null));
 	}
 
 	@Test
@@ -137,7 +144,7 @@ public class RenameTest {
 				map(),
 				(r) -> {});
 
-		assertEquals(10L, resultRelationshipsMatches("`Whatever`` WITH n MATCH (m) DETACH DELETE m //`", null));
+		assertEquals(10L, resultRelationshipsMatches("Whatever`` WITH n MATCH (m) DETACH DELETE m //", null));
 		assertEquals(0L, resultRelationshipsMatches("KNOWS", null));
 
 		testCall(db, "CALL apoc.refactor.rename.type(" +
@@ -147,25 +154,33 @@ public class RenameTest {
 				map(),
 				(r) -> {});
 
-		assertEquals(0L, resultRelationshipsMatches("`Whatever`` WITH n MATCH (m) DETACH DELETE m //`", null));
+		assertEquals(0L, resultRelationshipsMatches("Whatever`` WITH n MATCH (m) DETACH DELETE m //", null));
 		assertEquals(10L, resultRelationshipsMatches( "KNOWS", null));
 	}
 	@Test
 	public void testRenameTypeDoesntAllowCypherInjectionForSomeRelationships() throws Exception {
 		db.executeTransactionally("UNWIND range(0,9) AS id CREATE (f:Foo {id: id})-[:KNOWS {id: id}]->(l:Fii {id: id})");
 
-		List<Relationship> rels = TestUtil.firstColumn(db, "MATCH (:Foo)-[r:KNOWS]->(:Fii) RETURN r LIMIT 2");
+		List<Relationship> rels = TestUtil.firstColumn(db, "MATCH (:Foo)-[r:KNOWS]->(:Fii) RETURN r LIMIT 4");
 
 		testCall(db, "CALL apoc.refactor.rename.type(" +
 						"  'KNOWS', " +
 						"  'Whatever` WITH n MATCH (m) DETACH DELETE m //'," +
 						"  $rels" +
 						")",
-				map("rels", rels),
+				map("rels", rels.subList(0,2)),
 				(r) -> {});
 
-		assertEquals(2L, resultRelationshipsMatches("`Whatever`` WITH n MATCH (m) DETACH DELETE m //`", null));
-		assertEquals(8L, resultRelationshipsMatches("KNOWS", null));
+		testCall(db, "CALL apoc.refactor.rename.type(" +
+						"  'KNOWS', " +
+						"  'Whatever\u0060 WITH n MATCH (m) DETACH DELETE m //'," +
+						"  $rels" +
+						")",
+				map("rels", rels.subList(2,4)),
+				(r) -> {});
+
+		assertEquals(4L, resultRelationshipsMatches("Whatever`` WITH n MATCH (m) DETACH DELETE m //", null));
+		assertEquals(6L, resultRelationshipsMatches("KNOWS", null));
 
 		testCall(db, "CALL apoc.refactor.rename.type(" +
 						"  'Whatever` WITH n MATCH (m) DETACH DELETE m //', " +
@@ -174,8 +189,8 @@ public class RenameTest {
 				map(),
 				(r) -> {});
 
-		assertEquals(0L, resultRelationshipsMatches("`Whatever`` WITH n MATCH (m) DETACH DELETE m //`", null));
-		assertEquals(2L, resultRelationshipsMatches( "LIKES", null));
+		assertEquals(0L, resultRelationshipsMatches("Whatever`` WITH n MATCH (m) DETACH DELETE m //", null));
+		assertEquals(4L, resultRelationshipsMatches( "LIKES", null));
 	}
 
 	@Test
@@ -209,7 +224,7 @@ public class RenameTest {
 				map(),
 				(r) -> {});
 
-		assertEquals(10L, resultNodesMatches(null, "`Whatever`` WITH n MATCH (m) DETACH DELETE m //`"));
+		assertEquals(10L, resultNodesMatches(null, "Whatever`` WITH n MATCH (m) DETACH DELETE m //"));
 		assertEquals(0L, resultNodesMatches(null, "name"));
 
 		testCall(db, "CALL apoc.refactor.rename.nodeProperty(" +
@@ -219,7 +234,7 @@ public class RenameTest {
 				map(),
 				(r) -> {});
 
-		assertEquals(0L, resultNodesMatches(null, "`Whatever`` WITH n MATCH (m) DETACH DELETE m //`"));
+		assertEquals(0L, resultNodesMatches(null, "Whatever`` WITH n MATCH (m) DETACH DELETE m //"));
 		assertEquals(10L, resultNodesMatches(null, "name"));
 	}
 	@Test
@@ -232,9 +247,16 @@ public class RenameTest {
 						")",
 				map("nodes", nodes.subList(0,3)),
 				(r) -> {});
+		testCall(db, "CALL apoc.refactor.rename.nodeProperty(" +
+						"  'name', " +
+						"  'Whatever\u0060 WITH n MATCH (m) DETACH DELETE m //'," +
+						"	$nodes" +
+						")",
+				map("nodes", nodes.subList(4,6)),
+				(r) -> {});
 
-		assertEquals(3L, resultNodesMatches(null, "`Whatever`` WITH n MATCH (m) DETACH DELETE m //`"));
-		assertEquals(7L, resultNodesMatches(null, "name"));
+		assertEquals(5L, resultNodesMatches(null, "Whatever`` WITH n MATCH (m) DETACH DELETE m //"));
+		assertEquals(5L, resultNodesMatches(null, "name"));
 
 		testCall(db, "CALL apoc.refactor.rename.nodeProperty(" +
 						"  'Whatever` WITH n MATCH (m) DETACH DELETE m //', " +
@@ -243,8 +265,8 @@ public class RenameTest {
 				map(),
 				(r) -> {});
 
-		assertEquals(0L, resultNodesMatches(null, "`Whatever`` WITH n MATCH (m) DETACH DELETE m //`"));
-		assertEquals(3L, resultNodesMatches(null, "surname"));
+		assertEquals(0L, resultNodesMatches(null, "Whatever`` WITH n MATCH (m) DETACH DELETE m //"));
+		assertEquals(5L, resultNodesMatches(null, "surname"));
 	}
 
 	@Test
@@ -267,7 +289,7 @@ public class RenameTest {
 				map(),
 				(r) -> {});
 
-		assertEquals(10L, resultRelationshipsMatches(null, "`Whatever `` = null remove r.name //`"));
+		assertEquals(10L, resultRelationshipsMatches(null, "Whatever `` = null remove r.name //"));
 		assertEquals(0L, resultRelationshipsMatches(null, "name"));
 
 		testCall(db, "CALL apoc.refactor.rename.typeProperty(" +
@@ -277,7 +299,7 @@ public class RenameTest {
 				map(),
 				(r) -> {});
 
-		assertEquals(0L, resultRelationshipsMatches(null, "`Whatever `` = null remove r.name //`"));
+		assertEquals(0L, resultRelationshipsMatches(null, "Whatever `` = null remove r.name //"));
 		assertEquals(10L, resultRelationshipsMatches(null, "name"));
 	}
 
@@ -293,7 +315,7 @@ public class RenameTest {
 				map("rels",rels),
 				(r) -> {});
 
-		assertEquals(2L, resultRelationshipsMatches(null, "`Whatever `` = null remove r.name //`"));
+		assertEquals(2L, resultRelationshipsMatches(null, "Whatever `` = null remove r.name //"));
 		assertEquals(8L, resultRelationshipsMatches(null, "name"));
 
 		testCall(db, "CALL apoc.refactor.rename.typeProperty(" +
@@ -303,7 +325,7 @@ public class RenameTest {
 				map(),
 				(r) -> {});
 
-		assertEquals(0L, resultRelationshipsMatches(null, "`Whatever `` = null remove r.name //`"));
+		assertEquals(0L, resultRelationshipsMatches(null, "Whatever `` = null remove r.name //"));
 		assertEquals(2L, resultRelationshipsMatches(null, "surname"));
 	}
 
@@ -343,12 +365,12 @@ public class RenameTest {
 	}
 
 	private long resultRelationshipsMatches(String type, String prop){
-		String query = type != null ? "MATCH ()-[r:"+type+"]->() RETURN count(r) as countResult" : "match ()-[r]->() where r."+prop+" IS NOT NULL return count(r) as countResult";
+		String query = type != null ? "MATCH ()-[r:`"+type+"`]->() RETURN count(r) as countResult" : "match ()-[r]->() where r.`"+prop+"` IS NOT NULL return count(r) as countResult";
 		return TestUtil.singleResultFirstColumn(db, query);
 	}
 
 	private long resultNodesMatches(String label, String prop) {
-		String query = label != null ? "MATCH (b:"+label+") RETURN count(b) as countResult" : "match (n) where n."+prop+" IS NOT NULL return count(n) as countResult";
+		String query = label != null ? "MATCH (b:`"+label+"`) RETURN count(b) as countResult" : "match (n) where n.`"+prop+"` IS NOT NULL return count(n) as countResult";
 		return TestUtil.singleResultFirstColumn(db, query);
 	}
 

--- a/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
+++ b/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
@@ -61,6 +61,19 @@ public class SchemasEnterpriseFeaturesTest {
     }
 
     @Test
+    public void testAddConstraintDoesntAllowCypherInjection() {
+        String query = "CALL apoc.schema.assert(null,{Bar:[[\"foo`) IS UNIQUE MATCH (n) DETACH DELETE n; //\", \"bar\"]]}, false)";
+        testResult(session, query, (result) -> {
+            Map<String, Object> r = result.next();
+            assertEquals("Bar", r.get("label"));
+            assertEquals(expectedKeys("foo`) IS UNIQUE MATCH (n) DETACH DELETE n; //", "bar"), r.get("keys"));
+            assertEquals(true, r.get("unique"));
+            assertEquals("CREATED", r.get("action"));
+            assertFalse(result.hasNext());
+        });
+    }
+
+    @Test
     public void testKeptNodeKeyAndUniqueConstraintIfExists() {
         String query = "CALL apoc.schema.assert(null,{Foo:[['foo','bar']]}, false)";
         testResult(session, query, (result) -> {

--- a/core/src/test/java/apoc/schema/SchemasTest.java
+++ b/core/src/test/java/apoc/schema/SchemasTest.java
@@ -474,6 +474,22 @@ public class SchemasTest {
             assertEquals(1, indexes.size());
         }
     }
+
+    @Test
+    public void testCompoundIndexDoesntAllowCypherInjection() throws Exception {
+        awaitIndexesOnline();
+        testResult(db, "CALL apoc.schema.assert({Foo:[['bar`) MATCH (n) DETACH DELETE n; //','baa']]},null,false)", (result) -> {
+            Map<String, Object> r = result.next();
+            assertEquals("Foo", r.get("label"));
+            assertEquals(expectedKeys("bar`) MATCH (n) DETACH DELETE n; //", "baa"), r.get("keys"));
+            assertEquals(false, r.get("unique"));
+        });
+        try (Transaction tx = db.beginTx()) {
+            List<IndexDefinition> indexes = Iterables.asList(tx.schema().getIndexes());
+            assertEquals(1, indexes.size());
+        }
+    }
+
     /*
         This is only for 3.2+
     */

--- a/core/src/test/java/apoc/util/UtilTest.java
+++ b/core/src/test/java/apoc/util/UtilTest.java
@@ -100,6 +100,17 @@ public class UtilTest {
         assertEquals("Hi``````there", Util.sanitizeBackTicks("Hi`````there"));
         assertEquals("``a``b``c``", Util.sanitizeBackTicks("`a`b`c`"));
         assertEquals("``a``b``c``d``", Util.sanitizeBackTicks("\u0060a`b`c\u0060d\u0060"));
+        assertEquals("Foo `\\u0060", Util.sanitizeBackTicks("Foo \\u0060"));
+        assertEquals("ABC", Util.sanitizeBackTicks("ABC"));
+        assertEquals("A C", Util.sanitizeBackTicks("A C"));
+        assertEquals("A`` C", Util.sanitizeBackTicks("A` C"));
+        assertEquals("ALabel", Util.sanitizeBackTicks("ALabel"));
+        assertEquals("A Label", Util.sanitizeBackTicks("A Label"));
+        assertEquals("A ``Label", Util.sanitizeBackTicks("A `Label"));
+        assertEquals("``A ``Label", Util.sanitizeBackTicks("`A `Label"));
+        assertEquals("``A ``Label", Util.sanitizeBackTicks("`A `Label"));
+        assertEquals("Spring Data Neo4j⚡️RX", Util.sanitizeBackTicks("Spring Data Neo4j⚡️RX"));
+        assertEquals("Foo ``", Util.sanitizeBackTicks("Foo \u0060"));
     }
 
     @Test

--- a/core/src/test/java/apoc/util/UtilTest.java
+++ b/core/src/test/java/apoc/util/UtilTest.java
@@ -90,6 +90,19 @@ public class UtilTest {
     }
 
     @Test
+    public void testSanitizeBackTicks() {
+        assertEquals("``", Util.sanitizeBackTicks("`"));
+        assertEquals("``", Util.sanitizeBackTicks("\u0060"));
+        assertEquals("``", Util.sanitizeBackTicks("``"));
+        assertEquals("````", Util.sanitizeBackTicks("\u0060\u0060\u0060"));
+        assertEquals("Hello``", Util.sanitizeBackTicks("Hello`"));
+        assertEquals("Hi````there", Util.sanitizeBackTicks("Hi````there"));
+        assertEquals("Hi``````there", Util.sanitizeBackTicks("Hi`````there"));
+        assertEquals("``a``b``c``", Util.sanitizeBackTicks("`a`b`c`"));
+        assertEquals("``a``b``c``d``", Util.sanitizeBackTicks("\u0060a`b`c\u0060d\u0060"));
+    }
+
+    @Test
     public void testMerge() {
         try {
             final ResultTransformer<Object> resultTransformer = res -> res.next().get("count");


### PR DESCRIPTION
Back-ticks will be escaped to allow users to still have back-ticks in their labels, properties etc as in Cypher, without the risk of Cypher Injection.

This also fixes this issue: https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/3139 