### PR TITLE
[eRGoCYQI] Installs Snyk monitor GitHub action on PRs

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -6,7 +6,40 @@ on:
   pull_request:
     branches: [ "dev" ]
 
+env:
+  TEAMCITY_DEV_URL: ${{ secrets.TEAMCITY_DEV_URL }}
+  TEAMCITY_USER: ${{ secrets.TEAMCITY_USER }}
+  TEAMCITY_PASSWORD: ${{ secrets.TEAMCITY_PASSWORD }}
+  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
 jobs:
+  snyk-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: snyk/actions/setup@master
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Snyk test dependencies
+        run: snyk test --all-projects --severity-threshold=high
+
+  snyk-monitor:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: snyk/actions/setup@master
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Snyk monitor dependencies
+        run: snyk monitor --all-projects --severity-threshold=high
+
   build:
     runs-on: ubuntu-latest
 
@@ -18,9 +51,6 @@ jobs:
     env:
       DOCKER_ENTERPRISE_DEV_URL: ${{ secrets.DOCKER_ENTERPRISE_DEV_URL }}
       DOCKER_COMMUNITY_DEV_URL: ${{ secrets.DOCKER_COMMUNITY_DEV_URL }}
-      TEAMCITY_DEV_URL: ${{ secrets.TEAMCITY_DEV_URL }}
-      TEAMCITY_USER: ${{ secrets.TEAMCITY_USER }}
-      TEAMCITY_PASSWORD: ${{ secrets.TEAMCITY_PASSWORD }}
       ENTERPRISE_TAR: enterprise-docker.tar
       COMMUNITY_TAR: community-docker.tar
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
     compileOnly group: 'org.apache.commons', name: 'commons-configuration2', version: '2.8.0'
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
-    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.2', withoutServers
+    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.3', withoutServers
     compileOnly group: 'com.google.cloud', name: 'google-cloud-storage', version: '2.6.1'
 
     // These dependencies affect the tests only, they will not be packaged in the resulting .jar

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -22,9 +22,9 @@ dependencies {
     api group: 'org.neo4j.community', name: 'it-test-support', version: neo4jVersionEffective // , classifier: "tests"
     api group: 'org.neo4j', name: 'log-test-utils', version: neo4jVersionEffective // , classifier: "tests"
     api group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.0.0'
-    api group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.2', withoutServers
-    api group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.2', withoutServers
-    api group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '3.3.2', withoutServers
+    api group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.3', withoutServers
+    api group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.3', withoutServers
+    api group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '3.3.3', withoutServers
     api group: 'org.testcontainers', name: 'testcontainers', version: testContainersVersion
     api group: 'org.testcontainers', name: 'neo4j', version: testContainersVersion
     api group: 'org.testcontainers', name: 'elasticsearch', version: testContainersVersion


### PR DESCRIPTION
## What
Installs Snyk for PRs. There are three different Snyk jobs:

- Snyk test: tests for dependencies and licenses. Triggered on PRs and on merges to dev.
- code/snyk: not defined in this PR. The repo was imported manually. This will analyze the code included in the PRs for security vulnerabilities (unsafe patterns for example).
- Snyk monitor: allows us to monitor the project from https://app.snyk.io. Creates a snapshot of the list of dependencies and will ping us when bleeding edge new vulnerabilities are associated to those. Only runs when pushing to dev.


## Why
Because we want to increase how safe the code is and be alerted about the bleeding edge vulnerabilities.
