### PR TITLE
[pDw6xmRG] Fixes #26: apoc.refactor.rename.label delets label if oldLabel is equal to newLabel

### DIFF
--- a/core/src/main/java/apoc/refactor/rename/Rename.java
+++ b/core/src/main/java/apoc/refactor/rename/Rename.java
@@ -65,7 +65,7 @@ public class Rename {
 		oldLabel = Util.sanitize(oldLabel);
 		newLabel = Util.sanitize(newLabel);
 		String cypherIterate = nodes != null && !nodes.isEmpty() ? "UNWIND $nodes AS n WITH n WHERE n:`"+oldLabel+"` RETURN n" : "MATCH (n:`"+oldLabel+"`) RETURN n";
-        String cypherAction = "SET n:`"+newLabel+"` REMOVE n:`"+oldLabel+"`";
+		String cypherAction = "REMOVE n:`"+oldLabel+"` SET n:`" + newLabel + "`";
         Map<String, Object> parameters = MapUtil.map("batchSize", 100000, "parallel", true, "iterateList", true, "params", MapUtil.map("nodes", nodes));
 		return getResultOfBatchAndTotalWithInfo( newPeriodic().iterate(cypherIterate, cypherAction, parameters), db, oldLabel, null, null);
 	}
@@ -124,7 +124,7 @@ public class Rename {
 		oldName = Util.sanitize(oldName);
 		newName = Util.sanitize(newName);
 		String cypherIterate = nodes != null && ! nodes.isEmpty() ? "UNWIND $nodes AS n WITH n WHERE n.`"+oldName+"` IS NOT NULL return n" : "match (n) where n.`"+oldName+"` IS NOT NULL return n";
-		String cypherAction = "set n.`"+newName+"`= n.`"+oldName+"` remove n.`"+oldName+"`";
+		String cypherAction = "WITH n, n. `" + oldName + "` AS propVal REMOVE n.`" + oldName + "` SET n.`"+newName+"` = propVal";
 		final Map<String, Object> params = MapUtil.map("nodes", nodes);
 		Map<String, Object> parameters = getPeriodicConfig(config, params);
 		return getResultOfBatchAndTotalWithInfo(newPeriodic().iterate(cypherIterate, cypherAction, parameters), db, null, null, oldName);
@@ -143,7 +143,7 @@ public class Rename {
 		newName = Util.sanitize(newName);
 		oldName = Util.sanitize(oldName);
 		String cypherIterate = rels != null && ! rels.isEmpty() ? "UNWIND $rels AS r WITH r WHERE r.`"+oldName+"` IS NOT NULL return r" : "match ()-[r]->() where r.`"+oldName+"` IS NOT NULL return r";
-		String cypherAction = "set r.`"+newName+"` = r.`"+oldName+"` remove r.`"+oldName+"`";
+		String cypherAction = "WITH r, r. `" + oldName + "` AS propVal REMOVE r.`"+oldName + "` SET r.`"+newName+"`= propVal";
 		final Map<String, Object> params = MapUtil.map("rels", rels);
 		Map<String, Object> parameters = getPeriodicConfig(config, params);
 		return getResultOfBatchAndTotalWithInfo(newPeriodic().iterate(cypherIterate, cypherAction, parameters), db, null, null, oldName);

--- a/core/src/test/java/apoc/refactor/rename/RenameTest.java
+++ b/core/src/test/java/apoc/refactor/rename/RenameTest.java
@@ -17,6 +17,7 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
+import static apoc.util.TestUtil.testCallCount;
 import static apoc.util.TestUtil.testResult;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -362,6 +363,22 @@ public class RenameTest {
 
 		assertEquals(2L, resultRelationshipsMatches(null, "surname"));
 		assertEquals(8L, resultRelationshipsMatches(null, "name"));
+	}
+	
+	@Test
+	public void testRenameWithSameValues() {
+		db.executeTransactionally("CREATE (n:ToRename {a: 1})-[:REL_TO_RENAME {a: 1}]->(:Other)");
+		testCall(db, "CALL apoc.refactor.rename.label('ToRename', 'ToRename')", r -> assertEquals(1L, r.get("total")));
+		testCallCount(db, "MATCH (n:ToRename {a: 1}) RETURN n", 1);
+
+		testCall(db, "CALL apoc.refactor.rename.type('REL_TO_RENAME', 'REL_TO_RENAME')", r -> assertEquals(1L, r.get("total")));
+		testCallCount(db, "MATCH (:ToRename)-[r:REL_TO_RENAME {a: 1}]->(:Other) RETURN r", 1);
+
+		testCall(db, "CALL apoc.refactor.rename.nodeProperty('a', 'a')", r -> assertEquals(1L, r.get("total")));
+		testCallCount(db, "MATCH (n:ToRename {a: 1}) RETURN n", 1);
+
+		testCall(db, "CALL apoc.refactor.rename.typeProperty('a', 'a')", r -> assertEquals(1L, r.get("total")));
+		testCallCount(db, "MATCH (:ToRename)-[r:REL_TO_RENAME {a: 1}]->(:Other) RETURN r", 1);
 	}
 
 	private long resultRelationshipsMatches(String type, String prop){


### PR DESCRIPTION
Fixes #26

The same bug also affects relationship types in `apoc.refactor.rename.type` and properties in `apoc.refactor.rename.nodeProperty` / `apoc.refactor.rename.relProperty`.