### PR TITLE
[eRGoCYQI] Solves problem with empty GITHUB_REF for branches

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -38,7 +38,7 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
       - name: Snyk monitor dependencies
-        run: snyk monitor --all-projects --target-reference=${GITHUB_BASE_REF}
+        run: snyk monitor --all-projects --target-reference=${GITHUB_REF}
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
Changes `GITHUB_REF_NAME` for `GITHUB_REF` because the first one is only populated for PRs.

## Why

Because Snyk is complaining that the target reference is empty for the monitor job on master:
<img width="1532" src="https://user-images.githubusercontent.com/5649971/203780567-404f828c-489c-4b98-b9f0-4beb24a4fa72.png">
