### PR TITLE
[NOID] Corrects versioning manually until automatic job is fixed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ static def neo4jReleases() {
 
 // In an ideal world this method would return an empty list. Alas, 5.0.0 was never published to mvn
 static def initialiseNeo4jReleases() {
-    return [ "5.0.0 "]
+    return [ "5.0.0"]
 }
 
 // Gets all APOC releases from Github

--- a/versions.json
+++ b/versions.json
@@ -1,7 +1,7 @@
 [
     {
-        "neo4j": "5.1.0",
-        "neo4jVersion": "5.1.0",
+        "neo4j": "5.2.0",
+        "neo4jVersion": "5.2.0",
         "apoc": "5.2.1",
         "version": "5.2.1",
         "url": "https://github.com/neo4j/apoc/releases/5.2.1",
@@ -18,17 +18,35 @@
         }
     },
     {
-        "neo4j": "5.0.0 ",
-        "neo4jVersion": "5.0.0 ",
-        "apoc": "5.2.1",
-        "version": "5.2.1",
-        "url": "https://github.com/neo4j/apoc/releases/5.2.1",
-        "homepageUrl": "https://github.com/neo4j/apoc/releases/5.2.1",
-        "jar": "https://github.com/neo4j/apoc/releases/download/5.2.1/apoc-5.2.1-core.jar",
-        "downloadUrl": "https://github.com/neo4j/apoc/releases/download/5.2.1/apoc-5.2.1-core.jar",
-        "sha1": "dc9f6ea430d9e951fb3c25ddab0e743830a2aff0",
-        "sha256": "8e69647d207e810b79f6eb2329987ad9cc59d219bacf166c022432d557adec5d",
-        "md5": "89484d67181fe0a26a678038673428ea",
+        "neo4j": "5.1.0",
+        "neo4jVersion": "5.1.0",
+        "apoc": "5.1.0",
+        "version": "5.1.0",
+        "url": "https://github.com/neo4j/apoc/releases/5.1.0",
+        "homepageUrl": "https://github.com/neo4j/apoc/releases/5.1.0",
+        "jar": "https://github.com/neo4j/apoc/releases/download/5.1.0/apoc-5.1.0-core.jar",
+        "downloadUrl": "https://github.com/neo4j/apoc/releases/download/5.1.0/apoc-5.1.0-core.jar",
+        "sha1": "bae4dc6c6b2eb823d4b20aa20c46f5a7df149cc6",
+        "sha256": "f45f7b313e48288c35c01fec33d390626d4a5cbddab298332127dc1150f6007d",
+        "md5": "9494820a00c7ce8149bf435e77bcdd0c",
+        "config": {
+            "+:dbms.security.procedures.unrestricted": [
+                "apoc.*"
+            ]
+        }
+    },
+    {
+        "neo4j": "5.0.0",
+        "neo4jVersion": "5.0.0",
+        "apoc": "5.0.0",
+        "version": "5.0.0",
+        "url": "https://github.com/neo4j/apoc/releases/5.0.0",
+        "homepageUrl": "https://github.com/neo4j/apoc/releases/5.0.0",
+        "jar": "https://github.com/neo4j/apoc/releases/download/5.0.0/apoc-5.0.0-core.jar",
+        "downloadUrl": "https://github.com/neo4j/apoc/releases/download/5.0.0/apoc-5.0.0-core.jar",
+        "sha1": "cedf320fd91947da3a628c1cdf81020ce46071a6",
+        "sha256": "6c416afdf973518d466a82b640648a7402caa0f2d47704b5290f5537e16dc3dd",
+        "md5": "ffb5db073178515a43472842397046ab",
         "config": {
             "+:dbms.security.procedures.unrestricted": [
                 "apoc.*"


### PR DESCRIPTION
The automatic job for updating `versions.json` is not working as we expected. It should have written:

* neo4j 5.0.0 -> apoc 5.0.0
* neo4j 5.1.0 -> apoc 5.1.0
* neo4j 5.2.0 (not in Maven Central yet) -> apoc 5.2.1

but instead has written:

* neo4j 5.0.0 -> apoc 5.2.1
* neo4j 5.1.0 -> apoc 5.2.1

This PR fixes the `versions.json` manually.
