### PR TITLE
[Zl3h9sM8] apoc.schema.relationships return wrong output for relationship indexes

### DIFF
--- a/common/src/main/java/apoc/result/IndexConstraintNodeInfo.java
+++ b/common/src/main/java/apoc/result/IndexConstraintNodeInfo.java
@@ -34,18 +34,18 @@ public class IndexConstraintNodeInfo {
      * @param label
      * @param properties
      * @param status status of the index, if it's a constraint it will be empty
-     * @param type if it is an index type will be "INDEX" otherwise it will be the type of constraint
+     * @param schemaType if it is an index type will be "INDEX" otherwise it will be the type of constraint
      * @param failure
      * @param populationProgress
      * @param size
      * @param userDescription
      */
-    public IndexConstraintNodeInfo(String name, Object label, List<String> properties, String status, String type, String failure, float populationProgress, long size, double valuesSelectivity, String userDescription) {
+    public IndexConstraintNodeInfo(String name, Object label, List<String> properties, String status, String schemaType, String failure, float populationProgress, long size, double valuesSelectivity, String userDescription) {
         this.name = name;
         this.label = label;
         this.properties = properties;
         this.status = status;
-        this.type = type;
+        this.type = schemaType;
         this.failure = failure;
         this.populationProgress = populationProgress;
         this.size = size;

--- a/common/src/main/java/apoc/result/IndexConstraintRelationshipInfo.java
+++ b/common/src/main/java/apoc/result/IndexConstraintRelationshipInfo.java
@@ -17,9 +17,9 @@ public class IndexConstraintRelationshipInfo {
     
     public final Object relationshipType;
 
-    public IndexConstraintRelationshipInfo(String name, String type, List<String> properties, String status, Object relationshipType) {
+    public IndexConstraintRelationshipInfo(String name, String schemaType, List<String> properties, String status, Object relationshipType) {
         this.name = name;
-        this.type = type;
+        this.type = schemaType;
         this.properties = properties;
         this.status = status;
         this.relationshipType = relationshipType;

--- a/common/src/main/java/apoc/result/IndexConstraintRelationshipInfo.java
+++ b/common/src/main/java/apoc/result/IndexConstraintRelationshipInfo.java
@@ -9,16 +9,19 @@ public class IndexConstraintRelationshipInfo {
 
     public final String name;
 
-    public final Object type;
+    public final String type;
 
     public final List<String> properties;
 
     public final String status;
+    
+    public final Object relationshipType;
 
-    public IndexConstraintRelationshipInfo(String name, Object type, List<String> properties, String status) {
+    public IndexConstraintRelationshipInfo(String name, String type, List<String> properties, String status, Object relationshipType) {
         this.name = name;
         this.type = type;
         this.properties = properties;
         this.status = status;
+        this.relationshipType = relationshipType;
     }
 }

--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -534,7 +534,7 @@ public class Schemas {
                     labelName,
                     properties,
                     schemaRead.indexGetState(indexDescriptor).toString(),
-                    !indexDescriptor.isUnique() ? "INDEX" : "UNIQUENESS",
+                    getIndexType(indexDescriptor),
                     schemaRead.indexGetState(indexDescriptor).equals(InternalIndexState.FAILED) ? schemaRead.indexGetFailure(indexDescriptor) : "NO FAILURE",
                     schemaRead.indexGetPopulationProgress(indexDescriptor).getCompleted() / schemaRead.indexGetPopulationProgress(indexDescriptor).getTotal() * 100,
                     schemaRead.indexSize(indexDescriptor),
@@ -548,7 +548,7 @@ public class Schemas {
                     labelName,
                     properties,
                     "NOT_FOUND",
-                    !indexDescriptor.isUnique() ? "INDEX" : "UNIQUENESS",
+                    getIndexType(indexDescriptor),
                     "NOT_FOUND",
                     0,0,0,
                     indexDescriptor.userDescription(tokens)
@@ -579,7 +579,7 @@ public class Schemas {
             return new IndexConstraintRelationshipInfo(
                     // Pretty print for index name
                     getSchemaInfoName(relName, properties),
-                    "INDEX",
+                    getIndexType(indexDescriptor),
                     properties,
                     "NOT_FOUND",
                     relName
@@ -601,6 +601,10 @@ public class Schemas {
                 "",
                 constraintDefinition.getRelationshipType().name()
         );
+    }
+
+    private static String getIndexType(IndexDescriptor indexDescriptor) {
+        return indexDescriptor.isUnique() ? "UNIQUENESS" : "INDEX";
     }
 
     private String getSchemaInfoName(Object labelOrType, List<String> properties) {

--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -574,14 +574,15 @@ public class Schemas {
                 .mapToObj(tokens::propertyKeyGetName)
                 .collect(Collectors.toList());
         try {
-            return new IndexConstraintRelationshipInfo(getSchemaInfoName(relName, properties), relName, properties, schemaRead.indexGetState(indexDescriptor).toString());
+            return new IndexConstraintRelationshipInfo(getSchemaInfoName(relName, properties), "INDEX", properties, schemaRead.indexGetState(indexDescriptor).toString(), relName);
         } catch (IndexNotFoundKernelException e) {
             return new IndexConstraintRelationshipInfo(
                     // Pretty print for index name
                     getSchemaInfoName(relName, properties),
-                    relName,
+                    "INDEX",
                     properties,
-                    "NOT_FOUND"
+                    "NOT_FOUND",
+                    relName
             );
         }
     }
@@ -597,7 +598,8 @@ public class Schemas {
                 String.format("CONSTRAINT %s", constraintDefinition.toString()),
                 constraintDefinition.getConstraintType().name(),
                 Iterables.asList(constraintDefinition.getPropertyKeys()),
-                ""
+                "",
+                constraintDefinition.getRelationshipType().name()
         );
     }
 

--- a/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
+++ b/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
@@ -382,6 +382,7 @@ public class SchemasEnterpriseFeaturesTest {
             Map<String, Object> r = result.next();
             assertEquals("CONSTRAINT FOR ()-[liked:LIKED]-() REQUIRE liked.day IS NOT NULL", r.get("name"));
             assertEquals("RELATIONSHIP_PROPERTY_EXISTENCE", r.get("type"));
+            assertEquals("LIKED", r.get("relationshipType"));
             assertEquals(asList("day"), r.get("properties"));
             assertEquals(StringUtils.EMPTY, r.get("status"));
             assertFalse(result.hasNext());
@@ -401,12 +402,13 @@ public class SchemasEnterpriseFeaturesTest {
             tx.commit();
             return null;
         });
-        testResult(session, "CALL apoc.schema.relationships() YIELD name, type, properties, status " +
+        testResult(session, "CALL apoc.schema.relationships() YIELD name, type, properties, status, relationshipType " +
                 "WHERE type <> '<any-types>' " +
                 "RETURN *", (result) -> {
             Map<String, Object> r = result.next();
             assertEquals("CONSTRAINT FOR ()-[liked:LIKED]-() REQUIRE liked.day IS NOT NULL", r.get("name"));
             assertEquals("RELATIONSHIP_PROPERTY_EXISTENCE", r.get("type"));
+            assertEquals("LIKED", r.get("relationshipType"));
             assertEquals(asList("day"), r.get("properties"));
             assertEquals(StringUtils.EMPTY, r.get("status"));
             assertFalse(result.hasNext());

--- a/core/src/test/java/apoc/schema/SchemasTest.java
+++ b/core/src/test/java/apoc/schema/SchemasTest.java
@@ -349,7 +349,8 @@ public class SchemasTest {
         testCall(db, "CALL apoc.schema.relationships()", row -> {
             assertEquals(":KNOWS(id,since)", row.get("name"));
             assertEquals("ONLINE", row.get("status"));
-            assertEquals("KNOWS", row.get("type"));
+            assertEquals("KNOWS", row.get("relationshipType"));
+            assertEquals("INDEX", row.get("type"));
             assertEquals(List.of("id", "since"), row.get("properties"));
         });
     }
@@ -712,7 +713,8 @@ public class SchemasTest {
         testCall(db, "CALL apoc.schema.relationships()", (row) -> {
             assertEquals(":" + TOKEN_REL_TYPE + "()", row.get("name"));
             assertEquals("ONLINE", row.get("status"));
-            assertEquals(TOKEN_REL_TYPE, row.get("type"));
+            assertEquals("INDEX", row.get("type"));
+            assertEquals(TOKEN_REL_TYPE, row.get("relationshipType"));
             assertTrue(((List)row.get("properties")).isEmpty());
         });
     }
@@ -753,8 +755,9 @@ public class SchemasTest {
         testCall(db, "CALL apoc.schema.relationships()", (r) -> {
             assertEquals(":[TYPE_1, TYPE_2],(alpha,beta)", r.get("name"));
             assertEquals("ONLINE", r.get("status"));
-            assertEquals(List.of("TYPE_1", "TYPE_2"), r.get("type"));
+            assertEquals(List.of("TYPE_1", "TYPE_2"), r.get("relationshipType"));
             assertEquals(List.of("alpha", "beta"), r.get("properties"));
+            assertEquals("INDEX", r.get("type"));
         });
     }
 }


### PR DESCRIPTION
For consistency with the `apoc. schema.nodes`, I put `"INDEX"` instead of relType.

I've put the old `"type"` in a new field `"relationshipType"`, in order not to lose output info and to be consistent with `"label"` in `schema.nodes` proc (I don't know if it can be considered an additional feature).

To discuss:
In any case, maybe, in both nodes and relationships procedure, instead of get only "INDEX" we could use `IndexDescriptor.getIndexType()` to get a more comprehensive "FULLTEXT"/"LOOKUP"/"TEXT"/"RANGE" or "POINT".
Most likely, since it's a feature, this change could be done in another card, in case.

