### PR TITLE
Update testJaroWinklerDistance test expectation

### DIFF
--- a/core/src/test/java/apoc/text/StringsTest.java
+++ b/core/src/test/java/apoc/text/StringsTest.java
@@ -317,7 +317,7 @@ public class StringsTest {
 
         testCall(db, "RETURN apoc.text.jaroWinklerDistance($a, $b) AS distance",
                 map("a", text1, "b", text2),
-                row -> assertEquals(0.77, (double) row.get("distance"), 0.01));
+                row -> assertEquals(0.22, (double) row.get("distance"), 0.01));
     }
 
     @Test


### PR DESCRIPTION
Before this PR test was expecting the incorrect value of distance.
As a result, https://issues.apache.org/jira/browse/TEXT-191 and the new commons-text test
is updated with the correct expected value.
