### PR TITLE
[UHxIZ8JO] Grant CodeQL permissions

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -10,6 +10,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    # required by CodeQL
+    permissions:
+      security-events: write
+      actions: read
+
     env:
       DOCKER_ENTERPRISE_DEV_URL: ${{ secrets.DOCKER_ENTERPRISE_DEV_URL }}
       DOCKER_COMMUNITY_DEV_URL: ${{ secrets.DOCKER_COMMUNITY_DEV_URL }}


### PR DESCRIPTION
We've performed a Github Actions review of this repository and made changes to the default permissions offered to our Actions.

As a result, we must make this [recommended change](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#analyzing-python-dependencies) to the build job so that CodeQL can function without warnings. 

