### PR TITLE
Changed gradle version in order to build extended library

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: [ "5.1.0" ]
   pull_request:
-    branches: [ "dev" ]
+    branches: [ "5.1.0" ]
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -71,8 +71,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise' : 'neo4j:5.1.0-dev-enterprise',
-                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") : 'neo4j:5.1.0-dev',
+                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise' : 'neo4j:5.1.0-enterprise',
+                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") : 'neo4j:5.1.0',
                 'coreDir': 'core'
 
         maxHeapSize = "8G"

--- a/build.gradle
+++ b/build.gradle
@@ -129,8 +129,6 @@ subprojects {
 }
 
 ext {
-    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ?
-            project.getProperty("neo4jVersionOverride")
-            : (System.env.CI != null) ? "5.1.0-dev" : "5.1.0-SNAPSHOT"
+    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : "5.1.0"
     testContainersVersion = '1.16.2'
 }


### PR DESCRIPTION
Changed gradle versions in order to build extended library 
See https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3284

Currently extended fails with `org.gradle.internal.resolve.ModuleVersionNotFoundException: Could not find org.neo4j:neo4j:5.1.0-dev` error, because in `CoreExtendedTest` is executed  an `TestContainerUtil.executeGradleTasks(projectDir, "shadowJar");` of the core project, but doesn't find neo4j (because neo4jVersionEffective in `apoc-core/build.gradle` is  "5.1.0-dev" )

---

Updated `ci.yaml` from "dev" to "5.1.0" in order to run the CI.


