### PR TITLE
Use DefaultDatabaseResolver to resolve default db (instead of Config)

### DIFF
--- a/core/src/main/java/apoc/cypher/CypherInitializer.java
+++ b/core/src/main/java/apoc/cypher/CypherInitializer.java
@@ -28,7 +28,6 @@ public class CypherInitializer implements AvailabilityListener {
     private final Log userLog;
     private final GlobalProcedures procs;
     private final DependencyResolver dependencyResolver;
-    private final String defaultDb;
 
     /**
      * indicates the status of the initializer, to be used for tests to ensure initializer operations are already done
@@ -40,7 +39,6 @@ public class CypherInitializer implements AvailabilityListener {
         this.userLog = userLog;
         this.dependencyResolver = db.getDependencyResolver();
         this.procs = dependencyResolver.resolveDependency(GlobalProcedures.class);
-        this.defaultDb = dependencyResolver.resolveDependency(DefaultDatabaseResolver.class).defaultDatabase(null);
     }
 
     public boolean isFinished() {
@@ -64,6 +62,7 @@ public class CypherInitializer implements AvailabilityListener {
                     awaitApocProceduresRegistered();
                 }
 
+                var defaultDb = dependencyResolver.resolveDependency(DefaultDatabaseResolver.class).defaultDatabase(null);
                 if (defaultDb.equals(db.databaseName())) {
                     final List<String> versions = db.executeTransactionally("CALL dbms.components", Collections.emptyMap(),
                             r -> (List<String>) r.next().get("versions"));

--- a/core/src/main/java/apoc/cypher/CypherInitializer.java
+++ b/core/src/main/java/apoc/cypher/CypherInitializer.java
@@ -6,11 +6,11 @@ import apoc.version.Version;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.common.DependencyResolver;
-import org.neo4j.configuration.Config;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.kernel.api.procedure.GlobalProcedures;
 import org.neo4j.kernel.availability.AvailabilityListener;
+import org.neo4j.kernel.database.DefaultDatabaseResolver;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.Log;
 
@@ -40,7 +40,7 @@ public class CypherInitializer implements AvailabilityListener {
         this.userLog = userLog;
         this.dependencyResolver = db.getDependencyResolver();
         this.procs = dependencyResolver.resolveDependency(GlobalProcedures.class);
-        this.defaultDb = dependencyResolver.resolveDependency(Config.class).get(GraphDatabaseSettings.default_database);
+        this.defaultDb = dependencyResolver.resolveDependency(DefaultDatabaseResolver.class).defaultDatabase(null);
     }
 
     public boolean isFinished() {


### PR DESCRIPTION
Using Config to resolve default db is correct in Community. In Enterprise:
* in 4.x it is correct in  standalone, but not in clusters (probably nobody noticed - given the troublesome past cluster vs. apoc).
* in 5.0 it is not correct. The config value represents the "initial" default database only. The topology graph knows better, as the default database is dynamically changeable.

This PR is a prerequisite for https://github.com/neo-technology/neo4j/pull/16699