### PR TITLE
[NOID] Fix docs cve 2021-27568 (neo4j-contrib/neo4j-apoc-procedures#2953)

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     }
 
     // These will be dependencies packaged with the .jar
+    // when json-path is changed, it have to be changed in json-path-version version in antora.yml as well (placed in neo4j/docs-apoc repo )
     api group: 'com.jayway.jsonpath', name: 'json-path', version: '2.7.0'
     api group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
     api group: 'org.apache.commons', name: 'commons-collections4', version: '4.2'


### PR DESCRIPTION
Cherry pick (only gradle comment) https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/bf1b662a0663c851708ff3981d47abe92876f689
