### PR TITLE
Remove the neo4jVersions gradle property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,11 +128,8 @@ subprojects {
 }
 
 ext {
-    // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "5.0.0"
-    // This should be removed when the version is stable and released
-    neo4jInDevVersion = (System.env.CI != null) ? neo4jVersion + "-dev" : neo4jVersion + "-SNAPSHOT"
-    // instead we apply the override logic here
-    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jInDevVersion
+    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ?
+            project.getProperty("neo4jVersionOverride")
+            : (System.env.CI != null) ? "5.0.0-dev" : "5.0.0-SNAPSHOT"
     testContainersVersion = '1.16.2'
 }


### PR DESCRIPTION
This property was only being used by the `./gradlew versions` task which exists in the master branch.