### PR TITLE
[hDJkPkOQ] Add QueryType validation in apoc.trigger.add

### DIFF
--- a/core/src/main/java/apoc/trigger/Trigger.java
+++ b/core/src/main/java/apoc/trigger/Trigger.java
@@ -12,6 +12,10 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static org.neo4j.graphdb.QueryExecutionType.QueryType.READ_ONLY;
+import static org.neo4j.graphdb.QueryExecutionType.QueryType.READ_WRITE;
+import static org.neo4j.graphdb.QueryExecutionType.QueryType.WRITE;
+
 /**
  * @author mh
  * @since 20.09.16
@@ -53,7 +57,8 @@ public class Trigger {
     @Description("Adds a trigger to the given Cypher statement.\n" +
             "The selector for this procedure is {phase:'before/after/rollback/afterAsync'}.")
     public Stream<TriggerInfo> add(@Name("name") String name, @Name("statement") String statement, @Name(value = "selector"/*, defaultValue = "{}"*/)  Map<String,Object> selector, @Name(value = "config", defaultValue = "{}") Map<String,Object> config) {
-        Util.validateQuery(db, statement);
+        Util.validateQuery(db, statement,
+                READ_ONLY, WRITE, READ_WRITE);
         Map<String,Object> params = (Map)config.getOrDefault("params", Collections.emptyMap());
         Map<String, Object> removed = triggerHandler.add(name, statement, selector, params);
         if (removed != null) {


### PR DESCRIPTION
TODO - Waiting for https://github.com/neo4j/apoc/pull/250


Added QueryType validations in `validateQuery()` method, 
so as to fail if the procedure tries to execute schema operations.

See point 2 here: https://github.com/neo4j/apoc/pull/208#pullrequestreview-1145222227

