### PR TITLE
[NOID] Bump Neo4j to 5.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ downloadLicenses {
 
 allprojects {
     group = 'org.neo4j.procedure'
-    version = '5.1.0'
+    version = '5.2.0'
     archivesBaseName = 'apoc'
     description = """neo4j-apoc-procedures"""
 }
@@ -71,8 +71,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise' : 'neo4j:5.1.0-dev-enterprise',
-                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") : 'neo4j:5.1.0-dev',
+                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise' : 'neo4j:5.2.0-dev-enterprise',
+                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") : 'neo4j:5.2.0-dev',
                 'coreDir': 'core'
 
         maxHeapSize = "8G"
@@ -131,6 +131,6 @@ subprojects {
 ext {
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ?
             project.getProperty("neo4jVersionOverride")
-            : (System.env.CI != null) ? "5.1.0-dev" : "5.1.0-SNAPSHOT"
+            : (System.env.CI != null) ? "5.2.0-dev" : "5.2.0-SNAPSHOT"
     testContainersVersion = '1.16.2'
 }

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,8 +1,8 @@
 :readme:
 :branch: 5.0
 :docs: https://neo4j.com/docs/labs/apoc/current
-:apoc-release: 5.1.0
-:neo4j-version: 5.1.0
+:apoc-release: 5.2.0
+:neo4j-version: 5.2.0
 :img: https://raw.githubusercontent.com/neo4j/apoc/{branch}/images
 
 https://community.neo4j.com[image:https://img.shields.io/discourse/users?logo=discourse&server=https%3A%2F%2Fcommunity.neo4j.com[Discourse users]]


### PR DESCRIPTION
I copied what Nacho did in this 5.1.0 commit https://github.com/neo4j/apoc/commit/ca8663678a3dc5bf2477982e930723f7786a6503