### PR TITLE
Fixes password length, bumps testContainer version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,5 +130,5 @@ subprojects {
 
 ext {
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : "5.3.0"
-    testContainersVersion = '1.16.2'
+    testContainersVersion = '1.17.6'
 }

--- a/test-utils/src/main/java/apoc/util/TestContainerUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestContainerUtil.java
@@ -42,7 +42,7 @@ public class TestContainerUtil {
     public static final String neo4jEnterpriseDockerImageVersion = System.getProperty("neo4jDockerImage");
     public static final String neo4jCommunityDockerImageVersion = System.getProperty("neo4jCommunityDockerImage");
 
-    public static final String password = "apoc";
+    public static final String password = "apoc12345";
 
     private TestContainerUtil() {}
 


### PR DESCRIPTION
## Why

From neo4j 5.2, passwords now have to be 8 characters minimum length

