### PR TITLE
[eRGoCYQI] Fixes all Snyk dependency issues of medium security level

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -24,7 +24,7 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
       - name: Snyk test dependencies
-        run: snyk test --all-projects --severity-threshold=medium --fail-on=upgradable --fail-on=patchable
+        run: snyk test --all-projects --severity-threshold=medium --fail-on=all
 
   snyk-monitor:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -24,7 +24,7 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
       - name: Snyk test dependencies
-        run: snyk test --all-projects --severity-threshold=high
+        run: snyk test --all-projects --severity-threshold=medium --fail-on=upgradable --fail-on=patchable
 
   snyk-monitor:
     runs-on: ubuntu-latest
@@ -38,7 +38,7 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
       - name: Snyk monitor dependencies
-        run: snyk monitor --all-projects --severity-threshold=high
+        run: snyk monitor --all-projects --target-reference=${GITHUB_BASE_REF}
 
   build:
     runs-on: ubuntu-latest

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -68,13 +68,13 @@ dependencies {
     // They need to be provided either through the database or in an extra .jar
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
     compileOnly group: 'org.apache.commons', name: 'commons-configuration2', version: '2.8.0'
-    compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
-    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.3', withoutServers
-    compileOnly group: 'com.google.cloud', name: 'google-cloud-storage', version: '2.6.1'
+    compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.348'
+    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.4', withoutServers
+    compileOnly group: 'com.google.cloud', name: 'google-cloud-storage', version: '2.6.2'
 
     // These dependencies affect the tests only, they will not be packaged in the resulting .jar
     testImplementation project(':test-utils')
-    testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
+    testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.348'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -87,8 +87,8 @@ dependencies {
     testImplementation project(':test-utils')
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
-    testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
-    testImplementation group: 'org.mock-server', name: 'mockserver-netty', version: '5.6.0'
+    testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.348'
+    testImplementation group: 'org.mock-server', name: 'mockserver-netty', version: '5.13.0'
     testImplementation group: 'com.github.adejanovski', name: 'cassandra-jdbc-wrapper', version: '3.1.0'
     testImplementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: '2.13.2'
 

--- a/core/src/test/java/apoc/load/XmlTest.java
+++ b/core/src/test/java/apoc/load/XmlTest.java
@@ -10,7 +10,6 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.test.rule.DbmsRule;
@@ -35,6 +34,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class XmlTest {
@@ -43,8 +43,6 @@ public class XmlTest {
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Before
     public void setUp() throws Exception {
@@ -257,11 +255,12 @@ public class XmlTest {
 
     @Test
     public void testLoadXmlWithNextWordRels() {
-        thrown.expect(QueryExecutionException.class);
-        thrown.expectMessage("usage of `createNextWordRelationships` is no longer allowed. Use `{relType:'NEXT_WORD', label:'XmlWord'}` instead.");
-
-        db.executeTransactionally("call apoc.import.xml('file:" + FILE_SHORTENED + "', " +
-                "{createNextWordRelationships: true, filterLeadingWhitespace: true}) yield node");
+        assertThrows(
+            "usage of `createNextWordRelationships` is no longer allowed. Use `{relType:'NEXT_WORD', label:'XmlWord'}` instead.",
+            QueryExecutionException.class,
+            () -> db.executeTransactionally("call apoc.import.xml('file:" + FILE_SHORTENED + "', " +
+                "{createNextWordRelationships: true, filterLeadingWhitespace: true}) yield node")
+        );
     }
 
     @Test

--- a/core/src/test/java/apoc/refactor/CloneSubgraphTest.java
+++ b/core/src/test/java/apoc/refactor/CloneSubgraphTest.java
@@ -9,11 +9,11 @@ import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Collections;
 import java.util.List;
 
+import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -22,12 +22,10 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 public class CloneSubgraphTest {
     private static final String STANDIN_SYNTAX_EXCEPTION_MSG = "\'standinNodes\' must be a list of node pairs";
-
-    @Rule
-    public ExpectedException exceptionGrabber = ExpectedException.none();
 
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
@@ -407,67 +405,55 @@ public class CloneSubgraphTest {
 
     @Test
     public void testCloneSubgraph_With_A_1_Element_Standin_Pair_Should_Throw_Exception()  {
-        exceptionGrabber.expectMessage(STANDIN_SYNTAX_EXCEPTION_MSG);
-
-        TestUtil.testCall(db,
-                "MATCH (root:Root{name:'A'})-[*]-(node) " +
-                        "WITH root, collect(DISTINCT node) as nodes " +
-                        "CALL apoc.refactor.cloneSubgraph(nodes, [], {standinNodes:[[root]]}) YIELD input, output, error " +
-                        "WITH collect(output) as clones, collect(output.name) as cloneNames " +
-                        "RETURN cloneNames, size(cloneNames) as cloneCount, none(clone in clones WHERE (clone)--()) as noRelationshipsOnClones, " +
-                        " single(clone in clones WHERE clone.name = 'node5' AND clone:Oddball) as oddballNode5Exists, " +
-                        " size([clone in clones WHERE clone:Node]) as nodesWithNodeLabel",
-                (row) -> {
-                    assertThat((List<String>) row.get("cloneNames"), containsInAnyOrder("node1", "node2", "node3", "node4", "node5", "node8", "node9", "node10", "node6", "node7"));
-                    assertThat(row.get("cloneCount"), is(10L));
-                    assertThat(row.get("noRelationshipsOnClones"), is(true));
-                    assertThat(row.get("oddballNode5Exists"), is(true));
-                    assertThat(row.get("nodesWithNodeLabel"), is(10L));
-                }
+        assertThrows(
+            STANDIN_SYNTAX_EXCEPTION_MSG,
+            QueryExecutionException.class,
+            () -> TestUtil.testCall(db,
+                    "MATCH (root:Root{name:'A'})-[*]-(node) " +
+                            "WITH root, collect(DISTINCT node) as nodes " +
+                            "CALL apoc.refactor.cloneSubgraph(nodes, [], {standinNodes:[[root]]}) YIELD input, output, error " +
+                            "WITH collect(output) as clones, collect(output.name) as cloneNames " +
+                            "RETURN cloneNames, size(cloneNames) as cloneCount, none(clone in clones WHERE (clone)--()) as noRelationshipsOnClones, " +
+                            " single(clone in clones WHERE clone.name = 'node5' AND clone:Oddball) as oddballNode5Exists, " +
+                            " size([clone in clones WHERE clone:Node]) as nodesWithNodeLabel",
+                    (row) -> {}
+            )
         );
     }
 
     @Test
     public void testCloneSubgraph_With_A_3_Element_Standin_Pair_Should_Throw_Exception()  {
-        exceptionGrabber.expectMessage(STANDIN_SYNTAX_EXCEPTION_MSG);
-
-        TestUtil.testCall(db,
-                "MATCH (root:Root{name:'A'})-[*]-(node) " +
-                        "WITH root, collect(DISTINCT node) as nodes " +
-                        "CALL apoc.refactor.cloneSubgraph(nodes, [], {standinNodes:[[root, root, root]]}) YIELD input, output, error " +
-                        "WITH collect(output) as clones, collect(output.name) as cloneNames " +
-                        "RETURN cloneNames, size(cloneNames) as cloneCount, none(clone in clones WHERE (clone)--()) as noRelationshipsOnClones, " +
-                        " single(clone in clones WHERE clone.name = 'node5' AND clone:Oddball) as oddballNode5Exists, " +
-                        " size([clone in clones WHERE clone:Node]) as nodesWithNodeLabel",
-                (row) -> {
-                    assertThat((List<String>) row.get("cloneNames"), containsInAnyOrder("node1", "node2", "node3", "node4", "node5", "node8", "node9", "node10", "node6", "node7"));
-                    assertThat(row.get("cloneCount"), is(10L));
-                    assertThat(row.get("noRelationshipsOnClones"), is(true));
-                    assertThat(row.get("oddballNode5Exists"), is(true));
-                    assertThat(row.get("nodesWithNodeLabel"), is(10L));
-                }
+        assertThrows(
+            STANDIN_SYNTAX_EXCEPTION_MSG,
+            QueryExecutionException.class,
+            () -> TestUtil.testCall(db,
+                    "MATCH (root:Root{name:'A'})-[*]-(node) " +
+                            "WITH root, collect(DISTINCT node) as nodes " +
+                            "CALL apoc.refactor.cloneSubgraph(nodes, [], {standinNodes:[[root, root, root]]}) YIELD input, output, error " +
+                            "WITH collect(output) as clones, collect(output.name) as cloneNames " +
+                            "RETURN cloneNames, size(cloneNames) as cloneCount, none(clone in clones WHERE (clone)--()) as noRelationshipsOnClones, " +
+                            " single(clone in clones WHERE clone.name = 'node5' AND clone:Oddball) as oddballNode5Exists, " +
+                            " size([clone in clones WHERE clone:Node]) as nodesWithNodeLabel",
+                    (row) -> {}
+            )
         );
     }
 
     @Test
     public void testCloneSubgraph_With_A_Null_Element_In_Standin_Pair_Should_Throw_Exception()  {
-        exceptionGrabber.expectMessage(STANDIN_SYNTAX_EXCEPTION_MSG);
-
-        TestUtil.testCall(db,
-                "MATCH (root:Root{name:'A'})-[*]-(node) " +
-                        "WITH root, collect(DISTINCT node) as nodes " +
-                        "CALL apoc.refactor.cloneSubgraph(nodes, [], {standinNodes:[[root, null]]}) YIELD input, output, error " +
-                        "WITH collect(output) as clones, collect(output.name) as cloneNames " +
-                        "RETURN cloneNames, size(cloneNames) as cloneCount, none(clone in clones WHERE (clone)--()) as noRelationshipsOnClones, " +
-                        " single(clone in clones WHERE clone.name = 'node5' AND clone:Oddball) as oddballNode5Exists, " +
-                        " size([clone in clones WHERE clone:Node]) as nodesWithNodeLabel",
-                (row) -> {
-                    assertThat((List<String>) row.get("cloneNames"), containsInAnyOrder("node1", "node2", "node3", "node4", "node5", "node8", "node9", "node10", "node6", "node7"));
-                    assertThat(row.get("cloneCount"), is(10L));
-                    assertThat(row.get("noRelationshipsOnClones"), is(true));
-                    assertThat(row.get("oddballNode5Exists"), is(true));
-                    assertThat(row.get("nodesWithNodeLabel"), is(10L));
-                }
+        assertThrows(
+            STANDIN_SYNTAX_EXCEPTION_MSG,
+            QueryExecutionException.class,
+            () -> TestUtil.testCall(db,
+                    "MATCH (root:Root{name:'A'})-[*]-(node) " +
+                            "WITH root, collect(DISTINCT node) as nodes " +
+                            "CALL apoc.refactor.cloneSubgraph(nodes, [], {standinNodes:[[root, null]]}) YIELD input, output, error " +
+                            "WITH collect(output) as clones, collect(output.name) as cloneNames " +
+                            "RETURN cloneNames, size(cloneNames) as cloneCount, none(clone in clones WHERE (clone)--()) as noRelationshipsOnClones, " +
+                            " single(clone in clones WHERE clone.name = 'node5' AND clone:Oddball) as oddballNode5Exists, " +
+                            " size([clone in clones WHERE clone:Node]) as nodesWithNodeLabel",
+                    (row) -> {}
+            )
         );
     }
 

--- a/core/src/test/java/apoc/text/StringsTest.java
+++ b/core/src/test/java/apoc/text/StringsTest.java
@@ -5,9 +5,7 @@ import apoc.util.Util;
 import apoc.util.collection.Iterators;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.QueryExecutionException;
@@ -36,9 +34,6 @@ import static org.junit.Assert.*;
  * @since 05.05.16
  */
 public class StringsTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule();
@@ -388,11 +383,13 @@ public class StringsTest {
 
     @Test
     public void testUrlDecodeFailure() {
-        thrown.expect(QueryExecutionException.class);
-        thrown.expectMessage("Failed to invoke function `apoc.text.urldecode`: Caused by: java.lang.IllegalArgumentException: URLDecoder: Incomplete trailing escape (%) pattern");
-        testCall(db,
-                "RETURN apoc.text.urldecode('ab+cd%3Dgh%26ij%3')  AS value",
-                row -> assertEquals("ab cd=gh&ij?", row.get("value"))
+        assertThrows(
+                "Failed to invoke function `apoc.text.urldecode`: Caused by: java.lang.IllegalArgumentException: URLDecoder: Incomplete trailing escape (%) pattern",
+                QueryExecutionException.class,
+                () -> testCall(db,
+                    "RETURN apoc.text.urldecode('ab+cd%3Dgh%26ij%3')  AS value",
+                    row -> {}
+                )
         );
     }
 

--- a/core/src/test/java/apoc/trigger/TriggerDisabledTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerDisabledTest.java
@@ -4,7 +4,6 @@ import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
@@ -13,6 +12,7 @@ import java.util.Map;
 
 import static apoc.ApocConfig.APOC_TRIGGER_ENABLED;
 import static apoc.ApocConfig.apocConfig;
+import static org.junit.Assert.assertThrows;
 
 /**
  * @author alexiudice
@@ -30,39 +30,54 @@ public class TriggerDisabledTest {
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Before
     public void setUp() throws Exception {
         apocConfig().setProperty(APOC_TRIGGER_ENABLED, false);
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage(TriggerHandler.NOT_ENABLED_ERROR);
         TestUtil.registerProcedure(db, Trigger.class);
     }
 
     @Test
     public void testTriggerDisabledList() {
-        db.executeTransactionally("CALL apoc.trigger.list() YIELD name RETURN name", Map.of(), Result::resultAsString);
+        assertThrows(
+            TriggerHandler.NOT_ENABLED_ERROR,
+            RuntimeException.class,
+            () -> db.executeTransactionally("CALL apoc.trigger.list() YIELD name RETURN name", Map.of(), Result::resultAsString)
+        );
     }
 
     @Test
     public void testTriggerDisabledAdd() {
-        db.executeTransactionally("CALL apoc.trigger.add('test-trigger', 'RETURN 1', {phase: 'before'}) YIELD name RETURN name");
+        assertThrows(
+            TriggerHandler.NOT_ENABLED_ERROR,
+            RuntimeException.class,
+            () -> db.executeTransactionally("CALL apoc.trigger.add('test-trigger', 'RETURN 1', {phase: 'before'}) YIELD name RETURN name")
+        );
     }
 
     @Test
     public void testTriggerDisabledRemove() {
-        db.executeTransactionally("CALL apoc.trigger.remove('test-trigger')");
+        assertThrows(
+            TriggerHandler.NOT_ENABLED_ERROR,
+            RuntimeException.class,
+            () -> db.executeTransactionally("CALL apoc.trigger.remove('test-trigger')")
+        );
     }
 
     @Test
     public void testTriggerDisabledResume() {
-        db.executeTransactionally("CALL apoc.trigger.resume('test-trigger')");
+        assertThrows(
+            TriggerHandler.NOT_ENABLED_ERROR,
+            RuntimeException.class,
+            () -> db.executeTransactionally("CALL apoc.trigger.resume('test-trigger')")
+        );
     }
 
     @Test
     public void testTriggerDisabledPause() {
-        db.executeTransactionally("CALL apoc.trigger.pause('test-trigger')");
+        assertThrows(
+            TriggerHandler.NOT_ENABLED_ERROR,
+            RuntimeException.class,
+            () -> db.executeTransactionally("CALL apoc.trigger.pause('test-trigger')")
+        );
     }
 }

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -22,9 +22,9 @@ dependencies {
     api group: 'org.neo4j.community', name: 'it-test-support', version: neo4jVersionEffective // , classifier: "tests"
     api group: 'org.neo4j', name: 'log-test-utils', version: neo4jVersionEffective // , classifier: "tests"
     api group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.0.0'
-    api group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.3', withoutServers
-    api group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.3', withoutServers
-    api group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '3.3.3', withoutServers
+    api group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.4', withoutServers
+    api group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.4', withoutServers
+    api group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '3.3.4', withoutServers
     api group: 'org.testcontainers', name: 'testcontainers', version: testContainersVersion
     api group: 'org.testcontainers', name: 'neo4j', version: testContainersVersion
     api group: 'org.testcontainers', name: 'elasticsearch', version: testContainersVersion

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -19,6 +19,11 @@ dependencies {
     }
 
     api group: 'junit', name: 'junit', version: '4.13.2'
+    api group: 'org.hamcrest', name: 'hamcrest-core', {
+        version {
+            strictly '2.2'
+        }
+    }
     api group: 'org.neo4j.community', name: 'it-test-support', version: neo4jVersionEffective // , classifier: "tests"
     api group: 'org.neo4j', name: 'log-test-utils', version: neo4jVersionEffective // , classifier: "tests"
     api group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.0.0'


### PR DESCRIPTION
## What
* Bumps the policy for dependency Snyk tests to medium level
* Fixes the dependencies that make that fail
* Makes monitor use the dev branch to group projects. This will make it easier to navigate if we have to add 6.x code to this repo. We would end up with something similar to this in the Snyk UI, but for this repo

<img width="501"  src="https://user-images.githubusercontent.com/5649971/203543027-67430444-248e-422c-b426-8ee449fc3cdc.png">
