### PR TITLE
[NwnPuJ91] Rewrite tests for failures in a safer way

### DIFF
--- a/common/src/test/java/apoc/util/DateParseUtilTest.java
+++ b/common/src/test/java/apoc/util/DateParseUtilTest.java
@@ -6,7 +6,7 @@ import java.time.*;
 
 import static apoc.util.DateParseUtil.dateParse;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
 
 public class DateParseUtilTest {
 
@@ -21,14 +21,11 @@ public class DateParseUtilTest {
         assertEquals(OffsetTime.of(10,15,30,0,ZoneOffset.of("+01:00")),dateParse("10:15:30+01:00", OffsetTime.class, parseList));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void dateParseErrorTest() {
-        try {
-            dateParse("10/01/2010", LocalDateTime.class, parseList);
-        } catch (Exception e) {
-            assertTrue(e instanceof RuntimeException);
-            assertEquals("Can't format the date with the pattern", e.getMessage());
-            throw e;
-        }
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> dateParse("10/01/2010", LocalDateTime.class, parseList)
+        );
+        assertEquals("Can't format the date with the pattern", e.getMessage());
     }
 }

--- a/common/src/test/java/apoc/util/UtilIT.java
+++ b/common/src/test/java/apoc/util/UtilIT.java
@@ -132,20 +132,18 @@ public class UtilIT {
         }
     }
 
-    @Test(expected = RuntimeException.class)
-    public void redirectShouldThrowExceptionWhenProtocolChangesWithFileLocation() throws IOException {
-        try {
-            httpServer = setUpServer(null, "file:/etc/passwd");
-            // given
-            String url = getServerUrl(httpServer);
+    @Test
+    public void redirectShouldThrowExceptionWhenProtocolChangesWithFileLocation() {
+        httpServer =setUpServer(null, "file:/etc/passwd");
+        // given
+        String url = getServerUrl(httpServer);
 
-            // when
-            Util.openInputStream(url, null, null, null);
-        } catch (RuntimeException e) {
-            // then
-            assertEquals("The redirect URI has a different protocol: file:/etc/passwd", e.getMessage());
-            throw e;
-        }
+        // when
+        RuntimeException e = Assert.assertThrows( RuntimeException.class,
+                () -> Util.openInputStream(url, null, null, null)
+        );
+
+        assertEquals("The redirect URI has a different protocol: file:/etc/passwd", e.getMessage());
     }
 
     private String getServerUrl(GenericContainer httpServer) {

--- a/core/src/main/java/apoc/atomic/Atomic.java
+++ b/core/src/main/java/apoc/atomic/Atomic.java
@@ -156,7 +156,7 @@ public class Atomic {
 
             oldValue[0] = arrayBackedList;
             if(position > arrayBackedList.length || position < 0) {
-                throw new RuntimeException("Attention your position out of range or higher than array length, that is " + arrayBackedList.length);
+                throw new RuntimeException("Position " + position + " is out of range for array of length " + arrayBackedList.length);
             }
             Object[] newArray = ArrayUtils.addAll(Arrays.copyOfRange(arrayBackedList, 0, position.intValue()), Arrays.copyOfRange(arrayBackedList, position.intValue() +1, arrayBackedList.length));
             Class clazz;

--- a/core/src/test/java/apoc/atomic/AtomicTest.java
+++ b/core/src/test/java/apoc/atomic/AtomicTest.java
@@ -177,7 +177,7 @@ public class AtomicTest {
 		);
 		Throwable except = ExceptionUtils.getRootCause(e);
         assertTrue(except instanceof RuntimeException);
-		assertEquals("Attention your position out of range or higher than array length, that is 3", except.getMessage());
+		assertEquals("Position 5 is out of range for array of length 3", except.getMessage());
     }
 
     @Test
@@ -190,7 +190,7 @@ public class AtomicTest {
 		);
         Throwable except = ExceptionUtils.getRootCause(e);
         assertTrue(except instanceof RuntimeException);
-		assertEquals("Attention your position out of range or higher than array length, that is 0", except.getMessage());
+		assertEquals("Position 1 is out of range for array of length 0", except.getMessage());
     }
 
 	@Test

--- a/core/src/test/java/apoc/export/ExportStreamsStatementsTest.java
+++ b/core/src/test/java/apoc/export/ExportStreamsStatementsTest.java
@@ -14,6 +14,7 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import static apoc.ApocConfig.EXPORT_TO_FILE_ERROR;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.neo4j.configuration.SettingImpl.newBuilder;
 import static org.neo4j.configuration.SettingValueParsers.BOOL;
 
@@ -45,17 +46,17 @@ public class ExportStreamsStatementsTest {
         TestUtil.testCall(db, statement, (res) -> assertEquals(expected, res.get("data")));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void shouldNotExportCSVData() {
-        try {
-            String statement = "CALL apoc.export.csv.all('file.csv', {})";
-            TestUtil.testCall(db, statement, (res) -> {});
-        } catch (RuntimeException e) {
-            String expectedMessage = "Failed to invoke procedure `apoc.export.csv.all`: " +
-                    "Caused by: java.lang.RuntimeException: " + EXPORT_TO_FILE_ERROR;
-            assertEquals(expectedMessage, e.getMessage());
-            throw e;
-        }
+        String statement = "CALL apoc.export.csv.all('file.csv', {})";
+
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> TestUtil.testCall(db, statement, (res) -> {})
+        );
+
+        String expectedMessage = "Failed to invoke procedure `apoc.export.csv.all`: " +
+                "Caused by: java.lang.RuntimeException: " + EXPORT_TO_FILE_ERROR;
+        assertEquals(expectedMessage, e.getMessage());
     }
 
     @Test
@@ -86,17 +87,16 @@ public class ExportStreamsStatementsTest {
         TestUtil.testCall(db, statement, (res) -> assertEquals(expected, res.get("cypherStatements")));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void shouldNotExportCypherStatements() {
-        try {
-            String statement = "CALL apoc.export.cypher.all('file.cypher', {})";
-            TestUtil.testCall(db, statement, (res) -> {});
-        } catch (RuntimeException e) {
-            String expectedMessage = "Failed to invoke procedure `apoc.export.cypher.all`: " +
-                    "Caused by: java.lang.RuntimeException: " + EXPORT_TO_FILE_ERROR;
-            assertEquals(expectedMessage, e.getMessage());
-            throw e;
-        }
+        String statement = "CALL apoc.export.cypher.all('file.cypher', {})";
+
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> TestUtil.testCall(db, statement, (res) -> {})
+        );
+        String expectedMessage = "Failed to invoke procedure `apoc.export.cypher.all`: " +
+                "Caused by: java.lang.RuntimeException: " + EXPORT_TO_FILE_ERROR;
+        assertEquals(expectedMessage, e.getMessage());
     }
 
 }

--- a/core/src/test/java/apoc/export/csv/ExportCsvIT.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvIT.java
@@ -32,10 +32,8 @@ public class ExportCsvIT {
     @BeforeClass
     public static void beforeAll() {
         assumeFalse(isRunningInCI());
-        TestUtil.ignoreException(() -> {
-            neo4jContainer = createEnterpriseDB(List.of(ApocPackage.CORE), true);
-            neo4jContainer.start();
-        }, Exception.class);
+        neo4jContainer = createEnterpriseDB(List.of(ApocPackage.CORE), true);
+        neo4jContainer.start();
         assumeNotNull(neo4jContainer);
         assumeTrue("Neo4j Instance should be up-and-running", neo4jContainer.isRunning());
         session = neo4jContainer.getSession();

--- a/core/src/test/java/apoc/export/csv/ExportCsvIT.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvIT.java
@@ -2,7 +2,6 @@ package apoc.export.csv;
 
 import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil.ApocPackage;
-import apoc.util.TestUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
@@ -28,6 +28,7 @@ import static apoc.util.CompressionAlgo.GZIP;
 import static apoc.util.MapUtil.map;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class ExportCsvNeo4jAdminTest {
 
@@ -203,18 +204,16 @@ public class ExportCsvNeo4jAdminTest {
                 .collect(Collectors.toList());
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testCypherExportCsvForAdminNeo4jImportExceptionBulk() {
         String fileName = "query_nodes.csv";
-        try {
-            TestUtil.testCall(db, "CALL apoc.export.csv.query('MATCH (n) return (n)',$fileName,{bulkImport: true})",
-                    Util.map("fileName", fileName), (r) -> {});
-        } catch (Exception e) {
-            Throwable except = ExceptionUtils.getRootCause(e);
-            assertTrue(except instanceof RuntimeException);
-            assertEquals("You can use the `bulkImport` only with apoc.export.all and apoc.export.csv.graph", except.getMessage());
-            throw e;
-        }
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> TestUtil.testCall(db, "CALL apoc.export.csv.query('MATCH (n) return (n)',$fileName,{bulkImport: true})",
+                    Util.map("fileName", fileName), (r) -> {})
+        );
+        Throwable except = ExceptionUtils.getRootCause(e);
+        assertTrue(except instanceof RuntimeException);
+        assertEquals("You can use the `bulkImport` only with apoc.export.all and apoc.export.csv.graph", except.getMessage());
     }
 
     private void assertResults(String fileName, Map<String, Object> r, final String source) {

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -53,6 +53,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 import static org.neo4j.configuration.GraphDatabaseSettings.TransactionStateMemoryAllocation.OFF_HEAP;
@@ -332,17 +333,16 @@ public class ExportGraphMLTest {
         );
     }
 
-    @Test(expected = QueryExecutionException.class)
+    @Test
     public void testImportGraphMLWithNoImportConfig() {
         File output = new File(directory, "all.graphml");
-        try {
-            TestUtil.testCall(db, "CALL apoc.import.graphml($file,{readLabels:true})", map("file", output.getAbsolutePath()), (r) -> assertResults(output, r, "database"));
-        } catch (QueryExecutionException e) {
-            Throwable except = ExceptionUtils.getRootCause(e);
-            TestCase.assertTrue(except instanceof RuntimeException);
-            assertEquals("Import from files not enabled, please set apoc.import.file.enabled=true in your apoc.conf", except.getMessage());
-            throw e;
-        }
+        QueryExecutionException e = assertThrows(QueryExecutionException.class,
+                () -> TestUtil.testCall(db, "CALL apoc.import.graphml($file,{readLabels:true})", map("file", output.getAbsolutePath()),
+                        (r) -> assertResults(output, r, "database"))
+        );
+        Throwable except = ExceptionUtils.getRootCause(e);
+        TestCase.assertTrue(except instanceof RuntimeException);
+        assertEquals("Import from files not enabled, please set apoc.import.file.enabled=true in your apoc.conf", except.getMessage());
     }
 
     @Test
@@ -503,17 +503,16 @@ public class ExportGraphMLTest {
         assertXMLEquals(output, EXPECTED_TYPES);
     }
 
-    @Test(expected = QueryExecutionException.class)
+    @Test
     public void testExportGraphGraphMLTypesWithNoExportConfig() {
         File output = new File(directory, "all.graphml");
-        try {
-            TestUtil.testCall(db, "CALL apoc.export.graphml.all($file,null)", map("file", output.getAbsolutePath()), (r) -> assertResults(output, r, "database"));
-        } catch (QueryExecutionException e) {
-            Throwable except = ExceptionUtils.getRootCause(e);
-            TestCase.assertTrue(except instanceof RuntimeException);
-            assertEquals(EXPORT_TO_FILE_ERROR, except.getMessage());
-            throw e;
-        }
+        QueryExecutionException e = assertThrows(QueryExecutionException.class,
+                () -> TestUtil.testCall(db, "CALL apoc.export.graphml.all($file,null)", map("file", output.getAbsolutePath()),
+                        (r) -> assertResults(output, r, "database"))
+        );
+        Throwable except = ExceptionUtils.getRootCause(e);
+        TestCase.assertTrue(except instanceof RuntimeException);
+        assertEquals(EXPORT_TO_FILE_ERROR, except.getMessage());
     }
 
     @Test
@@ -679,18 +678,18 @@ public class ExportGraphMLTest {
         assertXMLEquals(output, EXPECTED_TYPES_PATH_CAPTION_TINKER);
     }
 
-    @Test(expected = QueryExecutionException.class)
+    @Test
     public void testExportGraphGraphMLQueryGephiWithStringCaption() {
         File output = new File(directory, "query.graphml");
-        try {
-        TestUtil.testCall(db, "call apoc.export.graphml.query('MATCH p=()-[r]->() RETURN p limit 1000',$file,{useTypes:true, format: 'gephi', caption: 'name'}) ", map("file", output.getAbsolutePath()),
-                (r) -> {});
-        } catch (QueryExecutionException e) {
-            Throwable except = ExceptionUtils.getRootCause(e);
-            TestCase.assertTrue(except instanceof RuntimeException);
-            assertEquals("Only array of Strings are allowed!", except.getMessage());
-            throw e;
-        }
+        QueryExecutionException e = assertThrows(QueryExecutionException.class,
+                () -> TestUtil.testCall(db,
+                        "call apoc.export.graphml.query('MATCH p=()-[r]->() RETURN p limit 1000',$file,{useTypes:true, format: 'gephi', caption: 'name'}) ",
+                        map("file", output.getAbsolutePath()),
+                        (r) -> {})
+        );
+        Throwable except = ExceptionUtils.getRootCause(e);
+        TestCase.assertTrue(except instanceof RuntimeException);
+        assertEquals("Only array of Strings are allowed!", except.getMessage());
     }
 
     @Test

--- a/core/src/test/java/apoc/load/LoadJsonTest.java
+++ b/core/src/test/java/apoc/load/LoadJsonTest.java
@@ -39,6 +39,7 @@ import static java.util.Arrays.asList;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.matchers.Times.exactly;
 import static org.mockserver.model.HttpRequest.request;
@@ -110,7 +111,7 @@ public class LoadJsonTest {
         var protocols = List.of("https", "http", "ftp");
 
         for (var protocol: protocols) {
-            QueryExecutionException e = Assert.assertThrows(QueryExecutionException.class,
+            QueryExecutionException e = assertThrows(QueryExecutionException.class,
                                             () -> testCall(db,
                                                            "CALL apoc.load.json('" + protocol + "://127.168.0.0/test.csv')",
                                                            map(),
@@ -310,19 +311,16 @@ public class LoadJsonTest {
                 });
     }
 
-    @Test(expected = QueryExecutionException.class)
+    @Test
     public void testLoadJsonByUrlInConfigFileWrongKey() {
-
-        try {
-            testResult(db, "CALL apoc.load.json($key)",map("key","foo"), (r) -> r.hasNext());
-        } catch (QueryExecutionException e) {
-            Throwable except = ExceptionUtils.getRootCause(e);
-            assertTrue(except instanceof IOException);
-            final String message = except.getMessage();
-            assertTrue(message.startsWith("Cannot open file "));
-            assertTrue(message.endsWith("foo for reading."));
-            throw e;
-        }
+        QueryExecutionException e = assertThrows(QueryExecutionException.class,
+                () -> testResult(db, "CALL apoc.load.json($key)",map("key","foo"), (r) -> r.hasNext())
+        );
+        Throwable except = ExceptionUtils.getRootCause(e);
+        assertTrue(except instanceof IOException);
+        final String message = except.getMessage();
+        assertTrue(message.startsWith("Cannot open file "));
+        assertTrue(message.endsWith("foo for reading."));
     }
 
     @Test

--- a/core/src/test/java/apoc/load/XmlTest.java
+++ b/core/src/test/java/apoc/load/XmlTest.java
@@ -201,7 +201,7 @@ public class XmlTest {
 
     @Test
     public void testLoadXmlWithBlockedIP () {
-        QueryExecutionException e = Assert.assertThrows(QueryExecutionException.class,
+        QueryExecutionException e = assertThrows(QueryExecutionException.class,
                 () -> testCall(db,
                         "CALL apoc.load.xml('http://127.0.0.0/fake.xml') yield value as result",
                         map(),
@@ -463,95 +463,91 @@ public class XmlTest {
                 (r) -> assertEquals(XmlTestUtils.XML_XPATH_AS_NESTED_MAP, r.get("result")));
     }
 
-    @Test(expected = QueryExecutionException.class)
+    @Test
     public void testLoadXmlPreventXXEVulnerabilityThrowsQueryExecutionException() {
-        try {
-            testResult(db, "CALL apoc.load.xml('" + TestUtil.getUrlFileName("xml/xxe.xml") + "')", (r) -> {
-                r.next();
-                r.close();
-            });
-        } catch (QueryExecutionException e) {
-            Throwable except = ExceptionUtils.getRootCause(e);
-            assertTrue(except instanceof RuntimeException);
-            assertEquals(except.getMessage(), "XML documents with a DOCTYPE are not allowed.");
-            throw e;
-        }
+        QueryExecutionException e = assertThrows(QueryExecutionException.class,
+                () -> testResult(db, "CALL apoc.load.xml('" + TestUtil.getUrlFileName("xml/xxe.xml") + "')", (r) -> {
+                    r.next();
+                    r.close();
+                })
+        );
+
+        Throwable except = ExceptionUtils.getRootCause(e);
+        assertTrue(except instanceof RuntimeException);
+        assertEquals(except.getMessage(), "XML documents with a DOCTYPE are not allowed.");
     }
 
-    @Test(expected = QueryExecutionException.class)
+    @Test
     public void testLoadXmlPreventBillionLaughVulnerabilityThrowsQueryExecutionException() {
-        try {
-            testResult(db, "CALL apoc.load.xml('" + TestUtil.getUrlFileName("xml/billion_laughs.xml") + "')", (r) -> {
-                r.next();
-                r.close();
-            });
-        } catch (QueryExecutionException e) {
-            Throwable except = ExceptionUtils.getRootCause(e);
-            assertTrue(except instanceof RuntimeException);
-            assertEquals(except.getMessage(), "XML documents with a DOCTYPE are not allowed.");
-            throw e;
-        }
+        QueryExecutionException e = assertThrows(QueryExecutionException.class,
+                () -> testResult(db, "CALL apoc.load.xml('" + TestUtil.getUrlFileName("xml/billion_laughs.xml") + "')", (r) -> {
+                    r.next();
+                    r.close();
+                })
+        );
+
+        Throwable except = ExceptionUtils.getRootCause(e);
+        assertTrue(except instanceof RuntimeException);
+        assertEquals(except.getMessage(), "XML documents with a DOCTYPE are not allowed.");
     }
 
-    @Test(expected = QueryExecutionException.class)
+    @Test
     public void testXmlParsePreventXXEVulnerabilityThrowsQueryExecutionException() {
-        try {
-            final var xml = "<?xml version=\"1.0\"?><!DOCTYPE GVI [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]><foo>&xxe;</foo>";
-            testResult(db, "RETURN apoc.xml.parse('" + xml + "')", (r) -> {
-                r.next();
-                r.close();
-            });
-        } catch (QueryExecutionException e) {
-            Throwable except = ExceptionUtils.getRootCause(e);
-            assertTrue(except instanceof RuntimeException);
-            assertEquals(except.getMessage(), "XML documents with a DOCTYPE are not allowed.");
-            throw e;
-        }
+        final var xml = "<?xml version=\"1.0\"?><!DOCTYPE GVI [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]><foo>&xxe;</foo>";
+
+        QueryExecutionException e = assertThrows(QueryExecutionException.class,
+                () -> testResult(db, "RETURN apoc.xml.parse('" + xml + "')", (r) -> {
+                    r.next();
+                    r.close();
+                })
+        );
+
+        Throwable except = ExceptionUtils.getRootCause(e);
+        assertTrue(except instanceof RuntimeException);
+        assertEquals(except.getMessage(), "XML documents with a DOCTYPE are not allowed.");
     }
 
-    @Test(expected = QueryExecutionException.class)
+    @Test
     public void testXmlParsePreventBillionLaughsVulnerabilityThrowsQueryExecutionException() {
-        try {
-            final var xml = "<?xml version=\"1.0\"?><!DOCTYPE lolz [<!ENTITY lol \"lol\"><!ENTITY lol1 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;\">]><foo>&lol1;</foo>";
-            testResult(db, "RETURN apoc.xml.parse('" + xml + "')", (r) -> {
-                r.next();
-                r.close();
-            });
-        } catch (QueryExecutionException e) {
-            Throwable except = ExceptionUtils.getRootCause(e);
-            assertTrue(except instanceof RuntimeException);
-            assertEquals(except.getMessage(), "XML documents with a DOCTYPE are not allowed.");
-            throw e;
-        }
+        final var xml = "<?xml version=\"1.0\"?><!DOCTYPE lolz [<!ENTITY lol \"lol\"><!ENTITY lol1 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;\">]><foo>&lol1;</foo>";
+
+        QueryExecutionException e = assertThrows(QueryExecutionException.class,
+                () ->  testResult(db, "RETURN apoc.xml.parse('" + xml + "')", (r) -> {
+                    r.next();
+                    r.close();
+                })
+        );
+
+        Throwable except = ExceptionUtils.getRootCause(e);
+        assertTrue(except instanceof RuntimeException);
+        assertEquals(except.getMessage(), "XML documents with a DOCTYPE are not allowed.");
     }
 
-    @Test(expected = QueryExecutionException.class)
+    @Test
     public void testImportXmlPreventXXEVulnerabilityThrowsQueryExecutionException() {
-        try {
-            testResult(db, "CALL apoc.import.xml('" + TestUtil.getUrlFileName("xml/xxe.xml") + "')", (r) -> {
-                r.next();
-                r.close();
-            });
-        } catch (QueryExecutionException e) {
-            Throwable except = ExceptionUtils.getRootCause(e);
-            assertTrue(except instanceof RuntimeException);
-            assertEquals(except.getMessage(), "XML documents with a DOCTYPE are not allowed.");
-            throw e;
-        }
+        QueryExecutionException e = assertThrows(QueryExecutionException.class,
+                () -> testResult(db, "CALL apoc.import.xml('" + TestUtil.getUrlFileName("xml/xxe.xml") + "')", (r) -> {
+                    r.next();
+                    r.close();
+                })
+        );
+
+        Throwable except = ExceptionUtils.getRootCause(e);
+        assertTrue(except instanceof RuntimeException);
+        assertEquals(except.getMessage(), "XML documents with a DOCTYPE are not allowed.");
     }
 
-    @Test(expected = QueryExecutionException.class)
+    @Test
     public void testImportXmlPreventBillionLaughsVulnerabilityThrowsQueryExecutionException() {
-        try {
-            testResult(db, "CALL apoc.import.xml('" + TestUtil.getUrlFileName("xml/billion_laughs.xml") + "')", (r) -> {
-                r.next();
-                r.close();
-            });
-        } catch (QueryExecutionException e) {
-            Throwable except = ExceptionUtils.getRootCause(e);
-            assertTrue(except instanceof RuntimeException);
-            assertEquals(except.getMessage(), "XML documents with a DOCTYPE are not allowed.");
-            throw e;
-        }
+        QueryExecutionException e = assertThrows(QueryExecutionException.class,
+                () -> testResult(db, "CALL apoc.import.xml('" + TestUtil.getUrlFileName("xml/billion_laughs.xml") + "')", (r) -> {
+                    r.next();
+                    r.close();
+                })
+        );
+
+        Throwable except = ExceptionUtils.getRootCause(e);
+        assertTrue(except instanceof RuntimeException);
+        assertEquals(except.getMessage(), "XML documents with a DOCTYPE are not allowed.");
     }
 }

--- a/core/src/test/java/apoc/load/XmlTest.java
+++ b/core/src/test/java/apoc/load/XmlTest.java
@@ -9,7 +9,6 @@ import inet.ipaddr.IPAddressString;
 import junit.framework.TestCase;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/core/src/test/java/apoc/meta/CollEnterpriseTest.java
+++ b/core/src/test/java/apoc/meta/CollEnterpriseTest.java
@@ -24,11 +24,9 @@ public class CollEnterpriseTest {
     @BeforeAll
     public static void beforeAll() {
         assumeFalse(isRunningInCI());
-        TestUtil.ignoreException(() -> {
-            // We build the project, the artifact will be placed into ./build/libs
-            neo4jContainer = createEnterpriseDB(List.of(ApocPackage.CORE), !TestUtil.isRunningInCI());
-            neo4jContainer.start();
-        }, Exception.class);
+        // We build the project, the artifact will be placed into ./build/libs
+        neo4jContainer = createEnterpriseDB(List.of(ApocPackage.CORE), !TestUtil.isRunningInCI());
+        neo4jContainer.start();
         assumeTrue(neo4jContainer.isRunning());
         assumeNotNull(neo4jContainer);
         assumeTrue("Neo4j Instance should be up-and-running", neo4jContainer.isRunning());

--- a/core/src/test/java/apoc/path/PathsTest.java
+++ b/core/src/test/java/apoc/path/PathsTest.java
@@ -51,9 +51,14 @@ public class PathsTest {
         TestUtil.testCall(db, "RETURN apoc.path.slice(null) as p",(row) -> assertNull(row.get("p")));
     }
 
-    @Test(expected = QueryExecutionException.class)
+    @Test
     public void combineFail() {
-        TestUtil.testCall(db, "MATCH p1 = (a:A)-[:NEXT]->(b:B), p2 = (c:C)-[:NEXT]->() RETURN apoc.path.combine(p1,p2) AS p", (row) -> fail("Should have failed"));
+        QueryExecutionException e = assertThrows(QueryExecutionException.class,
+                () -> TestUtil.testCall(db, "MATCH p1 = (a:A)-[:NEXT]->(b:B), p2 = (c:C)-[:NEXT]->() RETURN apoc.path.combine(p1,p2) AS p",
+                        (row) -> fail("Should have failed"))
+
+        );
+        assertTrue(e.getMessage().contains("Paths don't connect on their end and start-nodes"));
     }
     @Test
     public void combine() {

--- a/core/src/test/java/apoc/path/PathsTest.java
+++ b/core/src/test/java/apoc/path/PathsTest.java
@@ -54,9 +54,7 @@ public class PathsTest {
     @Test
     public void combineFail() {
         QueryExecutionException e = assertThrows(QueryExecutionException.class,
-                () -> TestUtil.testCall(db, "MATCH p1 = (a:A)-[:NEXT]->(b:B), p2 = (c:C)-[:NEXT]->() RETURN apoc.path.combine(p1,p2) AS p",
-                        (row) -> fail("Should have failed"))
-
+                () -> TestUtil.testCall(db, "MATCH p1 = (a:A)-[:NEXT]->(b:B), p2 = (c:C)-[:NEXT]->() RETURN apoc.path.combine(p1,p2) AS p", (r) -> {})
         );
         assertTrue(e.getMessage().contains("Paths don't connect on their end and start-nodes"));
     }

--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -587,7 +587,7 @@ public class PeriodicTest {
                 "{concurrency:0 ,parallel:true})";
 
         QueryExecutionException e = assertThrows(QueryExecutionException.class,
-                () -> testCall(db, query, row -> fail("The test should fail but it didn't"))
+                () -> testCall(db, query, (r) -> {})
         );
         assertTrue(e.getMessage().contains("concurrency parameter must be > 0"));
     }

--- a/core/src/test/java/apoc/spatial/GeocodeTest.java
+++ b/core/src/test/java/apoc/spatial/GeocodeTest.java
@@ -3,7 +3,6 @@ package apoc.spatial;
 import apoc.util.JsonUtil;
 import apoc.util.TestUtil;
 import org.junit.*;
-import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -34,16 +33,6 @@ public class GeocodeTest {
         // wrong url but doesn't fail because provider is osm, not opencage
         testGeocodeWithThrottling("osm", false, 
                 map("url", "https://api.opencagedata.com/geocode/v1/json?q=PLACE&key=KEY111"));
-    }
-    
-    @Test
-    public void testWrongUrlWithOpenCage() {
-        // overwrite ApocConfig provider
-        QueryExecutionException e = assertThrows(QueryExecutionException.class,
-                () -> testGeocodeWithThrottling("osm", false,
-                        map("provider", "opencage", "url", "https://api.opencagedata.com/geocode/v1/json?q=PLACE&key=KEY111"))
-        );
-        assertTrue(e.getMessage().contains("Server returned HTTP response code: 401 for URL"));
     }
     
     // -- with apoc config

--- a/core/src/test/java/apoc/spatial/GeocodeTest.java
+++ b/core/src/test/java/apoc/spatial/GeocodeTest.java
@@ -36,11 +36,14 @@ public class GeocodeTest {
                 map("url", "https://api.opencagedata.com/geocode/v1/json?q=PLACE&key=KEY111"));
     }
     
-    @Test(expected = QueryExecutionException.class)
-    public void testWrongUrlWithOpenCage() throws Exception {
+    @Test
+    public void testWrongUrlWithOpenCage() {
         // overwrite ApocConfig provider
-        testGeocodeWithThrottling("osm", false, 
-                map("provider", "opencage", "url", "https://api.opencagedata.com/geocode/v1/json?q=PLACE&key=KEY111"));
+        QueryExecutionException e = assertThrows(QueryExecutionException.class,
+                () -> testGeocodeWithThrottling("osm", false,
+                        map("provider", "opencage", "url", "https://api.opencagedata.com/geocode/v1/json?q=PLACE&key=KEY111"))
+        );
+        assertTrue(e.getMessage().contains("Server returned HTTP response code: 401 for URL"));
     }
     
     // -- with apoc config

--- a/core/src/test/java/apoc/spatial/SpatialTest.java
+++ b/core/src/test/java/apoc/spatial/SpatialTest.java
@@ -31,6 +31,7 @@ import static apoc.util.TestUtil.testResult;
 import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class SpatialTest {
@@ -142,44 +143,41 @@ public class SpatialTest {
         geocodeOnceCommon(config);
     }    
     
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testGeocodeOpencageWrongUrlFormat() {
         // with provider different from osm/google we have to explicit an url correctly formatted (i.e. with 'PLACE' string)
-        try {
-            final Map<String, Object> conf = map("provider", "opencage",
+        final Map<String, Object> conf = map("provider", "opencage",
                     "url", "wrongUrl",
                     "reverseUrl", REVERSE_URL);
-            geocodeOnceCommon(conf);
-        } catch (RuntimeException e) {
-            assertTrue(e.getMessage().contains("Missing 'PLACE' in url template"));
-            throw e;
-        }
+
+         RuntimeException e = assertThrows(RuntimeException.class,
+                 () -> geocodeOnceCommon(conf)
+         );
+         assertTrue(e.getMessage().contains("Missing 'PLACE' in url template"));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testGeocodeOpencageMissingKey() {
         // with provider (via config map) different from osm/google we have to explicit the key
-        try {
-            final Map<String, Object> conf = map("provider", "opencage",
+        final Map<String, Object> conf = map("provider", "opencage",
                     "url", URL, "reverseUrl", REVERSE_URL);
-            geocodeOnceCommon(conf);
-        } catch (RuntimeException e) {
-            assertTrue(e.getMessage().contains("Missing 'key' for geocode provider"));
-            throw e;
-        }
+
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> geocodeOnceCommon(conf)
+         );
+         assertTrue(e.getMessage().contains("Missing 'key' for geocode provider"));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testGeocodeOpencageMissingKeyViaApocConfig() {
         // with provider(via apocConfig()) different from osm/google we have to explicit the key
         apocConfig().setProperty(Geocode.PREFIX + ".provider", "something");
-        try {
-            final Map<String, Object> conf = map("url", URL, "reverseUrl", REVERSE_URL);
-            geocodeOnceCommon(conf);
-        } catch (RuntimeException e) {
-            assertTrue(e.getMessage().contains("Missing 'key' for geocode provider"));
-            throw e;
-        }
+        final Map<String, Object> conf = map("url", URL, "reverseUrl", REVERSE_URL);
+
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> geocodeOnceCommon(conf)
+         );
+         assertTrue(e.getMessage().contains("Missing 'key' for geocode provider"));
     }
 
     @Test
@@ -201,19 +199,18 @@ public class SpatialTest {
         geocodeOnceCommon(config);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testSimpleGeocodeWithWrongProvider() {
-        try {
-            // just to make sure that the spatial.json is well implemented
-            // we pass a well-formatted url, reverse url and key but an incorrect provider
-            final Map<String, Object> config = map("provider", "incorrect",
-                    "url", URL, "reverseUrl", REVERSE_URL,
-                    "key", "myOwnMockKey");
-            geocodeOnceCommon(config);
-        } catch (RuntimeException e) {
-            assertTrue(e.getMessage().contains(WRONG_PROVIDER_ERR));
-            throw e;
-        }
+        // just to make sure that the spatial.json is well implemented
+        // we pass a well-formatted url, reverse url and key but an incorrect provider
+        final Map<String, Object> config = map("provider", "incorrect",
+                "url", URL, "reverseUrl", REVERSE_URL,
+                "key", "myOwnMockKey");
+
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> geocodeOnceCommon(config)
+         );
+         assertTrue(e.getMessage().contains(WRONG_PROVIDER_ERR));
     }
 
     @Test
@@ -312,44 +309,41 @@ public class SpatialTest {
         reverseGeocodeCommon(config);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testReverseGeocodeOpencageWrongUrlFormat() {
         // with provider different from osm/google we have to explicit an url correctly formatted (i.e. with 'PLACE' string)
-        try {
-            final Map<String, Object> conf = map("provider", "opencage",
-                    "url", "wrongUrl",
-                    "reverseUrl", REVERSE_URL);
-            reverseGeocodeCommon(conf);
-        } catch (RuntimeException e) {
-            assertTrue(e.getMessage().contains("Missing 'PLACE' in url template"));
-            throw e;
-        }
+        final Map<String, Object> conf = map("provider", "opencage",
+                "url", "wrongUrl",
+                "reverseUrl", REVERSE_URL);
+
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> reverseGeocodeCommon(conf)
+        );
+         assertTrue(e.getMessage().contains("Missing 'PLACE' in url template"));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testReverseGeocodeOpencageMissingKey() {
         // with provider (via config map) different from osm/google we have to explicit the key
-        try {
-            final Map<String, Object> conf = map("provider", "opencage",
-                    "url", URL, "reverseUrl", REVERSE_URL);
-            reverseGeocodeCommon(conf);
-        } catch (RuntimeException e) {
-            assertTrue(e.getMessage().contains("Missing 'key' for geocode provider"));
-            throw e;
-        }
+        final Map<String, Object> conf = map("provider", "opencage",
+                "url", URL, "reverseUrl", REVERSE_URL);
+
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> reverseGeocodeCommon(conf)
+        );
+         assertTrue(e.getMessage().contains("Missing 'key' for geocode provider"));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testReverseGeocodeOpencageMissingKeyViaApocConfig() {
         // with provider(via apocConfig()) different from osm/google we have to explicit the key
         apocConfig().setProperty(Geocode.PREFIX + ".provider", "something");
-        try {
-            final Map<String, Object> conf = map("url", URL, "reverseUrl", REVERSE_URL);
-            reverseGeocodeCommon(conf);
-        } catch (RuntimeException e) {
-            assertTrue(e.getMessage().contains("Missing 'key' for geocode provider"));
-            throw e;
-        }
+        final Map<String, Object> conf = map("url", URL, "reverseUrl", REVERSE_URL);
+
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> reverseGeocodeCommon(conf)
+        );
+         assertTrue(e.getMessage().contains("Missing 'key' for geocode provider"));
     }
 
     @Test
@@ -371,18 +365,17 @@ public class SpatialTest {
         reverseGeocodeCommon(config);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testSimpleReverseGeocodeWithWrongProvider() {
-        try {
-            // just to make sure that the spatial.json is well implemented
-            final Map<String, Object> config = map("provider", "incorrect",
-                    "url", URL, "reverseUrl", REVERSE_URL,
-                    "key", "myOwnMockKey");
-            reverseGeocodeCommon(config);
-        } catch (RuntimeException e) {
-            assertTrue(e.getMessage().contains(WRONG_PROVIDER_ERR));
-            throw e;
-        }
+        // just to make sure that the spatial.json is well implemented
+        final Map<String, Object> config = map("provider", "incorrect",
+                "url", URL, "reverseUrl", REVERSE_URL,
+                "key", "myOwnMockKey");
+
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> reverseGeocodeCommon(config)
+        );
+         assertTrue(e.getMessage().contains(WRONG_PROVIDER_ERR));
     }
 
     @Test

--- a/core/src/test/java/apoc/trigger/TriggerTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerTest.java
@@ -25,6 +25,8 @@ import static apoc.ApocConfig.apocConfig;
 import static apoc.util.MapUtil.map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.neo4j.configuration.GraphDatabaseSettings.procedure_unrestricted;
 
 /**
@@ -257,9 +259,13 @@ public class TriggerTest {
         });
     }
 
-    @Test(expected = QueryExecutionException.class)
-    public void showThrowAnException() {
-        db.executeTransactionally("CALL apoc.trigger.add('test','UNWIND $createdNodes AS n SET n.txId = , n.txTime = $commitTime',{})");
+    @Test
+    public void showThrowAnExceptionOnBrokenCypherQuery() {
+        QueryExecutionException e = assertThrows(QueryExecutionException.class,
+                () ->  db.executeTransactionally("CALL apoc.trigger.add('test','UNWIND $createdNodes AS n SET n.txId = , n.txTime = $commitTime',{})")
+
+        );
+        assertTrue(e.getMessage().contains("Failed to invoke procedure `apoc.trigger.add`: Caused by: org.neo4j.exceptions.SyntaxException: Invalid input"));
     }
 
     @Test

--- a/core/src/test/java/apoc/util/UtilTest.java
+++ b/core/src/test/java/apoc/util/UtilTest.java
@@ -20,6 +20,7 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -79,14 +80,12 @@ public class UtilTest {
         assertNotNull(Util.merge(null, null));
     }
 
-    @Test(expected = QueryExecutionException.class)
+    @Test
     public void testValidateQuery() {
-        try {
-            Util.validateQuery(db, "Match (n) return m");
-        } catch (QueryExecutionException e) {
-            assertTrue(e.getMessage().contains("Variable `m` not defined"));
-            throw e;
-        }
+        QueryExecutionException e = assertThrows(QueryExecutionException.class,
+                () -> Util.validateQuery(db, "Match (n) return m")
+        );
+        assertTrue(e.getMessage().contains("Variable `m` not defined"));
     }
 
     @Test

--- a/core/src/test/java/apoc/util/UtilTest.java
+++ b/core/src/test/java/apoc/util/UtilTest.java
@@ -83,7 +83,7 @@ public class UtilTest {
     @Test
     public void testValidateQuery() {
         QueryExecutionException e = assertThrows(QueryExecutionException.class,
-                () -> Util.validateQuery(db, "Match (n) return m")
+                () -> Util.validateQuery(db, "MATCH (n) RETURN m")
         );
         assertTrue(e.getMessage().contains("Variable `m` not defined"));
     }

--- a/core/src/test/java/apoc/util/UtilsTest.java
+++ b/core/src/test/java/apoc/util/UtilsTest.java
@@ -124,16 +124,15 @@ public class UtilsTest {
         );
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testWrongDecompressionFromPreviousDifferentCompressionAlgo() {
-        try {
-            TestUtil.testCall(db, "WITH apoc.util.compress('test', {compression: 'GZIP'}) AS compressed RETURN apoc.util.decompress(compressed, {compression: 'DEFLATE'}) AS value", r -> {
-            });
-        } catch (RuntimeException e) {
-            String expectedMessage = "Failed to invoke function `apoc.util.decompress`: Caused by: java.util.zip.ZipException: incorrect header check";
-            assertEquals(expectedMessage, e.getMessage());
-            throw e;
-        }
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () ->  TestUtil.testCall(db, "WITH apoc.util.compress('test', {compression: 'GZIP'}) AS compressed RETURN apoc.util.decompress(compressed, {compression: 'DEFLATE'}) AS value",
+                        r -> {})
+        );
+
+        String expectedMessage = "Failed to invoke function `apoc.util.decompress`: Caused by: java.util.zip.ZipException: incorrect header check";
+        assertEquals(expectedMessage, e.getMessage());
     }
 
     @Test

--- a/core/src/test/java/apoc/warmup/WarmupEnterpriseTest.java
+++ b/core/src/test/java/apoc/warmup/WarmupEnterpriseTest.java
@@ -13,10 +13,12 @@ import static apoc.util.TestContainerUtil.createEnterpriseDB;
 import static apoc.util.TestContainerUtil.testCall;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class WarmupEnterpriseTest {
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testWarmupIsntAllowedWithOtherStorageEngines() {
         Neo4jContainerExtension neo4jContainer = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.CORE), true)
                 .withNeo4jConfig(GraphDatabaseInternalSettings.include_versions_under_development.name(), "true")
@@ -24,7 +26,8 @@ public class WarmupEnterpriseTest {
         neo4jContainer.start();
         Session session = neo4jContainer.getSession();
 
-        testCall(session, "CALL apoc.warmup.run()", (r) -> {});
+        RuntimeException e = assertThrows(RuntimeException.class, () -> testCall(session, "CALL apoc.warmup.run()", (r) -> {}));
+        assertTrue(e.getMessage().contains("Record engine type unsupported"));
 
         session.close();
         neo4jContainer.close();


### PR DESCRIPTION
Tests with '(expected = QueryExecutionException.class)' or similar can
fail with the correct exception for unrelated reasons before coming to the assertion, making the test green even if it is broken. Also ignoreExceptions() feels dangerous to have in test setups 

Builds on top of https://github.com/neo4j/apoc/pull/240
