### PR TITLE
5.0 add storage engine check

### DIFF
--- a/common/src/main/java/apoc/ApocConfig.java
+++ b/common/src/main/java/apoc/ApocConfig.java
@@ -286,6 +286,15 @@ public class ApocConfig extends LifecycleAdapter {
         }
     }
 
+    // Helper method for the apoc.warmup.run procedure, as upcoming storage engines are not able to work
+    // with it.
+    public void checkStorageEngine() {
+        final List<String> supportedTypes = Arrays.asList("standard", "aligned", "high_limit");
+        if (!supportedTypes.contains(neo4jConfig.get(GraphDatabaseSettings.db_format))) {
+            throw new RuntimeException("Record engine type unsupported; please use one of the following; standard, aligned or high_limit");
+        }
+    }
+
     public static ApocConfig apocConfig() {
         return theInstance;
     }

--- a/core/src/main/java/apoc/warmup/Warmup.java
+++ b/core/src/main/java/apoc/warmup/Warmup.java
@@ -1,5 +1,6 @@
 package apoc.warmup;
 
+import apoc.ApocConfig;
 import apoc.util.Util;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.io.pagecache.PageCache;
@@ -67,6 +68,9 @@ public class Warmup {
             "Secondly, the API of this procedure is very specific to Record storage engine." )
     @Description("apoc.warmup.run(loadProperties=false,loadDynamicProperties=false,loadIndexes=false) - quickly loads all nodes and rels into memory by skipping one page at a time")
     public Stream<WarmupResult> run(@Name(value = "loadProperties", defaultValue = "false") boolean loadProperties, @Name(value = "loadDynamicProperties", defaultValue = "false") boolean loadDynamicProperties, @Name(value = "loadIndexes", defaultValue = "false") boolean loadIndexes) throws IOException {
+        // This procedure is likely to break with future storage engines
+        ApocConfig.apocConfig().checkStorageEngine();
+
         PageCache pageCache = db.getDependencyResolver().resolveDependency(PageCache.class);
         KernelTransaction ktx = ((InternalTransaction)tx).kernelTransaction();
 

--- a/core/src/test/java/apoc/warmup/WarmupEnterpriseTest.java
+++ b/core/src/test/java/apoc/warmup/WarmupEnterpriseTest.java
@@ -2,8 +2,6 @@ package apoc.warmup;
 
 import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseInternalSettings;
 import org.neo4j.configuration.GraphDatabaseSettings;
@@ -13,29 +11,39 @@ import java.util.List;
 
 import static apoc.util.TestContainerUtil.createEnterpriseDB;
 import static apoc.util.TestContainerUtil.testCall;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class WarmupEnterpriseTest {
 
-    private static Neo4jContainerExtension neo4jContainer;
-    private static Session session;
-
-    @BeforeClass
-    public static void beforeAll() {
-        neo4jContainer = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.CORE), true)
+    @Test(expected = RuntimeException.class)
+    public void testWarmupIsntAllowedWithOtherStorageEngines() {
+        Neo4jContainerExtension neo4jContainer = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.CORE), true)
                 .withNeo4jConfig(GraphDatabaseInternalSettings.include_versions_under_development.name(), "true")
                 .withNeo4jConfig(GraphDatabaseSettings.db_format.name(), "freki");
         neo4jContainer.start();
-        session = neo4jContainer.getSession();
-    }
+        Session session = neo4jContainer.getSession();
 
-    @AfterClass
-    public static void afterAll() {
+        testCall(session, "CALL apoc.warmup.run()", (r) -> {});
+
         session.close();
         neo4jContainer.close();
     }
 
-    @Test(expected = RuntimeException.class)
-    public void testWarmupIsntAllowedWithOtherStorageEngines() {
-        testCall(session, "CALL apoc.warmup.run()", (r) -> {});
+    @Test
+    public void testWarmupOnEnterpriseStorageEngine() {
+        Neo4jContainerExtension neo4jContainer = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.CORE), true)
+                .withNeo4jConfig(GraphDatabaseInternalSettings.include_versions_under_development.name(), "true")
+                .withNeo4jConfig(GraphDatabaseSettings.db_format.name(), "high_limit");
+        neo4jContainer.start();
+        Session session = neo4jContainer.getSession();
+
+        testCall(session, "CALL apoc.warmup.run(true,true,true)", r -> {
+            assertEquals(true, r.get("indexesLoaded"));
+            assertNotEquals( 0L, r.get("indexPages") );
+        });
+
+        session.close();
+        neo4jContainer.close();
     }
 }

--- a/core/src/test/java/apoc/warmup/WarmupEnterpriseTest.java
+++ b/core/src/test/java/apoc/warmup/WarmupEnterpriseTest.java
@@ -1,0 +1,41 @@
+package apoc.warmup;
+
+import apoc.util.Neo4jContainerExtension;
+import apoc.util.TestContainerUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.configuration.GraphDatabaseInternalSettings;
+import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.driver.Session;
+
+import java.util.List;
+
+import static apoc.util.TestContainerUtil.createEnterpriseDB;
+import static apoc.util.TestContainerUtil.testCall;
+
+public class WarmupEnterpriseTest {
+
+    private static Neo4jContainerExtension neo4jContainer;
+    private static Session session;
+
+    @BeforeClass
+    public static void beforeAll() {
+        neo4jContainer = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.CORE), true)
+                .withNeo4jConfig(GraphDatabaseInternalSettings.include_versions_under_development.name(), "true")
+                .withNeo4jConfig(GraphDatabaseSettings.db_format.name(), "freki");
+        neo4jContainer.start();
+        session = neo4jContainer.getSession();
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        session.close();
+        neo4jContainer.close();
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testWarmupIsntAllowedWithOtherStorageEngines() {
+        testCall(session, "CALL apoc.warmup.run()", (r) -> {});
+    }
+}

--- a/core/src/test/java/apoc/warmup/WarmupTest.java
+++ b/core/src/test/java/apoc/warmup/WarmupTest.java
@@ -4,8 +4,13 @@ import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -67,5 +72,19 @@ public class WarmupTest {
             assertEquals(true, r.get("indexesLoaded"));
             assertNotEquals( 0L, r.get("indexPages") );
         });
+    }
+
+    @Test
+    public void testWarmupOnDifferentStorageEngines() throws Exception {
+        final List<String> supportedTypes = Arrays.asList("standard", "aligned");
+        for (String storageType : supportedTypes) {
+            db.restartDatabase(Map.of(GraphDatabaseSettings.db_format, storageType));
+            TestUtil.registerProcedure(db, Warmup.class);
+
+            TestUtil.testCall(db, "CALL apoc.warmup.run(true,true,true)", r -> {
+                assertEquals(true, r.get("indexesLoaded"));
+                assertNotEquals( 0L, r.get("indexPages") );
+            });
+        }
     }
 }

--- a/docs/asciidoc/modules/ROOT/pages/overview/apoc.warmup/apoc.warmup.run.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/overview/apoc.warmup/apoc.warmup.run.adoc
@@ -68,3 +68,10 @@ apoc.warmup.run(loadProperties = false :: BOOLEAN?, loadDynamicProperties = fals
 == Usage Examples
 include::partial$usage/apoc.warmup.run.adoc[]
 
+[WARNING]
+====
+This procedure can only be used with a Database record format of
+`standard`, `aligned` or `high_limit`. The record format is set using
+the neo4j configuration setting `db.format`.
+====
+


### PR DESCRIPTION
The apoc.warmup.run procedure can only be used with the currently available storage engines.

I've added a checker for checking which storage engine currently is set via config. Let me know thoughts on this! It is also possible to only have the docs updated :)