### PR TITLE
[4HrPR2Rm] Use internal function instead of procedure for compatibility check.

### DIFF
--- a/core/src/main/java/apoc/cypher/CypherInitializer.java
+++ b/core/src/main/java/apoc/cypher/CypherInitializer.java
@@ -14,10 +14,8 @@ import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.Log;
 
 import java.util.Collection;
-import java.util.Collections;
 
 import java.util.ConcurrentModificationException;
-import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -66,13 +64,12 @@ public class CypherInitializer implements AvailabilityListener {
                 if (isSystemDatabase) {
                     try {
                         awaitDbmsComponentsProcedureRegistered();
-                        final List<String> versions = db.executeTransactionally("CALL dbms.components", Collections.emptyMap(),
-                                r -> (List<String>) r.next().get("versions"));
+                        String neo4jVersion = org.neo4j.kernel.internal.Version.getNeo4jVersion();
                         final String apocVersion = Version.class.getPackage().getImplementationVersion();
-                        if (isVersionDifferent(versions, apocVersion)) {
+                        if (isVersionDifferent(neo4jVersion, apocVersion)) {
                             userLog.warn("The apoc version (%s) and the Neo4j DBMS versions %s are incompatible. \n" +
                                             "The two first numbers of both versions needs to be the same.",
-                                    apocVersion, versions.toString());
+                                    apocVersion, neo4jVersion);
                         }
                     } catch (Exception ignored) {
                         userLog.info("Cannot check APOC version compatibility because of a transient error. Retrying your request at a later time may succeed");
@@ -97,15 +94,13 @@ public class CypherInitializer implements AvailabilityListener {
     }
 
     // the visibility is public only for testing purpose, it could be private otherwise
-    public static boolean isVersionDifferent(List<String> versions, String apocVersion) {
+    public static boolean isVersionDifferent(String neo4jVersion, String apocVersion) {
         final String[] apocSplit = splitVersion(apocVersion);
-        return versions.stream()
-                .noneMatch(kernelVersion -> {
-                    final String[] kernelSplit = splitVersion(kernelVersion);
-                    return apocSplit != null && kernelSplit != null
-                            && apocSplit[0].equals(kernelSplit[0])
-                            && apocSplit[1].equals(kernelSplit[1]);
-                });
+        final String[] neo4jSplit = splitVersion(neo4jVersion);
+
+        return !(apocSplit != null && neo4jSplit != null
+                && apocSplit[0].equals(neo4jSplit[0])
+                && apocSplit[1].equals(neo4jSplit[1]));
     }
 
     private static String[] splitVersion(String completeVersion) {

--- a/core/src/test/java/apoc/cypher/CypherIsVersionDifferentTest.java
+++ b/core/src/test/java/apoc/cypher/CypherIsVersionDifferentTest.java
@@ -17,6 +17,9 @@ public class CypherIsVersionDifferentTest {
         assertFalse(isVersionDifferent("4.4.5", "4.4.0.4"));
         assertFalse(isVersionDifferent("5.1.1", "5.1.0"));
         assertTrue(isVersionDifferent("5.1.0", "5.2.0"));
+        assertFalse(isVersionDifferent("5.1-aura", "5.1.0"));
+        assertTrue(isVersionDifferent("4.4-aura", "5.1.0"));
+        assertTrue(isVersionDifferent("5.2-aura", "5.1.0"));
 
         // we expect that APOC versioning is always consistent to Neo4j versioning
         assertTrue(isVersionDifferent("", "5_2_0_1"));

--- a/core/src/test/java/apoc/cypher/CypherIsVersionDifferentTest.java
+++ b/core/src/test/java/apoc/cypher/CypherIsVersionDifferentTest.java
@@ -2,8 +2,6 @@ package apoc.cypher;
 
 import org.junit.Test;
 
-import java.util.List;
-
 import static apoc.cypher.CypherInitializer.isVersionDifferent;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -12,30 +10,30 @@ public class CypherIsVersionDifferentTest {
 
     @Test
     public void shouldReturnFalseOnlyWithCompatibleVersion() {
-        assertTrue(isVersionDifferent(List.of("3.5"), "4.4.0.2"));
-        assertTrue(isVersionDifferent(List.of("5_0"), "4.4.0.2"));
-        assertFalse(isVersionDifferent(List.of("3.5.12"), "3.5.0.9"));
-        assertFalse(isVersionDifferent(List.of("3.5.12"), "3.5.1.9"));
-        assertFalse(isVersionDifferent(List.of("4.4.5"), "4.4.0.4"));
-        assertFalse(isVersionDifferent(List.of("5.1.1"), "5.1.0"));
-        assertTrue(isVersionDifferent(List.of("5.1.0"), "5.2.0"));
+        assertTrue(isVersionDifferent("3.5", "4.4.0.2"));
+        assertTrue(isVersionDifferent("5_0", "4.4.0.2"));
+        assertFalse(isVersionDifferent("3.5.12", "3.5.0.9"));
+        assertFalse(isVersionDifferent("3.5.12", "3.5.1.9"));
+        assertFalse(isVersionDifferent("4.4.5", "4.4.0.4"));
+        assertFalse(isVersionDifferent("5.1.1", "5.1.0"));
+        assertTrue(isVersionDifferent("5.1.0", "5.2.0"));
 
         // we expect that APOC versioning is always consistent to Neo4j versioning
-        assertTrue(isVersionDifferent(List.of(""), "5_2_0_1"));
-        assertTrue(isVersionDifferent(List.of("5_1_0"), "5_0_0_1"));
-        assertTrue(isVersionDifferent(List.of("5_1_0"), "5_2_0_1"));
-        assertTrue(isVersionDifferent(List.of("5_22_1"), "5_2_0_1"));
-        assertTrue(isVersionDifferent(List.of("5_2_1"), "5_22_0_1"));
-        assertTrue(isVersionDifferent(List.of("55_2_1"), "5_2_1"));
-        assertTrue(isVersionDifferent(List.of("55_2_1"), "5_2_1_0_1"));
-        assertTrue(isVersionDifferent(List.of("51-1-9-9"), "5-1-1-9"));
+        assertTrue(isVersionDifferent("", "5_2_0_1"));
+        assertTrue(isVersionDifferent("5_1_0", "5_0_0_1"));
+        assertTrue(isVersionDifferent("5_1_0", "5_2_0_1"));
+        assertTrue(isVersionDifferent("5_22_1", "5_2_0_1"));
+        assertTrue(isVersionDifferent("5_2_1", "5_22_0_1"));
+        assertTrue(isVersionDifferent("55_2_1", "5_2_1"));
+        assertTrue(isVersionDifferent("55_2_1", "5_2_1_0_1"));
+        assertTrue(isVersionDifferent("51-1-9-9", "5-1-1-9"));
 
-        assertFalse(isVersionDifferent(List.of("4_4_5"), "4.4.0.4"));
-        assertFalse(isVersionDifferent(List.of("5_1_0"), "5-1-0-1"));
-        assertFalse(isVersionDifferent(List.of("5_22_1"), "5_22_0_1"));
-        assertFalse(isVersionDifferent(List.of("5_0"), "5_0_0_1"));
-        assertFalse(isVersionDifferent(List.of("5_0_1"), "5_0_0_1"));
+        assertFalse(isVersionDifferent("4_4_5", "4.4.0.4"));
+        assertFalse(isVersionDifferent("5_1_0", "5-1-0-1"));
+        assertFalse(isVersionDifferent("5_22_1", "5_22_0_1"));
+        assertFalse(isVersionDifferent("5_0", "5_0_0_1"));
+        assertFalse(isVersionDifferent("5_0_1", "5_0_0_1"));
         
-        assertFalse(isVersionDifferent(List.of("5-1-9-9"), "5-1-0-1"));
+        assertFalse(isVersionDifferent("5-1-9-9", "5-1-0-1"));
     }
 }


### PR DESCRIPTION
This has been requested by Neo4j Aura, which couldn't see if the procedure call came from APOC or a user
