### PR TITLE
SchemasTest expect text-2.0 as default index provider for TEXT indexes

### DIFF
--- a/core/src/test/java/apoc/schema/SchemasTest.java
+++ b/core/src/test/java/apoc/schema/SchemasTest.java
@@ -86,7 +86,7 @@ public class SchemasTest {
         assertEquals("NO FAILURE", r.get("failure"));
         assertEquals(100d, r.get("populationProgress"));
         assertEquals(1d, r.get("valuesSelectivity"));
-        Assertions.assertThat( r.get( "userDescription").toString() ).contains( "name='index3', type='TEXT', schema=(:Person {name}), indexProvider='text-1.0' )" );
+        Assertions.assertThat( r.get( "userDescription").toString() ).contains( "name='index3', type='TEXT', schema=(:Person {name}), indexProvider='text-2.0' )" );
 
         assertTrue(!result.hasNext());
     }


### PR DESCRIPTION
This is a result of the default provider changing in main repo. See this PR https://github.com/neo-technology/neo4j/pull/16580