### PR TITLE
Fixes neo4j/apoc#126: apoc.periodic.submit fails with schema operations (core)

### DIFF
--- a/common/src/main/java/apoc/periodic/PeriodicUtils.java
+++ b/common/src/main/java/apoc/periodic/PeriodicUtils.java
@@ -11,6 +11,7 @@ import org.neo4j.logging.Log;
 import org.neo4j.procedure.TerminationGuard;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -244,6 +245,46 @@ public class PeriodicUtils {
             log.debug("Terminated periodic iteration with id %s with %d executions", periodicId, collector.getCount());
         }
         return Stream.of(collector.getResult());
+    }
+
+    public static Stream<JobInfo> submitProc(String name, String statement, Map<String, Object> config, GraphDatabaseService db, Log log, Pools pools) {
+        Map<String,Object> params = (Map) config.getOrDefault("params", Collections.emptyMap());
+        JobInfo info = submitJob(name, () -> {
+            try {
+                db.executeTransactionally(statement, params);
+            } catch(Exception e) {
+                log.warn("in background task via submit", e);
+                throw new RuntimeException(e);
+            }
+        }, log, pools);
+        return Stream.of(info);
+    }
+
+    /**
+     * Call from a procedure that gets a <code>@Context GraphDatbaseAPI db;</code> injected and provide that db to the runnable.
+     */
+    public static <T> JobInfo submitJob(String name, Runnable task, Log log, Pools pools) {
+        JobInfo info = new JobInfo(name);
+        Future<T> future = pools.getJobList().remove(info);
+        if (future != null && !future.isDone()) future.cancel(false);
+
+        Runnable wrappingTask = wrapTask(name, task, log);
+        Future newFuture = pools.getScheduledExecutorService().submit(wrappingTask);
+        pools.getJobList().put(info,newFuture);
+        return info;
+    }
+
+    public static Runnable wrapTask(String name, Runnable task, Log log) {
+        return () -> {
+            log.debug("Executing task " + name);
+            try {
+                task.run();
+            } catch (Exception e) {
+                log.error("Error while executing task " + name + " because of the following exception (the task will be killed):", e);
+                throw e;
+            }
+            log.debug("Executed task " + name);
+        };
     }
 }
 

--- a/core/src/main/java/apoc/periodic/Periodic.java
+++ b/core/src/main/java/apoc/periodic/Periodic.java
@@ -22,7 +22,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import static org.neo4j.graphdb.QueryExecutionType.QueryType.READ_ONLY;
+import static org.neo4j.graphdb.QueryExecutionType.QueryType.READ_WRITE;
+import static org.neo4j.graphdb.QueryExecutionType.QueryType.WRITE;
 import static apoc.periodic.PeriodicUtils.recordError;
+import static apoc.periodic.PeriodicUtils.submitJob;
+import static apoc.periodic.PeriodicUtils.submitProc;
+import static apoc.periodic.PeriodicUtils.wrapTask;
 import static apoc.util.Util.merge;
 
 public class Periodic {
@@ -156,16 +162,7 @@ public class Periodic {
     @Description("apoc.periodic.submit('name',statement,params) - submit a one-off background statement; parameter 'params' is optional and can contain query parameters for Cypher statement")
     public Stream<JobInfo> submit(@Name("name") String name, @Name("statement") String statement, @Name(value = "params", defaultValue = "{}") Map<String,Object> config) {
         validateQuery(statement);
-        Map<String,Object> params = (Map)config.getOrDefault("params", Collections.emptyMap());
-        JobInfo info = submit(name, () -> {
-            try {
-                db.executeTransactionally(statement, params);
-            } catch(Exception e) {
-                log.warn("in background task via submit", e);
-                throw new RuntimeException(e);
-            }
-        }, log);
-        return Stream.of(info);
+        return submitProc(name, statement, config, db, log, pools);
     }
 
     @Procedure(mode = Mode.WRITE)
@@ -180,31 +177,19 @@ public class Periodic {
     }
 
     private void validateQuery(String statement) {
-        Util.validateQuery(db, statement);
+        Util.validateQuery(db, statement,
+                READ_ONLY, WRITE, READ_WRITE);
     }
 
     @Procedure(mode = Mode.WRITE)
     @Description("apoc.periodic.countdown('name',statement,repeat-rate-in-seconds) submit a repeatedly-called background statement until it returns 0")
     public Stream<JobInfo> countdown(@Name("name") String name, @Name("statement") String statement, @Name("rate") long rate) {
         validateQuery(statement);
-        JobInfo info = submit(name, new Countdown(name, statement, rate, log), log);
+        JobInfo info = submitJob(name, new Countdown(name, statement, rate, log), log, pools);
         info.rate = rate;
         return Stream.of(info);
     }
 
-    /**
-     * Call from a procedure that gets a <code>@Context GraphDatbaseAPI db;</code> injected and provide that db to the runnable.
-     */
-    public <T> JobInfo submit(String name, Runnable task, Log log) {
-        JobInfo info = new JobInfo(name);
-        Future<T> future = pools.getJobList().remove(info);
-        if (future != null && !future.isDone()) future.cancel(false);
-
-        Runnable wrappingTask = wrapTask(name, task, log);
-        Future newFuture = pools.getScheduledExecutorService().submit(wrappingTask);
-        pools.getJobList().put(info,newFuture);
-        return info;
-    }
 
     /**
      * Call from a procedure that gets a <code>@Context GraphDatbaseAPI db;</code> injected and provide that db to the runnable.
@@ -218,19 +203,6 @@ public class Periodic {
         ScheduledFuture<?> newFuture = pools.getScheduledExecutorService().scheduleWithFixedDelay(wrappingTask, delay, repeat, TimeUnit.SECONDS);
         pools.getJobList().put(info,newFuture);
         return info;
-    }
-
-    private static Runnable wrapTask(String name, Runnable task, Log log) {
-        return () -> {
-            log.debug("Executing task " + name);
-            try {
-                task.run();
-            } catch (Exception e) {
-                log.error("Error while executing task " + name + " because of the following exception (the task will be killed):", e);
-                throw e;
-            }
-            log.debug("Executed task " + name);
-        };
     }
 
     /**
@@ -325,7 +297,7 @@ public class Periodic {
         @Override
         public void run() {
             if (Periodic.this.executeNumericResultStatement(statement, Collections.emptyMap()) > 0) {
-                pools.getScheduledExecutorService().schedule(() -> submit(name, this, log), rate, TimeUnit.SECONDS);
+                pools.getScheduledExecutorService().schedule(() -> submitJob(name, this, log, pools), rate, TimeUnit.SECONDS);
             }
         }
     }

--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
@@ -43,7 +42,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.neo4j.driver.internal.util.Iterables.count;
-import static org.neo4j.test.assertion.Assert.assertEventually;
 
 public class PeriodicTest {
 


### PR DESCRIPTION
Fixes neo4j/apoc#126 (core part)

1) Added QueryType validations in `validateQuery()` method, so as to fail if the procedure tries to execute schema operations

2) Refactored `apoc.periodic.submit` code in order to be reused in extended.

3) In  https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3211, added `apoc.periodic.submitSchema` procedure, equivalent but with different `validateQuery()` and `org.neo4j.procedure.Mode.SCHEMA`

----

NOTE FOR REVIEWER:
- We could also create a schema equivalent for the others periodic procedures (maybe in another issue/pr?)
- Even the `apoc.trigger.add` has the `validateQuery()`, maybe can be changed in the same way? (also in this case, perhaps in another pr)