### PR TITLE
[NOID] Fixes #2826: The apoc.import.csv/graphml procedures create empty wrong empty nodes with UNIQUE constraint violation (#3006)

### DIFF
--- a/common/src/main/java/apoc/export/util/BatchTransaction.java
+++ b/common/src/main/java/apoc/export/util/BatchTransaction.java
@@ -32,8 +32,8 @@ public class BatchTransaction implements AutoCloseable {
     public void rollback() {
         tx.rollback();
     }
-    
-    private void doCommit() {
+
+    public void doCommit() {
         tx.commit();
         tx.close();
         if (reporter!=null) reporter.progress("commit after " + count + " row(s) ");

--- a/common/src/main/java/apoc/export/util/BatchTransaction.java
+++ b/common/src/main/java/apoc/export/util/BatchTransaction.java
@@ -29,6 +29,10 @@ public class BatchTransaction implements AutoCloseable {
         }
     }
 
+    public void rollback() {
+        tx.rollback();
+    }
+    
     private void doCommit() {
         tx.commit();
         tx.close();
@@ -44,7 +48,6 @@ public class BatchTransaction implements AutoCloseable {
     @Override
     public void close() {
         if (tx!=null) {
-            tx.commit();
             tx.close();
             if (reporter!=null) reporter.progress("finish after " + count + " row(s) ");
         }

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
@@ -291,7 +291,7 @@ public class XmlGraphMLReader {
                     }
                 }
             }
-            tx.commit();
+            tx.doCommit();
         } catch (Exception e) {
             tx.rollback();
             throw e;

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
@@ -205,7 +205,8 @@ public class XmlGraphMLReader {
         Map<String, Key> nodeKeys = new HashMap<>();
         Map<String, Key> relKeys = new HashMap<>();
         int count = 0;
-        try (BatchTransaction tx = new BatchTransaction(db, batchSize * 10, reporter)) {
+        BatchTransaction tx = new BatchTransaction(db, batchSize * 10, reporter);
+        try {
 
             while (reader.hasNext()) {
                 XMLEvent event;
@@ -290,6 +291,12 @@ public class XmlGraphMLReader {
                     }
                 }
             }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            throw e;
+        } finally { 
+            tx.close();
         }
         return count;
     }

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -245,7 +245,7 @@ public class ImportCsvTest {
                     (r) -> fail());
         } catch (RuntimeException e) {
             String expected = "Failed to invoke procedure `apoc.import.csv`: " +
-                    "Caused by: IndexEntryConflictException{propertyValues=( String(\"John\") ), addedNodeId=-1, existingNodeId=0}";
+                    "Caused by: IndexEntryConflictException{propertyValues=( String(\"John\") ), addedEntityId=-1, existingEntityId=0}";
             assertEquals(expected, e.getMessage());
         }
 

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -234,6 +234,28 @@ public class ImportCsvTest {
     }
 
     @Test
+    public void issue2826WithImportCsv() {
+        db.executeTransactionally("CREATE (n:Person {name: 'John'})");
+        db.executeTransactionally("CREATE CONSTRAINT unique_person ON (n:Person) ASSERT n.name IS UNIQUE");
+        try {
+            TestUtil.testCall(db,
+                    "CALL apoc.import.csv([{fileName: $file, labels: ['Person']}], [], $config)",
+                    map("file", "file:/id.csv", "config", map("delimiter", '|')),
+                    (r) -> fail());
+        } catch (RuntimeException e) {
+            String expected = "Failed to invoke procedure `apoc.import.csv`: " +
+                    "Caused by: IndexEntryConflictException{propertyValues=( String(\"John\") ), addedNodeId=-1, existingNodeId=0}";
+            assertEquals(expected, e.getMessage());
+        }
+
+        // should return only 1 node due to constraint exception
+        TestUtil.testCall(db, "MATCH (n:Person) RETURN properties(n) AS props",
+                r -> assertEquals(Map.of("name", "John"), r.get("props")));
+
+        db.executeTransactionally("DROP CONSTRAINT unique_person");
+    }
+
+    @Test
     public void testNodesAndRelsWithMultiTypes() {
         TestUtil.testCall(db,
                 "CALL apoc.import.csv([{fileName: $nodeFile, labels: ['Person']}], [{fileName: $relFile, type: 'KNOWS'}], $config)",

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -53,6 +53,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.configuration.GraphDatabaseSettings.TransactionStateMemoryAllocation.OFF_HEAP;
 import static org.neo4j.configuration.SettingValueParsers.BYTES;
+import static org.junit.Assert.fail;
 
 public class ImportCsvTest {
     public static final String BASE_URL_FILES = "src/test/resources/csv-inputs";
@@ -236,7 +237,7 @@ public class ImportCsvTest {
     @Test
     public void issue2826WithImportCsv() {
         db.executeTransactionally("CREATE (n:Person {name: 'John'})");
-        db.executeTransactionally("CREATE CONSTRAINT unique_person ON (n:Person) ASSERT n.name IS UNIQUE");
+        db.executeTransactionally("CREATE CONSTRAINT unique_person FOR (n:Person) REQUIRE n.name IS UNIQUE");
         try {
             TestUtil.testCall(db,
                     "CALL apoc.import.csv([{fileName: $file, labels: ['Person']}], [], $config)",

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -293,7 +293,7 @@ public class ExportGraphMLTest {
                     (r) -> fail());
         } catch (Exception e) {
             String expected = "Failed to invoke procedure `apoc.import.graphml`: " +
-                    "Caused by: IndexEntryConflictException{propertyValues=( String(\"foo\") ), addedNodeId=-1, existingNodeId=3}";
+                    "Caused by: IndexEntryConflictException{propertyValues=( String(\"foo\") ), addedEntityId=-1, existingEntityId=3}";
             assertEquals(expected, e.getMessage());
         }
 

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -55,6 +55,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.neo4j.configuration.GraphDatabaseSettings.TransactionStateMemoryAllocation.OFF_HEAP;
 import static org.neo4j.configuration.SettingValueParsers.BYTES;
@@ -280,7 +281,28 @@ public class ExportGraphMLTest {
 
         TestUtil.testCall(db, "MATCH  ()-[c:RELATED]->() RETURN COUNT(c) AS c", null, (r) -> assertEquals(1L, r.get("c")));
     }
+    
+    @Test
+    public void issue2797WithImportGraphMl() {
+        db.executeTransactionally("CREATE (n:FOO {name: 'foo'})");
+        db.executeTransactionally("CREATE CONSTRAINT unique_foo ON (n:FOO) ASSERT n.name IS UNIQUE");
+        try {
+            TestUtil.testCall(db,
+                    "CALL apoc.import.graphml($file, {readLabels:true})",
+                    map("file", new File(directory, "importNodeEdges.graphml").getAbsolutePath()),
+                    (r) -> fail());
+        } catch (Exception e) {
+            String expected = "Failed to invoke procedure `apoc.import.graphml`: " +
+                    "Caused by: IndexEntryConflictException{propertyValues=( String(\"foo\") ), addedNodeId=-1, existingNodeId=3}";
+            assertEquals(expected, e.getMessage());
+        }
 
+        // should return only 1 node due to constraint exception
+        TestUtil.testCall(db, "MATCH (n:FOO) RETURN properties(n) AS props",
+                r -> assertEquals(Map.of("name", "foo"), r.get("props")));
+
+        db.executeTransactionally("DROP CONSTRAINT unique_foo");
+    }
 
     @Test
     public void testImportGraphMLWithoutCharactersDataKeys() throws Exception {

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -285,7 +285,7 @@ public class ExportGraphMLTest {
     @Test
     public void issue2797WithImportGraphMl() {
         db.executeTransactionally("CREATE (n:FOO {name: 'foo'})");
-        db.executeTransactionally("CREATE CONSTRAINT unique_foo ON (n:FOO) ASSERT n.name IS UNIQUE");
+        db.executeTransactionally("CREATE CONSTRAINT unique_foo FOR (n:FOO) REQUIRE n.name IS UNIQUE");
         try {
             TestUtil.testCall(db,
                     "CALL apoc.import.graphml($file, {readLabels:true})",


### PR DESCRIPTION
Cherry pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/dd6579b3108f4cddb6a828b382de34e1aef148fc