### PR TITLE
[NOID] Fixes CVE-2022-42889 in transitive dependencies

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: [ "5.2" ]
   pull_request:
-    branches: [ "dev" ]
+    branches: [ "5.2" ]
 
 jobs:
   build:
@@ -16,9 +16,9 @@ jobs:
       actions: read
 
     env:
-      DOCKER_ENTERPRISE_DEV_URL: ${{ secrets.DOCKER_ENTERPRISE_DEV_URL }}
-      DOCKER_COMMUNITY_DEV_URL: ${{ secrets.DOCKER_COMMUNITY_DEV_URL }}
-      TEAMCITY_DEV_URL: ${{ secrets.TEAMCITY_DEV_URL }}
+      DOCKER_ENTERPRISE_URL: ${{ secrets.DOCKER_ENTERPRISE_FIVE_DOT_TWO_URL }}
+      DOCKER_COMMUNITY_URL: ${{ secrets.DOCKER_COMMUNITY_FIVE_DOT_TWO_URL }}
+      TEAMCITY_URL: ${{ secrets.TEAMCITY_FIVE_DOT_TWO_URL }}
       TEAMCITY_USER: ${{ secrets.TEAMCITY_USER }}
       TEAMCITY_PASSWORD: ${{ secrets.TEAMCITY_PASSWORD }}
       ENTERPRISE_TAR: enterprise-docker.tar
@@ -41,8 +41,8 @@ jobs:
 
       - name: Download neo4j dev docker container
         run: |
-          curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_ENTERPRISE_DEV_URL} -o ${ENTERPRISE_TAR} &
-          curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_COMMUNITY_DEV_URL} -o ${COMMUNITY_TAR} &
+          curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_ENTERPRISE_URL} -o ${ENTERPRISE_TAR} &
+          curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_COMMUNITY_URL} -o ${COMMUNITY_TAR} &
           wait
           docker load --input ${ENTERPRISE_TAR}
           docker load --input ${COMMUNITY_TAR}

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -54,9 +54,7 @@ dependencies {
     api group: 'com.jayway.jsonpath', name: 'json-path', version: '2.7.0'
     api group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
     api group: 'org.apache.commons', name: 'commons-collections4', version: '4.2'
-    api group: 'org.apache.commons', name: 'commons-configuration2', version: '2.8.0', {
-        exclude module: "commons-lang3"
-    }
+
     // We need to force this dependency's verion due to a vulnerability https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/3048
     api group: 'org.apache.commons', name: 'commons-lang3', {
         version {
@@ -69,6 +67,7 @@ dependencies {
     // These will be dependencies not packaged with the .jar
     // They need to be provided either through the database or in an extra .jar
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
+    compileOnly group: 'org.apache.commons', name: 'commons-configuration2', version: '2.8.0'
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
     compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.2', withoutServers
     compileOnly group: 'com.google.cloud', name: 'google-cloud-storage', version: '2.6.1'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -68,7 +68,7 @@ dependencies {
 
     // These will be dependencies packaged with the .jar
     implementation project(":common")
-    implementation group: 'com.opencsv', name: 'opencsv', version: '4.6'
+    implementation group: 'com.opencsv', name: 'opencsv', version: '5.7.1'
     implementation group: 'org.roaringbitmap', name: 'RoaringBitmap', version: '0.7.17'
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     implementation group: 'org.apache.arrow', name: 'arrow-vector', version: '7.0.0', {

--- a/teamcity-repository.gradle
+++ b/teamcity-repository.gradle
@@ -3,7 +3,7 @@ allprojects {
         repositories {
             maven {
                 name = 'teamcity-neo4j-dev'
-                url =  System.getenv('TEAMCITY_DEV_URL')
+                url =  System.getenv('TEAMCITY_URL')
                 credentials {
                     username System.getenv('TEAMCITY_USER')
                     password System.getenv('TEAMCITY_PASSWORD')

--- a/test-utils/src/main/java/apoc/periodic/PeriodicTestUtils.java
+++ b/test-utils/src/main/java/apoc/periodic/PeriodicTestUtils.java
@@ -51,7 +51,6 @@ public class PeriodicTestUtils {
                         return row.get("wasTerminated");
                     }),
                 (value) -> true, 10L, TimeUnit.SECONDS);
-            fail("Should have terminated");
         } catch(Exception tfe) {
             assertEquals(tfe.getMessage(),true, tfe.getMessage().contains("terminated"));
         }


### PR DESCRIPTION
Cherry-picks #226 

* Moves commons-configuration2 dependency to compileOnly

This dependency was importing commons-text 1.9.0 which has the CVE-2022-42889 vulnerability. Since this dependency is imported by Neo4j at runtime, I've decided to simply not include it in the APOC runtime.

* Bumps openCsv to 5.7.1

OpenCsv has made a number of breaking change between 4.x and 5.x:
- you must now use the builder constructor
- you should now wrap the csv reader in a try-with-resources

https://opencsv.sourceforge.net/#upgrading_from_4_x_to_5_x


