### PR TITLE
Try to fix flaky testContainers

### DIFF
--- a/test-utils/src/main/java/apoc/util/Neo4jContainerExtension.java
+++ b/test-utils/src/main/java/apoc/util/Neo4jContainerExtension.java
@@ -78,7 +78,8 @@ public class Neo4jContainerExtension extends Neo4jContainer<Neo4jContainerExtens
                 System.out.println(this.execInContainer("cat", "logs/http.log").toString());
                 System.out.println(this.execInContainer("cat", "logs/security.log").toString());
             } catch (Exception ex) {
-                throw new RuntimeException(ex);
+                // we addSuppressed the exception produced by execInContainer, but we finally throw the original `startException`
+                startException.addSuppressed(new RuntimeException("Exception during fallback execInContainer", ex));
             }
             throw startException;
         }

--- a/test-utils/src/main/java/apoc/util/TestContainerUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestContainerUtil.java
@@ -134,6 +134,7 @@ public class TestContainerUtil {
                 .withExposedPorts(7687, 7473, 7474)
 //                .withDebugger()  // attach debugger
 
+                .withStartupAttempts(3)
                 // set uid if possible - export tests do write to "/import"
                 .withCreateContainerCmdModifier(cmd -> {
                     try {


### PR DESCRIPTION
Trello card: https://trello.com/c/9Gnr5umk/1384-essential-builds-failure-apocwarmupwarmupenterprisetesttestwarmuponenterprisestorageengine-is-failing-on-a-dev-essential-build

I was unable to replicate the error locally.

I added a retry mechanism via `withStartupAttempts(3)` hoping it can solve the problem.

I also changed `throw new RuntimeException(ex);` with `startException.addSuppressed`, because currently we catch the exception caused by `System.out.println(this.execInContainer` (which is always `java.lang.IllegalStateException: execInContainer can only be used while the Container is running`, e.g when an image is not found) but not the original `startException`, so that it should be easier to understand the original problem in case it reoccurs