### PR TITLE
Remove references to '-rc' releases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ downloadLicenses {
 
 allprojects {
     group = 'org.neo4j.procedure'
-    version = '5.1.0-rc01'
+    version = '5.1.0'
     archivesBaseName = 'apoc'
     description = """neo4j-apoc-procedures"""
 }

--- a/docs/asciidoc/antora.yml
+++ b/docs/asciidoc/antora.yml
@@ -8,4 +8,4 @@ asciidoc:
     docs-version: "5.0"
     branch: "5.0"
     apoc-release-absolute: "5.0"
-    apoc-release: "5.0.0-rc01"
+    apoc-release: "5.0.0"

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -29,7 +29,7 @@ plugins {
     id 'org.neo4j.doc.build.docbook' version '1.0-alpha12'
 }
 
-if (!project.hasProperty('apocVersion')) { ext.apocVersion = '5.0.0.0-rc01' }
+if (!project.hasProperty('apocVersion')) { ext.apocVersion = '5.0.0' }
 
 ext {
     versionParts = apocVersion.split('-')

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,7 +1,7 @@
 :readme:
 :branch: 5.0
 :docs: https://neo4j.com/docs/labs/apoc/current
-:apoc-release: 5.1.0-rc01
+:apoc-release: 5.1.0
 :neo4j-version: 5.1.0
 :img: https://raw.githubusercontent.com/neo4j/apoc/{branch}/docs/images
 


### PR DESCRIPTION
Everything we release in APOC is going to be "the latest version" and therefor downloadable by users. There isn't much value in calling these releases "release candidates" because they're real releases that will be used by ALL users.

