### PR TITLE
Improve backtick sanitization

### DIFF
--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -672,10 +672,7 @@ public class Util {
         return SourceVersion.isIdentifier(var) && !var.contains("$") ? var : '`' + var + '`';
     }
 
-    private static final String BACKTICK_OR_UC = "[`\\\\\u0060]";
-
-    private static final Pattern LABEL_AND_TYPE_QUOTATION = Pattern.compile(
-            String.format("(?<!%1$s)%1$s(?:%1$s{2})*(?!%1$s)", BACKTICK_OR_UC));
+    private static final Pattern LABEL_AND_TYPE_QUOTATION = Pattern.compile("\\\\u0060|(?<!`)`(?:`{2})*(?!`)");
 
     /**
      * This is a literal copy of {@code javax.lang.model.SourceVersion#isIdentifier(CharSequence)} included here to

--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -46,6 +46,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -672,7 +673,73 @@ public class Util {
         return SourceVersion.isIdentifier(var) && !var.contains("$") ? var : '`' + var + '`';
     }
 
-    private static final Pattern LABEL_AND_TYPE_QUOTATION = Pattern.compile("\\\\u0060|(?<!`)`(?:`{2})*(?!`)");
+    private static final String ESCAPED_UNICODE_BACKTICK = "\\u0060";
+
+    private static final Pattern PATTERN_ESCAPED_4DIGIT_UNICODE = Pattern.compile("\\\\u+(\\p{XDigit}{4})");
+    private static final Pattern PATTERN_LABEL_AND_TYPE_QUOTATION = Pattern.compile("(?<!`)`(?:`{2})*(?!`)");
+
+    private static final List<String[]> SUPPORTED_ESCAPE_CHARS = Collections.unmodifiableList(Arrays.asList(
+            new String[] { "\\b", "\b" },
+            new String[] { "\\f", "\f" },
+            new String[] { "\\n", "\n" },
+            new String[] { "\\r", "\r" },
+            new String[] { "\\t", "\t" },
+            new String[] { "\\`", "``" }
+    ));
+
+
+    /**
+     * Sanitizes the given input to be used as a valid schema name
+     *
+     * @param value The value to sanitize
+     * @return A value that is safe to be used in string concatenation, an empty optional indicates a value that cannot be safely quoted
+     */
+    public static String sanitize(String value) {
+        return sanitize(value, false);
+    }
+
+    /**
+     * Sanitizes the given input to be used as a valid schema name
+     *
+     * @param value The value to sanitize
+     * @param addQuotes If quotation should be added
+     * @return A value that is safe to be used in string concatenation, an empty optional indicates a value that cannot be safely quoted
+     */
+    public static String sanitize(String value, boolean addQuotes) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+
+        // Replace escaped chars
+        for (String[] pair : SUPPORTED_ESCAPE_CHARS) {
+            value = value.replace(pair[0], pair[1]);
+        }
+        value = value.replace(ESCAPED_UNICODE_BACKTICK, "`");
+
+        // Replace escaped octal hex
+        // Excluding the support for 6 digit literals, as this contradicts the overall example in CIP-59r
+        Matcher matcher = PATTERN_ESCAPED_4DIGIT_UNICODE.matcher(value);
+        StringBuffer sb = new StringBuffer();
+        while (matcher.find()) {
+            String replacement = Character.toString((char) Integer.parseInt(matcher.group(1), 16));
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+
+        matcher.appendTail(sb);
+        value = sb.toString();
+
+        value = value.replace("\\u", "\\u005C\\u0075");
+
+        matcher = PATTERN_LABEL_AND_TYPE_QUOTATION.matcher(value);
+        value = matcher.replaceAll("`$0");
+        value = value.replace("\\\\", "\\");
+
+        if (!addQuotes) {
+            return value;
+        }
+
+        return String.format(Locale.ENGLISH, "`%s`", value);
+    }
 
     /**
      * This is a literal copy of {@code javax.lang.model.SourceVersion#isIdentifier(CharSequence)} included here to
@@ -699,23 +766,6 @@ public class Util {
         }
         return true;
     }
-
-    /**
-     * Escapes the string {@literal potentiallyNonIdentifier} in all cases when it's not a valid Cypher identifier.
-     *
-     * @param potentiallyNonIdentifier A value to escape
-     * @return The escaped value or the same value if no escaping is necessary.
-     */
-    public static String sanitizeBackTicks(String potentiallyNonIdentifier) {
-
-        if (potentiallyNonIdentifier == null || potentiallyNonIdentifier.trim().isEmpty() || isIdentifier(potentiallyNonIdentifier)) {
-            return potentiallyNonIdentifier;
-        }
-
-        Matcher matcher = LABEL_AND_TYPE_QUOTATION.matcher(potentiallyNonIdentifier);
-        return matcher.replaceAll("`$0");
-    }
-
 
     public static String param(String var) {
         return var.charAt(0) == '$' ? var : '$'+quote(var);

--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -552,9 +552,9 @@ public class GraphRefactoring {
             node = Util.rebind(innerTx, node);
             Object value = node.getProperty(sourceKey, null);
             if (value != null) {
-                String nodeLabel = Util.sanitizeBackTicks(label);
-                String key = Util.sanitizeBackTicks(targetKey);
-                String relType = Util.sanitizeBackTicks(relationshipType);
+                String nodeLabel = Util.sanitize(label);
+                String key = Util.sanitize(targetKey);
+                String relType = Util.sanitize(relationshipType);
                 String q =
                         "WITH $node AS n " +
                                 "MERGE (cat:`" + nodeLabel + "` {`" + key + "`: $value}) " +

--- a/core/src/main/java/apoc/refactor/rename/Rename.java
+++ b/core/src/main/java/apoc/refactor/rename/Rename.java
@@ -62,8 +62,8 @@ public class Rename {
 	@Description("apoc.refactor.rename.label(oldLabel, newLabel, [nodes]) | rename a label from 'oldLabel' to 'newLabel' for all nodes. If 'nodes' is provided renaming is applied to this set only")
 	public Stream<BatchAndTotalResultWithInfo> label(@Name("oldLabel") String oldLabel, @Name("newLabel") String newLabel, @Name(value = "nodes", defaultValue = "[]") List<Node> nodes) {
 		nodes = nodes.stream().map(n -> Util.rebind(tx, n)).collect(Collectors.toList());
-		oldLabel = Util.sanitizeBackTicks(oldLabel);
-		newLabel = Util.sanitizeBackTicks(newLabel);
+		oldLabel = Util.sanitize(oldLabel);
+		newLabel = Util.sanitize(newLabel);
 		String cypherIterate = nodes != null && !nodes.isEmpty() ? "UNWIND $nodes AS n WITH n WHERE n:`"+oldLabel+"` RETURN n" : "MATCH (n:`"+oldLabel+"`) RETURN n";
         String cypherAction = "SET n:`"+newLabel+"` REMOVE n:`"+oldLabel+"`";
         Map<String, Object> parameters = MapUtil.map("batchSize", 100000, "parallel", true, "iterateList", true, "params", MapUtil.map("nodes", nodes));
@@ -80,8 +80,8 @@ public class Rename {
 													@Name(value = "rels", defaultValue = "[]") List<Relationship> rels,
 													@Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
 		rels = rels.stream().map(r -> Util.rebind(tx, r)).collect(Collectors.toList());
-		newType = Util.sanitizeBackTicks(newType);
-		oldType = Util.sanitizeBackTicks(oldType);
+		newType = Util.sanitize(newType);
+		oldType = Util.sanitize(oldType);
 		String cypherIterate = rels != null && ! rels.isEmpty() ?
 				"UNWIND $rels AS oldRel WITH oldRel WHERE type(oldRel)=\""+oldType+"\" RETURN oldRel,startNode(oldRel) as a,endNode(oldRel) as b" :
 				"MATCH (a)-[oldRel:`"+oldType+"`]->(b) RETURN oldRel,a,b";
@@ -121,8 +121,8 @@ public class Rename {
 															@Name(value="nodes", defaultValue = "[]") List<Node> nodes,
 															@Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
 		nodes = nodes.stream().map(n -> Util.rebind(tx, n)).collect(Collectors.toList());
-		oldName = Util.sanitizeBackTicks(oldName);
-		newName = Util.sanitizeBackTicks(newName);
+		oldName = Util.sanitize(oldName);
+		newName = Util.sanitize(newName);
 		String cypherIterate = nodes != null && ! nodes.isEmpty() ? "UNWIND $nodes AS n WITH n WHERE n.`"+oldName+"` IS NOT NULL return n" : "match (n) where n.`"+oldName+"` IS NOT NULL return n";
 		String cypherAction = "set n.`"+newName+"`= n.`"+oldName+"` remove n.`"+oldName+"`";
 		final Map<String, Object> params = MapUtil.map("nodes", nodes);
@@ -140,8 +140,8 @@ public class Rename {
 															@Name(value="rels", defaultValue = "[]") List<Relationship> rels,
 															@Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
 		rels = rels.stream().map(r -> Util.rebind(tx, r)).collect(Collectors.toList());
-		newName = Util.sanitizeBackTicks(newName);
-		oldName = Util.sanitizeBackTicks(oldName);
+		newName = Util.sanitize(newName);
+		oldName = Util.sanitize(oldName);
 		String cypherIterate = rels != null && ! rels.isEmpty() ? "UNWIND $rels AS r WITH r WHERE r.`"+oldName+"` IS NOT NULL return r" : "match ()-[r]->() where r.`"+oldName+"` IS NOT NULL return r";
 		String cypherAction = "set r.`"+newName+"` = r.`"+oldName+"` remove r.`"+oldName+"`";
 		final Map<String, Object> params = MapUtil.map("rels", rels);

--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -157,9 +157,9 @@ public class Schemas {
 
     private AssertSchemaResult createNodeKeyConstraint(String lbl, List<Object> keys) {
         String keyProperties = keys.stream()
-                .map( property -> String.format("n.`%s`", Util.sanitizeBackTicks(property.toString())))
+                .map( property -> String.format("n.`%s`", Util.sanitize(property.toString())))
                 .collect( Collectors.joining( "," ) );
-        tx.execute(String.format("CREATE CONSTRAINT FOR (n:`%s`) REQUIRE (%s) IS NODE KEY", Util.sanitizeBackTicks(lbl), keyProperties)).close();
+        tx.execute(String.format("CREATE CONSTRAINT FOR (n:`%s`) REQUIRE (%s) IS NODE KEY", Util.sanitize(lbl), keyProperties)).close();
         List<String> keysToSting = keys.stream().map(Object::toString).collect(Collectors.toList());
         return new AssertSchemaResult(lbl, keysToSting).unique().created();
     }
@@ -241,9 +241,9 @@ public class Schemas {
 
     private AssertSchemaResult createCompoundIndex(String label, List<String> keys) {
         List<String> backTickedKeys = new ArrayList<>();
-        keys.forEach(key->backTickedKeys.add(String.format("n.`%s`", Util.sanitizeBackTicks(key))));
+        keys.forEach(key->backTickedKeys.add(String.format("n.`%s`", Util.sanitize(key))));
 
-        tx.execute(String.format("CREATE INDEX FOR (n:`%s`) ON (%s)", Util.sanitizeBackTicks(label), String.join(",", backTickedKeys))).close();
+        tx.execute(String.format("CREATE INDEX FOR (n:`%s`) ON (%s)", Util.sanitize(label), String.join(",", backTickedKeys))).close();
         return new AssertSchemaResult(label, keys).created();
     }
 

--- a/core/src/test/java/apoc/util/UtilTest.java
+++ b/core/src/test/java/apoc/util/UtilTest.java
@@ -90,29 +90,45 @@ public class UtilTest {
     }
 
     @Test
-    public void testSanitizeBackTicks() {
-        assertEquals("``", Util.sanitizeBackTicks("`"));
-        assertEquals("``", Util.sanitizeBackTicks("\u0060"));
-        assertEquals("``", Util.sanitizeBackTicks("``"));
-        assertEquals("````", Util.sanitizeBackTicks("\u0060\u0060\u0060"));
-        assertEquals("Hello``", Util.sanitizeBackTicks("Hello`"));
-        assertEquals("Hi````there", Util.sanitizeBackTicks("Hi````there"));
-        assertEquals("Hi``````there", Util.sanitizeBackTicks("Hi`````there"));
-        assertEquals("``a``b``c``", Util.sanitizeBackTicks("`a`b`c`"));
-        assertEquals("``a``b``c``d``", Util.sanitizeBackTicks("\u0060a`b`c\u0060d\u0060"));
-        assertEquals("Foo `\\u0060", Util.sanitizeBackTicks("Foo \\u0060"));
-        assertEquals("ABC", Util.sanitizeBackTicks("ABC"));
-        assertEquals("A C", Util.sanitizeBackTicks("A C"));
-        assertEquals("A`` C", Util.sanitizeBackTicks("A` C"));
-        assertEquals("ALabel", Util.sanitizeBackTicks("ALabel"));
-        assertEquals("A Label", Util.sanitizeBackTicks("A Label"));
-        assertEquals("A ``Label", Util.sanitizeBackTicks("A `Label"));
-        assertEquals("``A ``Label", Util.sanitizeBackTicks("`A `Label"));
-        assertEquals("``A ``Label", Util.sanitizeBackTicks("`A `Label"));
-        assertEquals("Spring Data Neo4j⚡️RX", Util.sanitizeBackTicks("Spring Data Neo4j⚡️RX"));
-        assertEquals("Foo ``", Util.sanitizeBackTicks("Foo \u0060"));
-        assertEquals("Foo\\``bar", Util.sanitizeBackTicks("Foo\\`bar"));
-        assertEquals("Foo\\\\``bar", Util.sanitizeBackTicks("Foo\\\\`bar"));
+    public void testSanitize() {
+        assertEquals("``", Util.sanitize("`"));
+        assertEquals("``", Util.sanitize("\u0060"));
+        assertEquals("``", Util.sanitize("``"));
+        assertEquals("````", Util.sanitize("```"));
+        assertEquals("````", Util.sanitize("\u0060\u0060\u0060"));
+        assertEquals("````", Util.sanitize("\\u0060\\u0060\\u0060"));
+        assertEquals("Hello``", Util.sanitize("Hello`"));
+        assertEquals("Hi````there", Util.sanitize("Hi````there"));
+        assertEquals("Hi``````there", Util.sanitize("Hi`````there"));
+        assertEquals("``a``b``c``", Util.sanitize("`a`b`c`"));
+        assertEquals("``a``b``c``d``", Util.sanitize("\u0060a`b`c\u0060d\u0060"));
+        assertEquals("``a``b``c``d``", Util.sanitize("\\u0060a`b`c\\u0060d\\u0060"));
+        assertEquals("Foo ``", Util.sanitize("Foo \\u0060"));
+        assertEquals("ABC", Util.sanitize("ABC"));
+        assertEquals("A C", Util.sanitize("A C"));
+        assertEquals("A`` C", Util.sanitize("A` C"));
+        assertEquals("ALabel", Util.sanitize("ALabel"));
+        assertEquals("A Label", Util.sanitize("A Label"));
+        assertEquals("A ``Label", Util.sanitize("A `Label"));
+        assertEquals("``A ``Label", Util.sanitize("`A `Label"));
+        assertEquals("``A ``Label", Util.sanitize("`A `Label"));
+        assertEquals("Spring Data Neo4j⚡️RX", Util.sanitize("Spring Data Neo4j⚡️RX"));
+        assertEquals("Foo ``", Util.sanitize("Foo \u0060"));
+        assertEquals("Foo``bar", Util.sanitize("Foo\\`bar"));
+        assertEquals("Foo\\``bar", Util.sanitize("Foo\\\\`bar"));
+        assertEquals("ᑖ", Util.sanitize("ᑖ"));
+        assertEquals("⚡️", Util.sanitize("⚡️"));
+        assertEquals("uᑖ", Util.sanitize("\\u0075\\u1456"));
+        assertEquals("ᑖ", Util.sanitize("\u1456"));
+        assertEquals("something\\u005C\\u00751456", Util.sanitize("something\\u005C\\u00751456"));
+        assertEquals("``", Util.sanitize("\u005C\\u0060"));
+        assertEquals("\\u005C\\u00750060", Util.sanitize("\\u005Cu0060"));
+        assertEquals("\\``", Util.sanitize("\\u005C\\u0060"));
+        assertEquals("x\\y", Util.sanitize("x\\y"));
+        assertEquals("x\\y", Util.sanitize("x\\\\y"));
+        assertEquals("x\\\\y", Util.sanitize("x\\\\\\\\y"));
+        assertEquals("x``y", Util.sanitize("x\\`y"));
+        assertEquals("Foo ``", Util.sanitize("Foo \\u0060"));
     }
 
     @Test

--- a/core/src/test/java/apoc/util/UtilTest.java
+++ b/core/src/test/java/apoc/util/UtilTest.java
@@ -111,6 +111,8 @@ public class UtilTest {
         assertEquals("``A ``Label", Util.sanitizeBackTicks("`A `Label"));
         assertEquals("Spring Data Neo4j⚡️RX", Util.sanitizeBackTicks("Spring Data Neo4j⚡️RX"));
         assertEquals("Foo ``", Util.sanitizeBackTicks("Foo \u0060"));
+        assertEquals("Foo\\``bar", Util.sanitizeBackTicks("Foo\\`bar"));
+        assertEquals("Foo\\\\``bar", Util.sanitizeBackTicks("Foo\\\\`bar"));
     }
 
     @Test


### PR DESCRIPTION
Fixes:
- Too many escapes of the backslash
- No need to check for the actual ` and the unicode value
- But a need to check for the escaped unicode proper (which is literal \u0060, written down as Java String becomes \\u0060, no further escaping for the regex necessary