### PR TITLE
[hcaaOlXR] Various security fixes

### DIFF
--- a/core/src/main/java/apoc/load/Xml.java
+++ b/core/src/main/java/apoc/load/Xml.java
@@ -69,6 +69,7 @@ public class Xml {
     private static final XMLInputFactory FACTORY = XMLInputFactory.newFactory();
     static {
         FACTORY.setProperty(XMLInputFactory.IS_COALESCING, true);
+        FACTORY.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
     }
 
     @Context

--- a/core/src/test/java/apoc/load/XmlTest.java
+++ b/core/src/test/java/apoc/load/XmlTest.java
@@ -32,7 +32,12 @@ import static apoc.util.BinaryTestUtil.fileToBinary;
 import static apoc.util.CompressionConfig.COMPRESSION;
 import static apoc.util.TestUtil.*;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.neo4j.internal.helpers.collection.MapUtil.map;
 
 public class XmlTest {
@@ -452,15 +457,45 @@ public class XmlTest {
     @Test(expected = QueryExecutionException.class)
     public void testLoadXmlPreventXXEVulnerabilityThrowsQueryExecutionException() {
         try {
-            testResult(db, "CALL apoc.load.xml('" + TestUtil.getUrlFileName("xml/xxe.xml") + "', '/catalog/book[genre=\"Computer\"]') yield value as result", (r) -> {
+            testResult(db, "CALL apoc.load.xml('" + TestUtil.getUrlFileName("xml/xxe.xml") + "')", (r) -> {
                 r.next();
                 r.close();
             });
         } catch (Exception e) {
-            // We want test that the cause of the exception is SAXParseException with the correct cause message
             Throwable except = ExceptionUtils.getRootCause(e);
             assertTrue(except instanceof SAXParseException);
             assertEquals("DOCTYPE is disallowed when the feature \"http://apache.org/xml/features/disallow-doctype-decl\" set to true.", except.getMessage());
+            throw e;
+        }
+    }
+
+    @Test(expected = QueryExecutionException.class)
+    public void testXmlParsePreventXXEVulnerabilityThrowsQueryExecutionException() {
+        try {
+            final var xml = "<?xml version=\"1.0\"?><!DOCTYPE GVI [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]><foo>&xxe;</foo>";
+            testResult(db, "RETURN apoc.xml.parse('" + xml + "')", (r) -> {
+                r.next();
+                r.close();
+            });
+        } catch (Exception e) {
+            Throwable except = ExceptionUtils.getRootCause(e);
+            assertTrue(except instanceof SAXParseException);
+            assertEquals("DOCTYPE is disallowed when the feature \"http://apache.org/xml/features/disallow-doctype-decl\" set to true.", except.getMessage());
+            throw e;
+        }
+    }
+
+    @Test(expected = QueryExecutionException.class)
+    public void testImportXmlPreventXXEVulnerabilityThrowsQueryExecutionException() {
+        try {
+            testResult(db, "CALL apoc.import.xml('" + TestUtil.getUrlFileName("xml/xxe.xml") + "')", (r) -> {
+                r.next();
+                r.close();
+            });
+        } catch (Exception e) {
+            Throwable except = ExceptionUtils.getRootCause(e);
+            assertTrue(except instanceof com.ctc.wstx.exc.WstxParsingException);
+            assertThat(except.getMessage(), containsString("Encountered a reference to external entity \"xxe\""));
             throw e;
         }
     }


### PR DESCRIPTION
Makes XML procedures resistant to XXE attacks by following the general advice which is to disable External Entities. This is what we had done previously for apoc.load.xml and apoc.xml.parse, but forgot to do for apoc.import.xml.

