### PR TITLE
Fixes #126: Improve validateQuery

### DIFF
--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -14,7 +14,10 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.collections.api.iterator.LongIterator;
+import org.neo4j.graphdb.ExecutionPlanDescription;
+import org.neo4j.graphdb.Result;
 import org.neo4j.logging.NullLog;
+import org.neo4j.procedure.Mode;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
 import org.neo4j.values.storable.PointValue;
 import org.neo4j.values.storable.Values;
@@ -996,13 +999,54 @@ public class Util {
     }
 
     public static void validateQuery(GraphDatabaseService db, String statement, QueryExecutionType.QueryType... supportedQueryTypes) {
-        final boolean isValid = db.executeTransactionally("EXPLAIN " + statement, Collections.emptyMap(), result ->
-                supportedQueryTypes == null || supportedQueryTypes.length == 0 || Stream.of(supportedQueryTypes)
-                        .anyMatch(sqt -> sqt.equals(result.getQueryExecutionType().queryType())));
+        validateQuery(db, statement, Collections.emptySet(), supportedQueryTypes);
+    }
+
+    public static void validateQuery(GraphDatabaseService db, String statement, Set<Mode> supportedModes , QueryExecutionType.QueryType... supportedQueryTypes) {
+        final boolean isValid = db.executeTransactionally("EXPLAIN " + statement, Collections.emptyMap(), result -> {
+            final boolean isQueryTypeValid = supportedQueryTypes == null || supportedQueryTypes.length == 0 || Stream.of(supportedQueryTypes)
+                    .anyMatch(sqt -> sqt.equals(result.getQueryExecutionType().queryType()));
+            
+            return isQueryTypeValid && procsAreValid(db, supportedModes, result);
+        });
 
         if (!isValid) {
             throw new RuntimeException("Supported query types for the operation are " + Arrays.toString(supportedQueryTypes));
         }
+    }
+
+    private static boolean procsAreValid(GraphDatabaseService db, Set<Mode> supportedModes, Result result) {
+        if (supportedModes != null && !supportedModes.isEmpty()) {
+            final ExecutionPlanDescription executionPlanDescription = result.getExecutionPlanDescription();
+            // get procedures used into the query
+            Set<String> queryProcNames = new HashSet<>();
+            getAllQueryProcs(executionPlanDescription, queryProcNames);
+            
+            if (!queryProcNames.isEmpty()) {
+                final Set<String> modes = supportedModes.stream().map(Mode::name).collect(Collectors.toSet());
+                // check if sub-procedures have valid mode 
+                final Set<String> procNames = db.executeTransactionally("SHOW PROCEDURES YIELD name, mode where mode in $modes return name",
+                        Map.of("modes", modes),
+                        r -> Iterators.asSet(r.columnAs("name")));
+
+                return procNames.containsAll(queryProcNames);
+            }
+        }
+        
+        return true;
+    }
+
+    public static void getAllQueryProcs(ExecutionPlanDescription executionPlanDescription, Set<String> procs) {
+        executionPlanDescription.getChildren().forEach(i -> {
+            // if executionPlanDescription is a ProcedureCall
+            // we return proc. name from "Details" 
+            // by extracting up to the first `(` char, e.g. apoc.schema.assert(null, null)....
+            if (i.getName().equals("ProcedureCall")) {
+                final String procName = ((String) i.getArguments().get("Details")).split("\\(")[0];
+                procs.add(procName);
+            }
+            getAllQueryProcs(i, procs);
+        });
     }
 
     /**

--- a/core/src/main/java/apoc/periodic/Periodic.java
+++ b/core/src/main/java/apoc/periodic/Periodic.java
@@ -22,9 +22,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import static org.neo4j.graphdb.QueryExecutionType.QueryType.READ_ONLY;
-import static org.neo4j.graphdb.QueryExecutionType.QueryType.READ_WRITE;
-import static org.neo4j.graphdb.QueryExecutionType.QueryType.WRITE;
+import static org.neo4j.graphdb.QueryExecutionType.QueryType;
 import static apoc.periodic.PeriodicUtils.recordError;
 import static apoc.periodic.PeriodicUtils.submitJob;
 import static apoc.periodic.PeriodicUtils.submitProc;
@@ -177,8 +175,9 @@ public class Periodic {
     }
 
     private void validateQuery(String statement) {
-        Util.validateQuery(db, statement,
-                READ_ONLY, WRITE, READ_WRITE);
+        Util.validateQuery(db, statement, 
+                Set.of(Mode.WRITE, Mode.READ, Mode.DEFAULT),
+                QueryType.READ_ONLY, QueryType.WRITE, QueryType.READ_WRITE);
     }
 
     @Procedure(mode = Mode.WRITE)

--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -1,5 +1,7 @@
 package apoc.periodic;
 
+import apoc.cypher.Cypher;
+import apoc.schema.Schemas;
 import apoc.util.MapUtil;
 import apoc.util.TestUtil;
 import apoc.util.collection.Iterators;
@@ -53,7 +55,7 @@ public class PeriodicTest {
 
     @Before
     public void initDb() throws Exception {
-        TestUtil.registerProcedure(db, Periodic.class);
+        TestUtil.registerProcedure(db, Periodic.class, Schemas.class, Cypher.class);
         db.executeTransactionally("call apoc.periodic.list() yield name call apoc.periodic.cancel(name) yield name as name2 return count(*)");
     }
 
@@ -81,8 +83,25 @@ public class PeriodicTest {
 
     @Test
     public void testSubmitWithSchemaOperation() {
+        testSchemaOperationCommon("CREATE INDEX periodicIdx FOR (n:Bar) ON (n.first_name, n.last_name)");
+    }
+
+    @Test
+    public void testSubmitWithSchemaProcedure() {
+        testSchemaOperationCommon("CALL apoc.schema.assert({}, {})");
+        
+        testSchemaOperationCommon("CALL apoc.cypher.runSchema('CREATE CONSTRAINT periodicIdx FOR (n:Bar) REQUIRE n.first_name IS UNIQUE', {})");
+        
+        // inner schema procedure
+        final String query = "CALL { WITH 1 AS one CALL apoc.schema.assert({}, {}) YIELD key RETURN key } " +
+                "IN TRANSACTIONS OF 1000 rows RETURN 1";
+        testSchemaOperationCommon(query);
+    }
+
+    private void testSchemaOperationCommon(String query) {
         try {
-            testCall(db, "CALL apoc.periodic.submit('subSchema','CREATE INDEX periodicIdx FOR (n:Bar) ON (n.first_name, n.last_name)')",
+            testCall(db, "CALL apoc.periodic.submit('subSchema', $query)",
+                    Map.of("query", query),
                     (row) -> fail("Should fail because of unsupported schema operation"));
         } catch (RuntimeException e) {
             final String expected = "Failed to invoke procedure `apoc.periodic.submit`: " +


### PR DESCRIPTION
After this cherry-pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3234,
I realized that the validateQuery doesn't work with an inner `org.neo4j.procedure.Mode.SCHEMA` procedure, e.g. `CALL db.createUniquePropertyConstraint`,
so I improved it to check these situations.

The `validateQuery` still has some limitations, for example it does not catch cases like this `CALL apoc.cypher.run (\" CALL apoc.schema.assert ({}, {}) \ ", {}) YIELD value RETURN value`, with a sub-inner schema procedure,

or I might have a `call apoc.cypher.runSchema ('return 1', {})` which even though it's a `Mode.SCHEMA`, doesn't actually perform schema operations (even if it doesn't make much sense).

Perhaps, in some way, the above 2 cases can also be validated,
but I think they could be very complex to verify and I don't know if it's worthwhile.