### PR TITLE
[NOID] 5.x fix apoc versions script 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ task versions <<  {
         def apocVersion = findApocVersion(apocReleases, neo4jRelease)
 
         if (apocVersion != null) {
-            def url = apocReleases
+            def url = apocReleasesJSON
                     .find { it.tag_name == apocVersion }
                     .assets.find { it.browser_download_url.contains("apoc-${apocVersion}") }
                     .browser_download_url

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ static def neo4jReleases() {
             .replace("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">", "")
 
     def rootNode = new XmlParser().parseText(htmlString)
-    def releases = []
+    def releases = initialiseNeo4jReleases()
 
     for (a in rootNode.body.main.pre.a) {
         def href = a.attributes()["href"]
@@ -23,6 +23,11 @@ static def neo4jReleases() {
             .findAll { it >= "5.0.0" }
             .sort { o1, o2 -> normalizeVersion(o1) <=> normalizeVersion(o2) }
             .reverse()
+}
+
+// In an ideal world this method would return an empty list. Alas, 5.0.0 was never published to mvn
+static def initialiseNeo4jReleases() {
+    return [ "5.0.0 "]
 }
 
 // Gets all APOC releases from Github
@@ -49,7 +54,7 @@ task versions <<  {
     def reader = new JsonSlurper();
     def checksums = reader.parse(new File("checksums.json"))
     def previousVersions = reader.parse(new File("versions.json"))
-    def versions = previousVersions
+    def versions = []
 
     println(neo4jReleases)
     println(apocReleases)
@@ -78,25 +83,22 @@ task versions <<  {
                     config: [ "+:dbms.security.procedures.unrestricted": ["apoc.*"] ]
             ]
 
-            def shouldAdd = true
-            for (v in versions) {
-                if (v.neo4j == neo4jRelease && v.apoc == apocVersion) {
-                    shouldAdd = false
-                }
-            }
-
-            if (shouldAdd) {
-                versions.add(version)
-            }
+            versions.add(version)
         }
     }
 
-    if (previousVersions.size > versions.size) {
-        def versionsFile = new File("build/versions.json")
-        versionsFile.write(JsonOutput.prettyPrint(JsonOutput.toJson(versions)))
-    } else {
-        println("The file size is the same. No update needed.")
-    }
+    assertVersionsDidntShrink(previousVersions, versions)
+
+    def versionsFile = new File("build/versions.json")
+    versionsFile.write(JsonOutput.prettyPrint(JsonOutput.toJson(versions)))
+}
+
+// We have noticed in the past that the versions.json file sometimes gets wiped clean by the task when it's run in
+// TeamCity. We assume that this is due to one or several of the HTTP requests this job makes fails silently. In these
+// scenarios it is better to simply keep the old versions.json file. We detect this scenario by verifying the new
+// versions have at least as many keys as the previous versions
+static def assertVersionsDidntShrink(previousVersions, versions) {
+    if (previousVersions.size() > versions.size()) throw new Exception("Error: versions file shrank.")
 }
 
 // TODO: Remove this once we begin signing APOC jars

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ task versions <<  {
     def reader = new JsonSlurper();
     def checksums = reader.parse(new File("checksums.json"))
     def previousVersions = reader.parse(new File("versions.json"))
-    def versions = []
+    def versions = previousVersions
 
     println(neo4jReleases)
     println(apocReleases)
@@ -78,14 +78,25 @@ task versions <<  {
                     config: [ "+:dbms.security.procedures.unrestricted": ["apoc.*"] ]
             ]
 
-            versions.add(version)
+            def shouldAdd = true
+            for (v in versions) {
+                if (v.neo4j == neo4jRelease && v.apoc == apocVersion) {
+                    shouldAdd = false
+                }
+            }
+
+            if (shouldAdd) {
+                versions.add(version)
+            }
         }
     }
 
-    assertVersionsGrew(previousVersions, versions)
-
-    def versionsFile = new File("build/versions.json")
-    versionsFile.write(JsonOutput.prettyPrint(JsonOutput.toJson(versions)))
+    if (previousVersions.size > versions.size) {
+        def versionsFile = new File("build/versions.json")
+        versionsFile.write(JsonOutput.prettyPrint(JsonOutput.toJson(versions)))
+    } else {
+        println("The file size is the same. No update needed.")
+    }
 }
 
 // TODO: Remove this once we begin signing APOC jars
@@ -126,14 +137,6 @@ task checksums <<  {
 
 static def normalizeVersion(str) {
     return str.split("[.-]").collect { it =~ "^\\d+\$" ? it.padLeft(4,"0") : it }.join(".") + "/"
-}
-
-// We have noticed in the past that the versions.json file sometimes gets wiped clean by the task when it's run in
-// TeamCity. We assume that this is due to one or several of the HTTP requests this job makes fails silently. In these
-// scenarios it is better to simply keep the old versions.json file. We detect this scenario by verifying the new
-// versions have at least as many keys as the previous versions
-static def assertVersionsGrew(previousVersions, versions) {
-    if (previousVersions.size() > versions.size()) throw new Exception("Error: versions file shrank.")
 }
 
 class Checksum {


### PR DESCRIPTION
So we found some new issues 😅

As neo4j versions are not going to show past ones, we think we need to update how the script adds versions, we have made some assumptions for how this works, let me know if you need to discuss it more :) 