### PR TITLE
[4Bmcyc2U] Fix ignored testGeocodeGoogle

### DIFF
--- a/core/src/test/java/apoc/spatial/GeocodeTest.java
+++ b/core/src/test/java/apoc/spatial/GeocodeTest.java
@@ -25,19 +25,7 @@ public class GeocodeTest {
 
     @Before
     public void initDb() throws Exception {
-        assumeRunningInCI();
-        apocConfig().setProperty("apoc.spatial.geocode.provider", "opencage");
-        apocConfig().setProperty("apoc.spatial.geocode.opencage.key", "<YOUR_API_KEY>");
-        apocConfig().setProperty("apoc.spatial.geocode.opencage.url", "https://api.opencagedata.com/geocode/v1/json?q=PLACE&key=KEY");
-        apocConfig().setProperty("apoc.spatial.geocode.opencage.reverse.url", "https://api.opencagedata.com/geocode/v1/json?q=LAT+LNG&key=KEY");
-
-//        List<String> strings = Iterators.asList(apocConfig().getConfig().getKeys("apoc.spatial.geocode.opencage"));
         TestUtil.registerProcedure(db, Geocode.class);
-    }
-
-    @Before
-    public void setUp() throws Exception {
-        assumeRunningInCI();
     }
 
     // -- with config map
@@ -66,36 +54,6 @@ public class GeocodeTest {
         testGeocodeWithThrottling("osm", true);
     }
 
-    @Ignore
-    @Test
-    public void testGeocodeGoogle() throws Exception {
-        testGeocodeWithThrottling("google", false);
-    }
-
-    @Test
-    public void testReverseGeocodeGoogle() throws Exception {
-        testGeocodeWithThrottling("google", true);
-    }
-
-    @Test
-    public void testGeocodeOpenCage() throws Exception {
-        // If the key is not defined the test won't fail
-        String provider = apocConfig().getString(Geocode.PREFIX +"." + Geocode.GEOCODE_PROVIDER_KEY).toLowerCase();
-        Assume.assumeTrue(!"<YOUR_API_KEY>".equals(apocConfig().getString(Geocode.PREFIX +"." + provider + ".key")));
-
-        // We use testGeocode() instead of testGeocodeWithThrottling() because the slow test takes less time than the fast one
-        // The overall execution is strictly tight to the remote service according to quota and request policies
-        testGeocode("openCage",1000, false);
-    }
-
-    @Test
-    public void testReverseGeocodeOpenCage() throws Exception {
-        // If the key is not defined the test won't fail
-        String provider = apocConfig().getString(Geocode.PREFIX +"." + Geocode.GEOCODE_PROVIDER_KEY).toLowerCase();
-        Assume.assumeTrue(!"<YOUR_API_KEY>".equals(apocConfig().getString(Geocode.PREFIX +"." + provider + ".key")));
-        testGeocode("openCage",1000, true);
-    }
-
     private void testGeocodeWithThrottling(String supplier, Boolean reverseGeocode) throws Exception {
         testGeocodeWithThrottling(supplier, reverseGeocode, Collections.emptyMap());
     }
@@ -104,10 +62,6 @@ public class GeocodeTest {
         long fast = testGeocode(supplier, 100, reverseGeocode, config);
         long slow = testGeocode(supplier, 2000, reverseGeocode, config);
         assertTrue("Fast " + supplier + " took " + fast + "ms and slow took " + slow + "ms, but expected slow to be at least twice as long", (1.0 * slow / fast) > 1.2);
-    }
-
-    private long testGeocode(String provider, long throttle, boolean reverseGeocode) throws Exception {
-        return testGeocode(provider, throttle, reverseGeocode, Collections.emptyMap());
     }
 
     private long testGeocode(String provider, long throttle, boolean reverseGeocode, Map<String, Object> config) throws Exception {
@@ -134,6 +88,7 @@ public class GeocodeTest {
         ignoreQuotaError(() -> {
             testResult(db, "CALL apoc.spatial.reverseGeocode($latitude, $longitude, false, $config)",
                     map("latitude", latitude, "longitude", longitude, "config", config), (row) -> {
+                        assertTrue(row.hasNext());
                         row.forEachRemaining((r)->{
                             assertNotNull(r.get("description"));
                             assertNotNull(r.get("location"));
@@ -228,18 +183,4 @@ public class GeocodeTest {
                     }
                 });
     }
-
-/*
-    private void testConfig(String provider) {
-        testCall(db, "CALL apoc.spatial.config($config)", map("config", map(GEO_PREFIX + ".test", provider)),
-                (row) -> {
-                    Map<String, String> value = (Map) row.get("value");
-                    assertEquals("Expected provider to be set in '" + GEO_PREFIX + ".test'", provider, value.get(GEO_PREFIX + ".test"));
-                    assertEquals(provider, value.get(Geocode.GEOCODE_PROVIDER_KEY));
-                    String throttleKey = GEO_PREFIX + "." + provider + ".throttle";
-                    assertTrue("Expected a throttle setting", value.containsKey(throttleKey));
-                    assertTrue("Expected a valid throttle setting", Long.parseLong(value.get(throttleKey)) > 0);
-                });
-    }
-*/
 }

--- a/core/src/test/java/apoc/spatial/GeocodeTest.java
+++ b/core/src/test/java/apoc/spatial/GeocodeTest.java
@@ -66,7 +66,6 @@ public class GeocodeTest {
 
     private long testGeocode(String provider, long throttle, boolean reverseGeocode, Map<String, Object> config) throws Exception {
         setupSupplier(provider, throttle);
-//        testConfig(provider);
         InputStream is = getClass().getResourceAsStream("/spatial.json");
         Map tests = JsonUtil.OBJECT_MAPPER.readValue(is, Map.class);
         long start = System.currentTimeMillis();


### PR DESCRIPTION
Currently the tests, except for the `"osm"` one, are quite unusable.

In fact, the `"opencage"` tests are actually ignored due to [this assumption](https://github.com/neo4j/apoc/compare/fix_ignored_testGeocodeGoogle?expand=1#diff-252f4d56949dc064efccfe8ec2a9f918c432ad1b2a224973c2fc2b9e499e90d1L84), 
so in order to run them, we should manually writ your own key instead of `<YOUR_API_KEY>`.

While the reverse `"google"` test is a false positive, as it returns (with an invalid/absent ket) an empty result and [here](https://github.com/neo4j/apoc/compare/fix_ignored_testGeocodeGoogle?expand=1#diff-252f4d56949dc064efccfe8ec2a9f918c432ad1b2a224973c2fc2b9e499e90d1L137) the return result works even if it shouldn't. 
There should be a `assertTrue(row.hasNext());` before the foreach.


So to make these tests valid, I think the possible ways are:
- delete these tests as we already have some mock tests (`SpatialTest.java`).

- plan insertion in the CIs of some key, e.g. `OPENCAGE_KEY` and `GOOGLE_KEY` and write the tests like this, for example:
```
private static final String GMAPS_KEY = System.getenv("GMAPS_KEY");

// in @Before/@BeforeClass method
apocConfig().setProperty("apoc.spatial.geocode.google.key", GMAPS_KEY);

    @Test
    public void testGeocodeGoogle() throws Exception {
          Assume.assumeNotNull(GMAPS_KEY);
...

```