### PR TITLE
Code cleanup

### DIFF
--- a/common/src/main/java/apoc/ApocExtensionFactory.java
+++ b/common/src/main/java/apoc/ApocExtensionFactory.java
@@ -84,7 +84,7 @@ public class ApocExtensionFactory extends ExtensionFactory<ApocExtensionFactory.
         }
 
         @Override
-        public void init() throws Exception {
+        public void init() {
             withNonSystemDatabase(db, aVoid -> {
                 for (ApocGlobalComponents c: apocGlobalComponents) {
                     services.putAll(c.getServices(db, dependencies));

--- a/common/src/main/java/apoc/Pools.java
+++ b/common/src/main/java/apoc/Pools.java
@@ -86,7 +86,7 @@ public class Pools extends LifecycleAdapter {
     }
 
     @Override
-    public void shutdown() throws Exception {
+    public void shutdown() {
         Stream.of(singleExecutorService, defaultExecutorService, scheduledExecutorService).forEach( service -> {
             try {
                 service.shutdown();

--- a/common/src/main/java/apoc/RegisterComponentFactory.java
+++ b/common/src/main/java/apoc/RegisterComponentFactory.java
@@ -53,7 +53,7 @@ public class RegisterComponentFactory extends ExtensionFactory<RegisterComponent
         }
 
         @Override
-        public void init() throws Exception {
+        public void init() {
 
             for (ApocGlobalComponents c: Services.loadAll(ApocGlobalComponents.class)) {
                 for (Class clazz: c.getContextClasses()) {

--- a/common/src/main/java/apoc/SystemPropertyKeys.java
+++ b/common/src/main/java/apoc/SystemPropertyKeys.java
@@ -26,5 +26,5 @@ public enum SystemPropertyKeys  {
     // uuid handler
     label,
     addToSetLabel,
-    propertyName;
+    propertyName
 }

--- a/common/src/main/java/apoc/export/util/CountingInputStream.java
+++ b/common/src/main/java/apoc/export/util/CountingInputStream.java
@@ -21,7 +21,7 @@ public class CountingInputStream extends FilterInputStream implements SizeCounte
         super(toBufferedStream(Files.newInputStream(file.toPath())));
         this.total = file.length();
     }
-    public CountingInputStream(InputStream stream, long total) throws FileNotFoundException {
+    public CountingInputStream(InputStream stream, long total) {
         super(toBufferedStream(stream));
         this.total = total;
     }

--- a/common/src/main/java/apoc/export/util/CountingReader.java
+++ b/common/src/main/java/apoc/export/util/CountingReader.java
@@ -16,7 +16,7 @@ public class CountingReader extends FilterReader implements SizeCounter {
         super(new BufferedReader(new FileReader(file), BUFFER_SIZE));
         this.total = file.length();
     }
-    public CountingReader(Reader reader, long total) throws FileNotFoundException {
+    public CountingReader(Reader reader, long total) {
         super(new BufferedReader(reader, BUFFER_SIZE));
         this.total = total;
     }

--- a/common/src/main/java/apoc/export/util/Format.java
+++ b/common/src/main/java/apoc/export/util/Format.java
@@ -11,6 +11,6 @@ import java.io.Reader;
  * @since 17.01.14
  */
 public interface Format {
-    ProgressInfo load(Reader reader, Reporter reporter, ExportConfig config) throws Exception;
+    ProgressInfo load(Reader reader, Reporter reporter, ExportConfig config);
     ProgressInfo dump(SubGraph graph, ExportFileManager writer, Reporter reporter, ExportConfig config) throws Exception;
 }

--- a/common/src/main/java/apoc/meta/ConstraintTracker.java
+++ b/common/src/main/java/apoc/meta/ConstraintTracker.java
@@ -7,6 +7,6 @@ import java.util.Map;
 public class ConstraintTracker {
     // The following maps are (label|rel-type)/constraintdefinition entries
 
-    public static final Map<String, List<String>> relConstraints = new HashMap<>(20);;
-    public static final Map<String, List<String>> nodeConstraints = new HashMap<>(20);;
+    public static final Map<String, List<String>> relConstraints = new HashMap<>(20);
+    public static final Map<String, List<String>> nodeConstraints = new HashMap<>(20);
 }

--- a/common/src/main/java/apoc/trigger/TriggerHandler.java
+++ b/common/src/main/java/apoc/trigger/TriggerHandler.java
@@ -282,7 +282,7 @@ public class TriggerHandler extends LifecycleAdapter implements TransactionEvent
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         updateCache();
         long refreshInterval = apocConfig().getInt(TRIGGER_REFRESH, 60000);
         restoreTriggerHandler = jobScheduler.scheduleRecurring(Group.STORAGE_MAINTENANCE, () -> {

--- a/common/src/main/java/apoc/util/FileUtils.java
+++ b/common/src/main/java/apoc/util/FileUtils.java
@@ -191,7 +191,7 @@ public class FileUtils {
         return urlPath;
     }
 
-    private static boolean pathStartsWithOther(Path resolvedPath, Path basePath) throws IOException {
+    private static boolean pathStartsWithOther(Path resolvedPath, Path basePath) {
         try {
             return resolvedPath.toRealPath().startsWith(basePath.toRealPath());
         } catch (Exception e) {

--- a/common/src/main/java/apoc/util/JsonUtil.java
+++ b/common/src/main/java/apoc/util/JsonUtil.java
@@ -61,7 +61,7 @@ public class JsonUtil {
         }
 
         @Override
-        public void close() throws IOException {
+        public void close() {
         }
     }
 

--- a/common/src/main/java/apoc/util/google/cloud/GCStorageURLConnection.java
+++ b/common/src/main/java/apoc/util/google/cloud/GCStorageURLConnection.java
@@ -8,7 +8,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.neo4j.util.VisibleForTesting;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -82,7 +81,7 @@ public class GCStorageURLConnection extends URLConnection {
     }
 
     @Override
-    public InputStream getInputStream() throws IOException {
+    public InputStream getInputStream() {
         if (!connected) {
             connect();
         }

--- a/common/src/main/java/apoc/util/google/cloud/GCStorageURLStreamHandler.java
+++ b/common/src/main/java/apoc/util/google/cloud/GCStorageURLStreamHandler.java
@@ -1,6 +1,5 @@
 package apoc.util.google.cloud;
 
-import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
@@ -9,7 +8,7 @@ public class GCStorageURLStreamHandler extends URLStreamHandler {
     public GCStorageURLStreamHandler() {}
 
     @Override
-    protected URLConnection openConnection(final URL url) throws IOException {
+    protected URLConnection openConnection(final URL url) {
         return new GCStorageURLConnection(url);
     }
 }

--- a/common/src/main/java/apoc/util/s3/S3URLConnection.java
+++ b/common/src/main/java/apoc/util/s3/S3URLConnection.java
@@ -5,7 +5,6 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Protocol;
 import com.amazonaws.regions.Regions;
 
-import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Objects;
@@ -43,7 +42,7 @@ public class S3URLConnection extends URLConnection {
     }
 
 
-    public static StreamConnection openS3InputStream(URL url) throws IOException {
+    public static StreamConnection openS3InputStream(URL url) {
         S3Params s3Params = S3ParamsExtractor.extract(url);
         String region = Objects.nonNull(s3Params.getRegion()) ? s3Params.getRegion() : Regions.US_EAST_1.getName();
         return new S3Aws(s3Params, region).getS3AwsInputStream(s3Params);

--- a/common/src/main/java/apoc/util/s3/S3UrlStreamHandlerFactory.java
+++ b/common/src/main/java/apoc/util/s3/S3UrlStreamHandlerFactory.java
@@ -1,6 +1,5 @@
 package apoc.util.s3;
 
-import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
@@ -11,7 +10,7 @@ public class S3UrlStreamHandlerFactory implements URLStreamHandlerFactory {
     public URLStreamHandler createURLStreamHandler(String protocol) {
         return new URLStreamHandler() {
             @Override
-            protected URLConnection openConnection(URL url) throws IOException {
+            protected URLConnection openConnection(URL url) {
                 return new S3URLConnection(url);
             }
         };

--- a/common/src/test/java/apoc/coll/SetBackedListTest.java
+++ b/common/src/test/java/apoc/coll/SetBackedListTest.java
@@ -17,7 +17,7 @@ public class SetBackedListTest {
 
 
     @Test
-    public void testEmptyList() throws Exception {
+    public void testEmptyList() {
         SetBackedList list = new SetBackedList(EMPTY_SET);
         assertEquals(0,list.size());
         assertEquals(true,list.isEmpty());
@@ -29,7 +29,7 @@ public class SetBackedListTest {
         assertEquals(0, it.nextIndex());
     }
     @Test
-    public void testSingleList() throws Exception {
+    public void testSingleList() {
         SetBackedList list = new SetBackedList(singleton(1));
         assertEquals(1,list.size());
         assertEquals(false,list.isEmpty());
@@ -52,7 +52,7 @@ public class SetBackedListTest {
 
 
     @Test
-    public void testDoubleList() throws Exception {
+    public void testDoubleList() {
         SetBackedList list = new SetBackedList(new LinkedHashSet<>(asList(1,2)));
         assertEquals(2,list.size());
         assertEquals(false,list.isEmpty());
@@ -86,7 +86,7 @@ public class SetBackedListTest {
     }
 
     @Test
-    public void testReverse() throws Exception {
+    public void testReverse() {
         LinkedHashSet set = new LinkedHashSet(asList(1, 2, 3, 4, 5));
         SetBackedList list = new SetBackedList(set);
         assertEquals(asList(1,2,3,4,5),list);
@@ -100,7 +100,7 @@ public class SetBackedListTest {
     }
 
     @Test
-    public void testContains() throws Exception {
+    public void testContains() {
         LinkedHashSet set = new LinkedHashSet(asList(1, 2, 3, 4, 5));
         SetBackedList list = new SetBackedList(set);
         assertEquals(true, list.contains(1));

--- a/common/src/test/java/apoc/export/util/FormatUtilsTest.java
+++ b/common/src/test/java/apoc/export/util/FormatUtilsTest.java
@@ -20,7 +20,7 @@ public class FormatUtilsTest {
     public DbmsRule db = new ImpermanentDbmsRule();
 
     @Test
-    public void formatString() throws Exception {
+    public void formatString() {
         assertEquals("\"\\n\"",FormatUtils.formatString("\n"));
         assertEquals("\"\\t\"",FormatUtils.formatString("\t"));
         assertEquals("\"\\\"\"",FormatUtils.formatString("\""));
@@ -32,7 +32,7 @@ public class FormatUtilsTest {
     }
 
     @Test
-    public void joinLabels() throws Exception {
+    public void joinLabels() {
         final String delimiter = ":";
         try (Transaction tx = db.beginTx()) {
             Node node = tx.createNode();

--- a/common/src/test/java/apoc/path/RelationshipTypeAndDirectionsTest.java
+++ b/common/src/test/java/apoc/path/RelationshipTypeAndDirectionsTest.java
@@ -50,7 +50,7 @@ public class RelationshipTypeAndDirectionsTest {
     public Iterable<Pair<RelationshipType, Direction>> expected;
 
     @Test
-    public void parse() throws Exception {
+    public void parse() {
         assertEquals(expected, RelationshipTypeAndDirections.parse(input));
     }
 

--- a/common/src/test/java/apoc/util/DateParseUtilTest.java
+++ b/common/src/test/java/apoc/util/DateParseUtilTest.java
@@ -22,7 +22,7 @@ public class DateParseUtilTest {
     }
 
     @Test(expected = RuntimeException.class)
-    public void dateParseErrorTest() throws Exception {
+    public void dateParseErrorTest() {
         try {
             dateParse("10/01/2010", LocalDateTime.class, parseList);
         } catch (Exception e) {

--- a/common/src/test/java/apoc/util/SortedArraySetTest.java
+++ b/common/src/test/java/apoc/util/SortedArraySetTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.*;
  */
 public class SortedArraySetTest {
     @Test
-    public void add() throws Exception {
+    public void add() {
         SortedArraySet<Integer> set = new SortedArraySet<>(Integer.class, 3);
         assertEquals(3, set.getCapacity());
         assertEquals(0, set.getSize());

--- a/common/src/test/java/apoc/util/UtilIT.java
+++ b/common/src/test/java/apoc/util/UtilIT.java
@@ -29,7 +29,7 @@ public class UtilIT {
     private static final String WITH_FILE_LOCATION = "WithFileLocation";
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         new ApocConfig();  // empty test configuration, ensure ApocConfig.apocConfig() can be used
         TestUtil.ignoreException(() -> {
             httpServer = new GenericContainer("alpine")

--- a/common/src/test/java/apoc/util/s3/S3ParamsExtractorTest.java
+++ b/common/src/test/java/apoc/util/s3/S3ParamsExtractorTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.*;
 public class S3ParamsExtractorTest {
 
     @Test
-    public void testEncodedS3Url() throws Exception {
+    public void testEncodedS3Url() {
         S3Params params = S3ParamsExtractor.extract("s3://accessKeyId:some%2Fsecret%2Fkey:some%2Fsession%2Ftoken@s3.us-east-2.amazonaws.com:1234/bucket/path/to/key");
         assertEquals("some/secret/key", params.getSecretKey());
         assertEquals("some/session/token", params.getSessionToken());
@@ -18,7 +18,7 @@ public class S3ParamsExtractorTest {
     }
 
     @Test
-    public void testEncodedS3UrlQueryParams() throws Exception {
+    public void testEncodedS3UrlQueryParams() {
         S3Params params = S3ParamsExtractor.extract("s3://s3.us-east-2.amazonaws.com:1234/bucket/path/to/key?accessKey=accessKeyId&secretKey=some%2Fsecret%2Fkey&sessionToken=some%2Fsession%2Ftoken");
         assertEquals("some/secret/key", params.getSecretKey());
         assertEquals("some/session/token", params.getSessionToken());
@@ -29,13 +29,13 @@ public class S3ParamsExtractorTest {
     }
 
     @Test
-    public void testExtractEndpointPort() throws Exception {
+    public void testExtractEndpointPort() {
         assertEquals("s3.amazonaws.com", S3ParamsExtractor.extract("s3://s3.amazonaws.com:80/bucket/path/to/key").getEndpoint());
         assertEquals("s3.amazonaws.com:1234", S3ParamsExtractor.extract("s3://s3.amazonaws.com:1234/bucket/path/to/key").getEndpoint());
     }
 
     @Test
-    public void testExtractRegion() throws Exception {
+    public void testExtractRegion() {
         assertEquals("us-east-2", S3ParamsExtractor.extract("s3://s3.us-east-2.amazonaws.com:80/bucket/path/to/key").getRegion());
         assertNull(S3ParamsExtractor.extract("s3://s3.amazonaws.com:80/bucket/path/to/key").getRegion());
     }

--- a/core/src/main/java/apoc/algo/Cover.java
+++ b/core/src/main/java/apoc/algo/Cover.java
@@ -26,16 +26,6 @@ public class Cover {
     @Description("Returns all relationships between a given set of nodes.")
     public Stream<RelationshipResult> cover(@Name("nodes") Object nodes) {
         Set<Node> nodeSet = Util.nodeStream(tx, nodes).collect(Collectors.toSet());
-        /*return nodeSet.parallelStream()
-                .flatMap(n ->
-                        Util.inTx(db,() ->
-                        StreamSupport.stream(n.getRelationships(Direction.OUTGOING)
-                                .spliterator(),false)
-                                .filter(r -> nodeSet.contains(r.getEndNode()))
-                                .map(RelationshipResult::new)));*/
-        // NB prallel approach doesn't work in 3.4 (see SubgraphTest.testSubgraphAllShouldContainExpectedNodesAndRels
-        // so falling back to single threaded
-        // TODO: consider using multithreading and maybe kernel API here
         return coverNodes(nodeSet).map(RelationshipResult::new);
     }
 

--- a/core/src/main/java/apoc/atomic/Atomic.java
+++ b/core/src/main/java/apoc/atomic/Atomic.java
@@ -144,7 +144,7 @@ public class Atomic {
     @Procedure(name = "apoc.atomic.remove", mode = Mode.WRITE)
     @Description("Removes the element at position from the array value of a property.\n" +
             "The procedure then sets the property to the resulting array value.")
-    public Stream<AtomicResults> remove(@Name("container") Object container, @Name("propertyName") String property, @Name("position") Long position, @Name(value = "times", defaultValue = "5") Long times) throws ClassNotFoundException {
+    public Stream<AtomicResults> remove(@Name("container") Object container, @Name("propertyName") String property, @Name("position") Long position, @Name(value = "times", defaultValue = "5") Long times) {
         checkIsEntity(container);
         Entity entity = Util.rebind(tx, (Entity) container);
         final Object[] oldValue = new Object[1];

--- a/core/src/main/java/apoc/atomic/Atomic.java
+++ b/core/src/main/java/apoc/atomic/Atomic.java
@@ -108,7 +108,7 @@ public class Atomic {
     @Procedure(name = "apoc.atomic.insert", mode = Mode.WRITE)
     @Description("Inserts a value at position into the array value of a property.\n" +
             "The procedure then sets the result back on the property.")
-    public Stream<AtomicResults> insert(@Name("container") Object container, @Name("propertyName") String property, @Name("position") Long position, @Name("value") Object value, @Name(value = "times", defaultValue = "5") Long times) throws ClassNotFoundException {
+    public Stream<AtomicResults> insert(@Name("container") Object container, @Name("propertyName") String property, @Name("position") Long position, @Name("value") Object value, @Name(value = "times", defaultValue = "5") Long times) {
         checkIsEntity(container);
         Entity entity = Util.rebind(tx, (Entity) container);
         final Object[] oldValue = new Object[1];

--- a/core/src/main/java/apoc/export/arrow/ExportArrow.java
+++ b/core/src/main/java/apoc/export/arrow/ExportArrow.java
@@ -47,13 +47,13 @@ public class ExportArrow {
 
     @Procedure("apoc.export.arrow.stream.all")
     @Description("apoc.export.arrow.stream.all(config) - exports whole database as arrow byte[] result")
-    public Stream<ByteArrayResult> all(@Name(value = "config", defaultValue = "{}") Map<String, Object> config) throws Exception {
+    public Stream<ByteArrayResult> all(@Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
         return new ExportArrowService(db, pools, terminationGuard, logger).stream(new DatabaseSubGraph(tx), new ArrowConfig(config));
     }
 
     @Procedure("apoc.export.arrow.stream.graph")
     @Description("apoc.export.arrow.stream.graph(graph, config) - exports given nodes and relationships as arrow byte[] result")
-    public Stream<ByteArrayResult> graph(@Name("graph") Object graph, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) throws Exception {
+    public Stream<ByteArrayResult> graph(@Name("graph") Object graph, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
         final SubGraph subGraph;
         if (graph instanceof Map) {
             Map<String, Object> mGraph = (Map<String, Object>) graph;
@@ -73,7 +73,7 @@ public class ExportArrow {
 
     @Procedure("apoc.export.arrow.stream.query")
     @Description("apoc.export.arrow.stream.query(query, config) - exports results from the cypher statement as arrow byte[] result")
-    public Stream<ByteArrayResult> query(@Name("query") String query, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) throws Exception {
+    public Stream<ByteArrayResult> query(@Name("query") String query, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
         Map<String, Object> params = config == null ? Collections.emptyMap() : (Map<String, Object>) config.getOrDefault("params", Collections.emptyMap());
         Result result = tx.execute(query, params);
         return new ExportArrowService(db, pools, terminationGuard, logger).stream(result, new ArrowConfig(config));
@@ -81,13 +81,13 @@ public class ExportArrow {
 
     @Procedure("apoc.export.arrow.all")
     @Description("apoc.export.arrow.all(fileName, config) - exports whole database as arrow file")
-    public Stream<ProgressInfo> all(@Name("fileName") String fileName, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) throws Exception {
+    public Stream<ProgressInfo> all(@Name("fileName") String fileName, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
         return new ExportArrowService(db, pools, terminationGuard, logger).file(fileName, new DatabaseSubGraph(tx), new ArrowConfig(config));
     }
 
     @Procedure("apoc.export.arrow.graph")
     @Description("apoc.export.arrow.graph(fileName, graph, config) - exports given nodes and relationships as arrow file")
-    public Stream<ProgressInfo> graph(@Name("fileName") String fileName, @Name("graph") Object graph, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) throws Exception {
+    public Stream<ProgressInfo> graph(@Name("fileName") String fileName, @Name("graph") Object graph, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
         final SubGraph subGraph;
         if (graph instanceof Map) {
             Map<String, Object> mGraph = (Map<String, Object>) graph;
@@ -107,7 +107,7 @@ public class ExportArrow {
 
     @Procedure("apoc.export.arrow.query")
     @Description("apoc.export.arrow.query(fileName, query, config) - exports results from the cypher statement as arrow file")
-    public Stream<ProgressInfo> query(@Name("fileName") String fileName, @Name("query") String query, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) throws Exception {
+    public Stream<ProgressInfo> query(@Name("fileName") String fileName, @Name("query") String query, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
         Map<String, Object> params = config == null ? Collections.emptyMap() : (Map<String, Object>) config.getOrDefault("params", Collections.emptyMap());
         Result result = tx.execute(query, params);
         return new ExportArrowService(db, pools, terminationGuard, logger).file(fileName, result, new ArrowConfig(config));

--- a/core/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/core/src/main/java/apoc/export/csv/CsvFormat.java
@@ -113,7 +113,7 @@ public class CsvFormat implements Format {
     }
 
     public ProgressInfo dump(Result result, ExportFileManager writer, Reporter reporter, ExportConfig config) {
-        try (Transaction tx = db.beginTx(); PrintWriter printWriter = writer.getPrintWriter("csv");) {
+        try (Transaction tx = db.beginTx(); PrintWriter printWriter = writer.getPrintWriter("csv")) {
             CSVWriter out = getCsvWriter(printWriter, config);
             String[] header = writeResultHeader(result, out);
 

--- a/core/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/core/src/main/java/apoc/export/csv/CsvFormat.java
@@ -58,7 +58,7 @@ public class CsvFormat implements Format {
     }
 
     @Override
-    public ProgressInfo load(Reader reader, Reporter reporter, ExportConfig config) throws Exception {
+    public ProgressInfo load(Reader reader, Reporter reporter, ExportConfig config) {
         return null;
     }
 

--- a/core/src/main/java/apoc/export/csv/ExportCSV.java
+++ b/core/src/main/java/apoc/export/csv/ExportCSV.java
@@ -54,14 +54,14 @@ public class ExportCSV {
 
     @Procedure("apoc.export.csv.all")
     @Description("Exports the full database to the provided CSV file.")
-    public Stream<ProgressInfo> all(@Name("file") String fileName, @Name("config") Map<String, Object> config) throws Exception {
+    public Stream<ProgressInfo> all(@Name("file") String fileName, @Name("config") Map<String, Object> config) {
         String source = String.format("database: nodes(%d), rels(%d)", Util.nodeCount(tx), Util.relCount(tx));
         return exportCsv(fileName, source, new DatabaseSubGraph(tx), new ExportConfig(config));
     }
 
     @Procedure("apoc.export.csv.data")
     @Description("Exports the given nodes and relationships to the provided CSV file.")
-    public Stream<ProgressInfo> data(@Name("nodes") List<Node> nodes, @Name("rels") List<Relationship> rels, @Name("file") String fileName, @Name("config") Map<String, Object> config) throws Exception {
+    public Stream<ProgressInfo> data(@Name("nodes") List<Node> nodes, @Name("rels") List<Relationship> rels, @Name("file") String fileName, @Name("config") Map<String, Object> config) {
         ExportConfig exportConfig = new ExportConfig(config);
         preventBulkImport(exportConfig);
         String source = String.format("data: nodes(%d), rels(%d)", nodes.size(), rels.size());
@@ -69,7 +69,7 @@ public class ExportCSV {
     }
     @Procedure("apoc.export.csv.graph")
     @Description("Exports the given graph to the provided CSV file.")
-    public Stream<ProgressInfo> graph(@Name("graph") Map<String,Object> graph, @Name("file") String fileName, @Name("config") Map<String, Object> config) throws Exception {
+    public Stream<ProgressInfo> graph(@Name("graph") Map<String,Object> graph, @Name("file") String fileName, @Name("config") Map<String, Object> config) {
         Collection<Node> nodes = (Collection<Node>) graph.get("nodes");
         Collection<Relationship> rels = (Collection<Relationship>) graph.get("relationships");
         String source = String.format("graph: nodes(%d), rels(%d)", nodes.size(), rels.size());
@@ -78,7 +78,7 @@ public class ExportCSV {
 
     @Procedure("apoc.export.csv.query")
     @Description("Exports the results from running the given Cypher query to the provided CSV file.")
-    public Stream<ProgressInfo> query(@Name("query") String query, @Name("file") String fileName, @Name("config") Map<String, Object> config) throws Exception {
+    public Stream<ProgressInfo> query(@Name("query") String query, @Name("file") String fileName, @Name("config") Map<String, Object> config) {
         ExportConfig exportConfig = new ExportConfig(config);
         preventBulkImport(exportConfig);
         Map<String,Object> params = config == null ? Collections.emptyMap() : (Map<String,Object>)config.getOrDefault("params", Collections.emptyMap());

--- a/core/src/main/java/apoc/export/csv/ExportCSV.java
+++ b/core/src/main/java/apoc/export/csv/ExportCSV.java
@@ -94,7 +94,7 @@ public class ExportCSV {
         }
     }
 
-    private Stream<ProgressInfo> exportCsv(@Name("file") String fileName, String source, Object data, ExportConfig exportConfig) throws Exception {
+    private Stream<ProgressInfo> exportCsv(@Name("file") String fileName, String source, Object data, ExportConfig exportConfig) {
         apocConfig.checkWriteAllowed(exportConfig, fileName);
         final String format = "csv";
         ProgressInfo progressInfo = new ProgressInfo(fileName, source, format);

--- a/core/src/main/java/apoc/export/csv/ImportCsv.java
+++ b/core/src/main/java/apoc/export/csv/ImportCsv.java
@@ -36,7 +36,7 @@ public class ImportCsv {
             @Name("nodes") List<Map<String, Object>> nodes,
             @Name("rels") List<Map<String, Object>> relationships,
             @Name("config") Map<String, Object> config
-    ) throws Exception {
+    ) {
         ProgressInfo result =
                 Util.inThread(pools, () -> {
 

--- a/core/src/main/java/apoc/export/cypher/ExportCypher.java
+++ b/core/src/main/java/apoc/export/cypher/ExportCypher.java
@@ -24,7 +24,6 @@ import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.TerminationGuard;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -54,16 +53,9 @@ public class ExportCypher {
     @Context
     public Pools pools;
 
-    public ExportCypher(GraphDatabaseService db) {
-        this.db = db;
-    }
-
-    public ExportCypher() {
-    }
-
     @Procedure("apoc.export.cypher.all")
     @Description("Exports the full database (incl. indexes) as Cypher statements to the provided file (default: Cypher Shell).")
-    public Stream<DataProgressInfo> all(@Name(value = "file",defaultValue = "") String fileName, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) throws IOException {
+    public Stream<DataProgressInfo> all(@Name(value = "file",defaultValue = "") String fileName, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
         if (Util.isNullOrEmpty(fileName)) fileName=null;
         String source = String.format("database: nodes(%d), rels(%d)", Util.nodeCount(tx), Util.relCount(tx));
         return exportCypher(fileName, source, new DatabaseSubGraph(tx), new ExportConfig(config), false);
@@ -71,7 +63,7 @@ public class ExportCypher {
 
     @Procedure("apoc.export.cypher.data")
     @Description("Exports the given nodes and relationships (incl. indexes) as Cypher statements to the provided file (default: Cypher Shell).")
-    public Stream<DataProgressInfo> data(@Name("nodes") List<Node> nodes, @Name("rels") List<Relationship> rels, @Name(value = "file",defaultValue = "") String fileName, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) throws IOException {
+    public Stream<DataProgressInfo> data(@Name("nodes") List<Node> nodes, @Name("rels") List<Relationship> rels, @Name(value = "file",defaultValue = "") String fileName, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
         if (Util.isNullOrEmpty(fileName)) fileName=null;
         String source = String.format("data: nodes(%d), rels(%d)", nodes.size(), rels.size());
         return exportCypher(fileName, source, new NodesAndRelsSubGraph(tx, nodes, rels), new ExportConfig(config), false);
@@ -79,7 +71,7 @@ public class ExportCypher {
 
     @Procedure("apoc.export.cypher.graph")
     @Description("Exports the given graph (incl. indexes) as Cypher statements to the provided file (default: Cypher Shell).")
-    public Stream<DataProgressInfo> graph(@Name("graph") Map<String, Object> graph, @Name(value = "file",defaultValue = "") String fileName, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) throws IOException {
+    public Stream<DataProgressInfo> graph(@Name("graph") Map<String, Object> graph, @Name(value = "file",defaultValue = "") String fileName, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
         if (Util.isNullOrEmpty(fileName)) fileName=null;
 
         Collection<Node> nodes = (Collection<Node>) graph.get("nodes");
@@ -90,7 +82,7 @@ public class ExportCypher {
 
     @Procedure("apoc.export.cypher.query")
     @Description("Exports the nodes and relationships from the given Cypher query (incl. indexes) as Cypher statements to the provided file (default: Cypher Shell).")
-    public Stream<DataProgressInfo> query(@Name("statement") String query, @Name(value = "file",defaultValue = "") String fileName, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) throws IOException {
+    public Stream<DataProgressInfo> query(@Name("statement") String query, @Name(value = "file",defaultValue = "") String fileName, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
         if (Util.isNullOrEmpty(fileName)) fileName=null;
         ExportConfig c = new ExportConfig(config);
         Result result = tx.execute(query);
@@ -103,7 +95,7 @@ public class ExportCypher {
 
     @Procedure("apoc.export.cypher.schema")
     @Description("Exports all schema indexes and constraints to Cypher statements.")
-    public Stream<DataProgressInfo> schema(@Name(value = "file",defaultValue = "") String fileName, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) throws IOException {
+    public Stream<DataProgressInfo> schema(@Name(value = "file",defaultValue = "") String fileName, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
         if (Util.isNullOrEmpty(fileName)) fileName=null;
         String source = String.format("database: nodes(%d), rels(%d)", Util.nodeCount(tx), Util.relCount(tx));
         return exportCypher(fileName, source, new DatabaseSubGraph(tx), new ExportConfig(config), true);

--- a/core/src/main/java/apoc/export/cypher/ExportCypher.java
+++ b/core/src/main/java/apoc/export/cypher/ExportCypher.java
@@ -109,7 +109,7 @@ public class ExportCypher {
         return exportCypher(fileName, source, new DatabaseSubGraph(tx), new ExportConfig(config), true);
     }
 
-    private Stream<DataProgressInfo> exportCypher(@Name("file") String fileName, String source, SubGraph graph, ExportConfig c, boolean onlySchema) throws IOException {
+    private Stream<DataProgressInfo> exportCypher(@Name("file") String fileName, String source, SubGraph graph, ExportConfig c, boolean onlySchema) {
         apocConfig.checkWriteAllowed(c, fileName);
 
         ProgressInfo progressInfo = new ProgressInfo(fileName, source, "cypher");

--- a/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
+++ b/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
@@ -31,32 +31,6 @@ import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_PROP;
  */
 public class MultiStatementCypherSubGraphExporter {
 
-    /*private enum IndexType {
-        NODE_LABEL_PROPERTY("node_label_property"),
-        NODE_UNIQUE_PROPERTY("node_unique_property"),
-        REL_TYPE_PROPERTY("relationship_type_property"),
-        NODE_FULLTEXT("node_fulltext"),
-        RELATIONSHIP_FULLTEXT("relationship_fulltext");
-
-        private final String typeName;
-
-        IndexType(String typeName) {
-            this.typeName = typeName;
-        }
-
-        static IndexType from(String type, String entityType, String uniqueness) {
-            if (uniqueness.equals("UNIQUE") && entityType.equals("NODE")) {
-                return NODE_UNIQUE_PROPERTY
-            }
-
-            return Stream.of(IndexType.values()).filter(type -> type.typeName().equals(stringType)).findFirst().orElseThrow();
-        }
-
-        public String typeName() {
-            return typeName;
-        }
-    }*/
-
     private final SubGraph graph;
     private final Map<String, Set<String>> uniqueConstraints = new HashMap<>();
     private Set<String> indexNames        = new LinkedHashSet<>();

--- a/core/src/main/java/apoc/export/graphml/ExportGraphML.java
+++ b/core/src/main/java/apoc/export/graphml/ExportGraphML.java
@@ -55,7 +55,7 @@ public class ExportGraphML {
 
     @Procedure(name = "apoc.import.graphml",mode = Mode.WRITE)
     @Description("Imports a graph from the provided GraphML file.")
-    public Stream<ProgressInfo> file(@Name("urlOrBinaryFile") Object urlOrBinaryFile, @Name("config") Map<String, Object> config) throws Exception {
+    public Stream<ProgressInfo> file(@Name("urlOrBinaryFile") Object urlOrBinaryFile, @Name("config") Map<String, Object> config) {
         ProgressInfo result =
         Util.inThread(pools, () -> {
             ExportConfig exportConfig = new ExportConfig(config);

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLFormat.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLFormat.java
@@ -23,7 +23,7 @@ public class XmlGraphMLFormat implements Format {
     }
 
     @Override
-    public ProgressInfo load(Reader reader, Reporter reporter, ExportConfig config) throws Exception {
+    public ProgressInfo load(Reader reader, Reporter reporter, ExportConfig config) {
         return null;
     }
 

--- a/core/src/main/java/apoc/export/json/ExportJson.java
+++ b/core/src/main/java/apoc/export/json/ExportJson.java
@@ -89,7 +89,7 @@ public class ExportJson {
         return exportJson(fileName, source,result,config);
     }
 
-    private Stream<ProgressInfo> exportJson(String fileName, String source, Object data, Map<String,Object> config) throws Exception {
+    private Stream<ProgressInfo> exportJson(String fileName, String source, Object data, Map<String,Object> config) {
         ExportConfig exportConfig = new ExportConfig(config);
         apocConfig.checkWriteAllowed(exportConfig, fileName);
         final String format = "json";

--- a/core/src/main/java/apoc/export/json/ExportJson.java
+++ b/core/src/main/java/apoc/export/json/ExportJson.java
@@ -54,7 +54,7 @@ public class ExportJson {
 
     @Procedure("apoc.export.json.all")
     @Description("Exports the full database to the provided JSON file.")
-    public Stream<ProgressInfo> all(@Name("file") String fileName, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) throws Exception {
+    public Stream<ProgressInfo> all(@Name("file") String fileName, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
 
         String source = String.format("database: nodes(%d), rels(%d)", Util.nodeCount(tx), Util.relCount(tx));
         return exportJson(fileName, source, new DatabaseSubGraph(tx), config);
@@ -62,7 +62,7 @@ public class ExportJson {
 
     @Procedure("apoc.export.json.data")
     @Description("Exports the given nodes and relationships to the provided JSON file.")
-    public Stream<ProgressInfo> data(@Name("nodes") List<Node> nodes, @Name("rels") List<Relationship> rels, @Name("file") String fileName, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) throws Exception {
+    public Stream<ProgressInfo> data(@Name("nodes") List<Node> nodes, @Name("rels") List<Relationship> rels, @Name("file") String fileName, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
         // initialize empty lists if nodes or rels are null
         nodes = nodes == null ? Collections.emptyList() : nodes;
         rels = rels == null ? Collections.emptyList() : rels;
@@ -72,7 +72,7 @@ public class ExportJson {
     }
     @Procedure("apoc.export.json.graph")
     @Description("Exports the given graph to the provided JSON file.")
-    public Stream<ProgressInfo> graph(@Name("graph") Map<String,Object> graph, @Name("file") String fileName, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) throws Exception {
+    public Stream<ProgressInfo> graph(@Name("graph") Map<String,Object> graph, @Name("file") String fileName, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
 
         Collection<Node> nodes = (Collection<Node>) graph.get("nodes");
         Collection<Relationship> rels = (Collection<Relationship>) graph.get("relationships");
@@ -82,7 +82,7 @@ public class ExportJson {
 
     @Procedure("apoc.export.json.query")
     @Description("Exports the results from the Cypher statement to the provided JSON file.")
-    public Stream<ProgressInfo> query(@Name("statement") String query, @Name("file") String fileName, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) throws Exception {
+    public Stream<ProgressInfo> query(@Name("statement") String query, @Name("file") String fileName, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
         Map<String,Object> params = config == null ? Collections.emptyMap() : (Map<String,Object>)config.getOrDefault("params", Collections.emptyMap());
         Result result = tx.execute(query,params);
         String source = String.format("statement: cols(%d)", result.columns().size());

--- a/core/src/main/java/apoc/export/json/JsonFormat.java
+++ b/core/src/main/java/apoc/export/json/JsonFormat.java
@@ -40,7 +40,7 @@ public class JsonFormat implements Format {
     }
 
     @Override
-    public ProgressInfo load(Reader reader, Reporter reporter, ExportConfig config) throws Exception {
+    public ProgressInfo load(Reader reader, Reporter reporter, ExportConfig config) {
         return null;
     }
 

--- a/core/src/main/java/apoc/export/json/JsonImporter.java
+++ b/core/src/main/java/apoc/export/json/JsonImporter.java
@@ -12,7 +12,6 @@ import org.neo4j.values.storable.DurationValue;
 import org.neo4j.values.storable.PointValue;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -352,7 +351,7 @@ public class JsonImporter implements Closeable {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         flush();
         reporter.done();
     }

--- a/core/src/main/java/apoc/graph/Graphs.java
+++ b/core/src/main/java/apoc/graph/Graphs.java
@@ -86,7 +86,7 @@ public class Graphs {
 
     @Procedure(name = "apoc.graph.fromDocument", mode = Mode.WRITE)
     @Description("Generates a virtual sub-graph by extracting all of the nodes and relationships from the data returned by the given JSON file.")
-    public Stream<VirtualGraph> fromDocument(@Name("json") Object document, @Name(value = "config", defaultValue = "{}") Map<String,Object> config) throws Exception {
+    public Stream<VirtualGraph> fromDocument(@Name("json") Object document, @Name(value = "config", defaultValue = "{}") Map<String,Object> config) {
         DocumentToGraph documentToGraph = new DocumentToGraph(tx, new GraphsConfig(config));
         return Stream.of(documentToGraph.create(document));
     }

--- a/core/src/main/java/apoc/help/Help.java
+++ b/core/src/main/java/apoc/help/Help.java
@@ -41,7 +41,7 @@ public class Help {
 
     @Procedure("apoc.help")
     @Description("Returns descriptions of the available APOC procedures and functions.")
-    public Stream<HelpResult> info(@Name("proc") String name) throws Exception {
+    public Stream<HelpResult> info(@Name("proc") String name) {
         boolean searchText = false;
         if (name != null) {
             name = name.trim();

--- a/core/src/main/java/apoc/log/Neo4jLogStream.java
+++ b/core/src/main/java/apoc/log/Neo4jLogStream.java
@@ -75,7 +75,7 @@ public class Neo4jLogStream {
 
             // Useful for tailing logfiles.
             if(config.containsKey("last")) {
-                return entries.sorted(Collections.reverseOrder()).limit(new Double(config.get("last").toString()).longValue());
+                return entries.sorted(Collections.reverseOrder()).limit(Double.valueOf(config.get("last").toString()).longValue());
             }
 
             return entries;

--- a/core/src/main/java/apoc/path/NodeEvaluators.java
+++ b/core/src/main/java/apoc/path/NodeEvaluators.java
@@ -15,7 +15,7 @@ import java.util.Set;
  */
 public final class NodeEvaluators {
     // non-instantiable
-    private NodeEvaluators() {};
+    private NodeEvaluators() {}
 
     /**
      * Returns an evaluator which handles end nodes and terminator nodes

--- a/core/src/main/java/apoc/periodic/Periodic.java
+++ b/core/src/main/java/apoc/periodic/Periodic.java
@@ -68,7 +68,7 @@ public class Periodic {
 
     @Procedure(name = "apoc.periodic.commit", mode = Mode.WRITE)
     @Description("Runs the given statement in separate batched transactions.")
-    public Stream<RundownResult> commit(@Name("statement") String statement, @Name(value = "params", defaultValue = "{}") Map<String,Object> parameters) throws ExecutionException, InterruptedException {
+    public Stream<RundownResult> commit(@Name("statement") String statement, @Name(value = "params", defaultValue = "{}") Map<String,Object> parameters) {
         validateQuery(statement);
         Map<String,Object> params = parameters == null ? Collections.emptyMap() : parameters;
         long total = 0, executions = 0, updates = 0;

--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -114,7 +114,7 @@ public class Schemas {
         return constraintsExistsForRelationship(type, propertyNames);
     }
 
-    public List<AssertSchemaResult> assertConstraints(Map<String, List<Object>> constraints0, boolean dropExisting) throws ExecutionException, InterruptedException {
+    public List<AssertSchemaResult> assertConstraints(Map<String, List<Object>> constraints0, boolean dropExisting) {
         Map<String, List<Object>> constraints = copyMapOfObjects(constraints0);
         List<AssertSchemaResult> result = new ArrayList<>(constraints.size());
         Schema schema = tx.schema();
@@ -172,7 +172,7 @@ public class Schemas {
         return new AssertSchemaResult(lbl, key).unique().created();
     }
 
-    public List<AssertSchemaResult> assertIndexes(Map<String, List<Object>> indexes0, boolean dropExisting) throws ExecutionException, InterruptedException, IllegalArgumentException {
+    public List<AssertSchemaResult> assertIndexes(Map<String, List<Object>> indexes0, boolean dropExisting) throws IllegalArgumentException {
         Schema schema = tx.schema();
         Map<String, List<Object>> indexes = copyMapOfObjects(indexes0);
         List<AssertSchemaResult> result = new ArrayList<>(indexes.size());

--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -46,7 +46,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -70,7 +69,7 @@ public class Schemas {
     @Procedure(name = "apoc.schema.assert", mode = Mode.SCHEMA)
     @Description("Drops all other existing indexes and constraints when `dropExisting` is `true` (default is `true`).\n" +
             "Asserts at the end of the operation that the given indexes and unique constraints are there.")
-    public Stream<AssertSchemaResult> schemaAssert(@Name("indexes") Map<String, List<Object>> indexes, @Name("constraints") Map<String, List<Object>> constraints, @Name(value = "dropExisting", defaultValue = "true") boolean dropExisting) throws ExecutionException, InterruptedException {
+    public Stream<AssertSchemaResult> schemaAssert(@Name("indexes") Map<String, List<Object>> indexes, @Name("constraints") Map<String, List<Object>> constraints, @Name(value = "dropExisting", defaultValue = "true") boolean dropExisting) {
         return Stream.concat(
                 assertIndexes(indexes, dropExisting).stream(),
                 assertConstraints(constraints, dropExisting).stream());
@@ -79,7 +78,7 @@ public class Schemas {
     @Procedure(name = "apoc.schema.nodes", mode = Mode.SCHEMA)
     @Description("Returns all indexes and constraints information for all node labels in the database.\n" +
             "It is possible to define a set of labels to include or exclude in the config parameters.")
-    public Stream<IndexConstraintNodeInfo> nodes(@Name(value = "config",defaultValue = "{}") Map<String,Object> config) throws IndexNotFoundKernelException {
+    public Stream<IndexConstraintNodeInfo> nodes(@Name(value = "config",defaultValue = "{}") Map<String,Object> config) {
         return indexesAndConstraintsForNode(config);
     }
 

--- a/core/src/test/java/apoc/agg/CollAggregationTest.java
+++ b/core/src/test/java/apoc/agg/CollAggregationTest.java
@@ -22,7 +22,7 @@ public class CollAggregationTest {
     }
 
     @Test
-    public void testNth() throws Exception {
+    public void testNth() {
         testCall(db, "UNWIND RANGE(0,10) as value RETURN apoc.agg.nth(value, 0) as first, apoc.agg.nth(value, 3) as third,apoc.agg.nth(value, -1) as last",
                 (row) -> {
                     assertEquals(0L, row.get("first"));
@@ -31,44 +31,28 @@ public class CollAggregationTest {
                 });
     }
     @Test
-    public void testFirst() throws Exception {
+    public void testFirst() {
         testCall(db, "UNWIND RANGE(0,10) as value RETURN apoc.agg.first(value) as first",
-                (row) -> {
-                    assertEquals(0L, row.get("first"));
-                });
+                (row) -> assertEquals(0L, row.get("first")));
         testCall(db, "UNWIND [null,42,43,null] as value RETURN apoc.agg.first(value) as first",
-                (row) -> {
-                    assertEquals(42L, row.get("first"));
-                });
+                (row) -> assertEquals(42L, row.get("first")));
     }
     @Test
-    public void testLast() throws Exception {
+    public void testLast() {
         testCall(db, "UNWIND RANGE(0,10) as value RETURN apoc.agg.last(value) as last",
-                (row) -> {
-                    assertEquals(10L, row.get("last"));
-                });
+                (row) -> assertEquals(10L, row.get("last")));
         testCall(db, "UNWIND [null,41,null,42,null] as value RETURN apoc.agg.last(value) as last",
-                (row) -> {
-                    assertEquals(42L, row.get("last"));
-                });
+                (row) -> assertEquals(42L, row.get("last")));
     }
     @Test
-    public void testSlice() throws Exception {
+    public void testSlice() {
         testCall(db, "UNWIND RANGE(0,10) as value RETURN apoc.agg.slice(value,1,3) as slice",
-                (row) -> {
-                    assertEquals(asList(1L,2L,3L), row.get("slice"));
-                });
+                (row) -> assertEquals(asList(1L,2L,3L), row.get("slice")));
         testCall(db, "UNWIND RANGE(0,3) as value RETURN apoc.agg.slice(value) as slice",
-                (row) -> {
-                    assertEquals(asList(0L,1L,2L,3L), row.get("slice"));
-                });
+                (row) -> assertEquals(asList(0L,1L,2L,3L), row.get("slice")));
         testCall(db, "UNWIND RANGE(0,3) as value RETURN apoc.agg.slice(value,2) as slice",
-                (row) -> {
-                    assertEquals(asList(2L,3L), row.get("slice"));
-                });
+                (row) -> assertEquals(asList(2L,3L), row.get("slice")));
         testCall(db, "UNWIND [null,41,null,42,null,43,null] as value RETURN apoc.agg.slice(value,1,3) as slice",
-                (row) -> {
-                    assertEquals(asList(42L,43L), row.get("slice"));
-                });
+                (row) -> assertEquals(asList(42L,43L), row.get("slice")));
     }
 }

--- a/core/src/test/java/apoc/agg/GraphAggregationTest.java
+++ b/core/src/test/java/apoc/agg/GraphAggregationTest.java
@@ -25,7 +25,7 @@ public class GraphAggregationTest {
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule();
 
-    @BeforeClass public static void setUp() throws Exception {
+    @BeforeClass public static void setUp() {
         TestUtil.registerProcedure(db, Graph.class);
         db.executeTransactionally("CREATE (a:A {id:'a'})-[:AB {id:'ab'}]->(b:B {id:'b'})-[:BC {id:'bc'}]->(c:C {id:'c'}),(a)-[:AC {id:'ac'}]->(c)");
     }

--- a/core/src/test/java/apoc/agg/GraphAggregationTest.java
+++ b/core/src/test/java/apoc/agg/GraphAggregationTest.java
@@ -31,7 +31,7 @@ public class GraphAggregationTest {
     }
 
     @Test
-    public void testGraph() throws Exception {
+    public void testGraph() {
         Map<String, Entity> pcs = db.executeTransactionally("MATCH (n) RETURN n.id as id, n UNION ALL MATCH ()-[n]->() RETURN n.id as id, n", Collections.emptyMap(),
                 result -> result.stream().collect(Collectors.toMap(row -> row.get("id").toString(), row -> (Entity) row.get("n"))));
 

--- a/core/src/test/java/apoc/agg/MaxAndMinItemsAggregationTest.java
+++ b/core/src/test/java/apoc/agg/MaxAndMinItemsAggregationTest.java
@@ -24,7 +24,7 @@ public class MaxAndMinItemsAggregationTest {
     public static DbmsRule db = new ImpermanentDbmsRule();
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, MaxAndMinItems.class);
 
         String movies = Util.readResourceFile("movies.cypher");

--- a/core/src/test/java/apoc/agg/MaxAndMinItemsAggregationTest.java
+++ b/core/src/test/java/apoc/agg/MaxAndMinItemsAggregationTest.java
@@ -42,7 +42,7 @@ public class MaxAndMinItemsAggregationTest {
     }
 
     @Test
-    public void testBasicMax() throws Exception {
+    public void testBasicMax() {
         testCall(db, "UNWIND RANGE(0,10) as value " +
                         "WITH apoc.agg.maxItems(value, value) as maxResult " +
                         "RETURN maxResult.value as value, maxResult.items as items",
@@ -65,7 +65,7 @@ public class MaxAndMinItemsAggregationTest {
     }
 
     @Test
-    public void testBasicMin() throws Exception {
+    public void testBasicMin() {
         testCall(db, "UNWIND RANGE(0,10) as value " +
                         "WITH apoc.agg.minItems(value, value) as minResult " +
                         "RETURN minResult.value as value, minResult.items as items",
@@ -88,7 +88,7 @@ public class MaxAndMinItemsAggregationTest {
     }
 
     @Test
-    public void testMaxWithGrouping() throws Exception {
+    public void testMaxWithGrouping() {
         /** comparing to:
           MATCH (p:Person)
           WHERE p.born <= 1974
@@ -112,7 +112,7 @@ public class MaxAndMinItemsAggregationTest {
     }
 
     @Test
-    public void testMinWithGrouping() throws Exception {
+    public void testMinWithGrouping() {
         /** comparing to:
          MATCH (p:Person)
          WHERE p.born >= 1930
@@ -137,7 +137,7 @@ public class MaxAndMinItemsAggregationTest {
     }
 
     @Test
-    public void testMaxWithLimitedGrouping() throws Exception {
+    public void testMaxWithLimitedGrouping() {
         /** comparing to:
          MATCH (p:Person)
          WHERE p.born <= 1974
@@ -163,7 +163,7 @@ public class MaxAndMinItemsAggregationTest {
     }
 
     @Test
-    public void testMinWithLimitedGrouping() throws Exception {
+    public void testMinWithLimitedGrouping() {
         /** comparing to:
          MATCH (p:Person)
          WHERE p.born >= 1930
@@ -189,7 +189,7 @@ public class MaxAndMinItemsAggregationTest {
     }
 
     @Test
-    public void testMaxWithNullValuesProducesNoResults() throws Exception {
+    public void testMaxWithNullValuesProducesNoResults() {
         testCall(db,  "MATCH (p:Person) " +
                         "WITH apoc.agg.maxItems(p, p.doesNotExist) as maxResult " +
                         "RETURN maxResult.value as value, [person in maxResult.items | person.name] as persons",
@@ -200,7 +200,7 @@ public class MaxAndMinItemsAggregationTest {
     }
 
     @Test
-    public void testMinWithNullValuesProducesNoResults() throws Exception {
+    public void testMinWithNullValuesProducesNoResults() {
         testCall(db,  "MATCH (p:Person) " +
                         "WITH apoc.agg.minItems(p, p.doesNotExist) as minResult " +
                         "RETURN minResult.value as value, [person in minResult.items | person.name] as persons",

--- a/core/src/test/java/apoc/agg/MedianTest.java
+++ b/core/src/test/java/apoc/agg/MedianTest.java
@@ -15,7 +15,8 @@ public class MedianTest {
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule();
 
-    @BeforeClass public static void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() {
         TestUtil.registerProcedure(db, Median.class);
     }
 

--- a/core/src/test/java/apoc/agg/MedianTest.java
+++ b/core/src/test/java/apoc/agg/MedianTest.java
@@ -20,7 +20,7 @@ public class MedianTest {
     }
 
     @Test
-    public void testMedian() throws Exception {
+    public void testMedian() {
         testCall(db, "UNWIND [] as value RETURN apoc.agg.median(value) as p",
                 (row) -> {
                     assertEquals(null, row.get("p"));

--- a/core/src/test/java/apoc/agg/PercentilesTest.java
+++ b/core/src/test/java/apoc/agg/PercentilesTest.java
@@ -24,7 +24,7 @@ public class PercentilesTest {
     }
 
     @Test
-    public void testPercentiles() throws Exception {
+    public void testPercentiles() {
         testCall(db, "UNWIND [] as value RETURN apoc.agg.percentiles(value) as p",
                 (row) -> {
                     assertEquals(asList(null,null,null,null,null,null), row.get("p"));
@@ -43,7 +43,7 @@ public class PercentilesTest {
                 });
     }
     @Test
-    public void testPercentilesDoubles() throws Exception {
+    public void testPercentilesDoubles() {
         testCall(db, "UNWIND [] as value RETURN apoc.agg.percentiles(value) as p",
                 (row) -> {
                     assertEquals(asList(null,null,null,null,null,null), row.get("p"));

--- a/core/src/test/java/apoc/agg/PercentilesTest.java
+++ b/core/src/test/java/apoc/agg/PercentilesTest.java
@@ -19,7 +19,7 @@ public class PercentilesTest {
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule();
 
-    @BeforeClass public static void setUp() throws Exception {
+    @BeforeClass public static void setUp() {
         TestUtil.registerProcedure(db, Percentiles.class);
     }
 

--- a/core/src/test/java/apoc/agg/ProductAggregationTest.java
+++ b/core/src/test/java/apoc/agg/ProductAggregationTest.java
@@ -20,7 +20,7 @@ public class ProductAggregationTest {
     }
 
     @Test
-    public void testProduct() throws Exception {
+    public void testProduct() {
         testCall(db, "UNWIND [] as value RETURN apoc.agg.product(value) as p",
                 (row) -> {
                     assertEquals(0D, row.get("p"));

--- a/core/src/test/java/apoc/agg/ProductAggregationTest.java
+++ b/core/src/test/java/apoc/agg/ProductAggregationTest.java
@@ -15,7 +15,8 @@ public class ProductAggregationTest {
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule();
 
-    @BeforeClass public static void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() {
         TestUtil.registerProcedure(db, Product.class);
     }
 

--- a/core/src/test/java/apoc/agg/StatisticsTest.java
+++ b/core/src/test/java/apoc/agg/StatisticsTest.java
@@ -24,7 +24,7 @@ public class StatisticsTest {
     }
 
     @Test
-    public void testStatistics() throws Exception {
+    public void testStatistics() {
         testCall(db, "UNWIND [] as value RETURN apoc.agg.statistics(value) as p",
                 (row) -> {
                     assertEquals(map("min", null, "max", null, "minNonZero", Long.valueOf(Long.MAX_VALUE).doubleValue(), "total", 0L, "stdev", 0D, "mean", 0D), row.get("p"));
@@ -36,7 +36,7 @@ public class StatisticsTest {
     }
 
     @Test
-    public void testStatisticsDouble() throws Exception {
+    public void testStatisticsDouble() {
         testCall(db, "UNWIND [0,1,1,2.0,2,2,3] as value RETURN apoc.agg.statistics(value,[0.5,0.95]) as p",
                 (row) -> {
                     assertEquals(map("total", 7L, "min", 0L, "minNonZero", 1D, "max", 3L, "mean", 1.5714329310825892D, "0.5", 2.0000076293945312D, "0.95", 3.0000076293945312D, "stdev", 0.9035111771858774), row.get("p"));
@@ -44,7 +44,7 @@ public class StatisticsTest {
     }
 
     @Test
-    public void testStatisticsDoubleMinMax() throws Exception {
+    public void testStatisticsDoubleMinMax() {
         testCall(db, "UNWIND [0.123,0.234] as value RETURN apoc.agg.statistics(value,[0.05,0.5,0.95]) as p",
                 (row) -> {
                     Map<String, Number> stats = (Map<String, Number>) row.get("p");

--- a/core/src/test/java/apoc/agg/StatisticsTest.java
+++ b/core/src/test/java/apoc/agg/StatisticsTest.java
@@ -19,7 +19,7 @@ public class StatisticsTest {
     public static DbmsRule db = new ImpermanentDbmsRule();
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, Statistics.class);
     }
 

--- a/core/src/test/java/apoc/algo/CoverTest.java
+++ b/core/src/test/java/apoc/algo/CoverTest.java
@@ -25,7 +25,7 @@ public class CoverTest {
     }
 
     @Test
-    public void testCover() throws Exception {
+    public void testCover() {
         TestUtil.testCall(db,
                 "match (n) with collect(id(n)) as nodes call apoc.algo.cover(nodes) yield rel return count(*) as c",
                 (r) -> assertEquals(3L,r.get("c")));

--- a/core/src/test/java/apoc/algo/CoverTest.java
+++ b/core/src/test/java/apoc/algo/CoverTest.java
@@ -19,7 +19,7 @@ public class CoverTest {
     public static DbmsRule db = new ImpermanentDbmsRule();
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, Cover.class);
         db.executeTransactionally("CREATE (a)-[:X]->(b)-[:X]->(c)-[:X]->(d)");
     }

--- a/core/src/test/java/apoc/algo/PathFindingTest.java
+++ b/core/src/test/java/apoc/algo/PathFindingTest.java
@@ -51,7 +51,7 @@ public class PathFindingTest {
 
 
     @Before
-   	public void setUp() throws Exception {
+   	public void setUp() {
    		TestUtil.registerProcedure(db, PathFinding.class);
    	}
 

--- a/core/src/test/java/apoc/atomic/AtomicTest.java
+++ b/core/src/test/java/apoc/atomic/AtomicTest.java
@@ -30,7 +30,8 @@ public class AtomicTest {
 	@Rule
 	public DbmsRule db = new ImpermanentDbmsRule();
 
-	@Before public void setUp() throws Exception {
+	@Before
+	public void setUp() {
 		TestUtil.registerProcedure(db, Atomic.class);
 	}
 

--- a/core/src/test/java/apoc/bitwise/BitwiseOperationsTest.java
+++ b/core/src/test/java/apoc/bitwise/BitwiseOperationsTest.java
@@ -23,7 +23,7 @@ public class BitwiseOperationsTest {
     private int a,b;
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, BitwiseOperations.class);
     }
 

--- a/core/src/test/java/apoc/bitwise/BitwiseOperationsTest.java
+++ b/core/src/test/java/apoc/bitwise/BitwiseOperationsTest.java
@@ -34,7 +34,7 @@ public class BitwiseOperationsTest {
     }
 
     @Test
-    public void testOperations() throws Throwable {
+    public void testOperations() {
         a = 0b0011_1100;
         b = 0b0000_1101;
         testOperation("&", 12L);
@@ -48,7 +48,7 @@ public class BitwiseOperationsTest {
     }
 
     @Test
-    public void testOperations2() throws Throwable {
+    public void testOperations2() {
         a = 0b0011_1100;
         b = 2;
         testOperation("<<", 240L);

--- a/core/src/test/java/apoc/coll/ArrayListTest.java
+++ b/core/src/test/java/apoc/coll/ArrayListTest.java
@@ -17,7 +17,7 @@ public class ArrayListTest {
 
 
     @Test
-    public void testEmptyList() throws Exception {
+    public void testEmptyList() {
         ArrayList list = new ArrayList(EMPTY_SET);
         assertEquals(0,list.size());
         assertEquals(true,list.isEmpty());
@@ -29,7 +29,7 @@ public class ArrayListTest {
         assertEquals(0, it.nextIndex());
     }
     @Test
-    public void testSingleList() throws Exception {
+    public void testSingleList() {
         ArrayList list = new ArrayList(singleton(1));
         assertEquals(1,list.size());
         assertEquals(false,list.isEmpty());
@@ -52,7 +52,7 @@ public class ArrayListTest {
 
 
     @Test
-    public void testDoubleList() throws Exception {
+    public void testDoubleList() {
         ArrayList list = new ArrayList(new LinkedHashSet<>(asList(1,2)));
         assertEquals(2,list.size());
         assertEquals(false,list.isEmpty());
@@ -86,7 +86,7 @@ public class ArrayListTest {
     }
 
     @Test
-    public void testReverse() throws Exception {
+    public void testReverse() {
         LinkedHashSet set = new LinkedHashSet(asList(1, 2, 3, 4, 5));
         ArrayList list = new ArrayList(set);
         assertEquals(asList(1,2,3,4,5),list);
@@ -97,15 +97,5 @@ public class ArrayListTest {
         while (it.hasPrevious()) { result.add(it.previous()); }
 
         assertEquals(asList(5,4,3,2,1),result);
-    }
-
-    @Test
-    public void testListIterator() throws Exception {
-
-    }
-
-    @Test
-    public void testContains() throws Exception {
-
     }
 }

--- a/core/src/test/java/apoc/coll/CollTest.java
+++ b/core/src/test/java/apoc/coll/CollTest.java
@@ -31,13 +31,13 @@ public class CollTest {
     }
 
     @Test
-    public void testRunningTotal() throws Exception {
+    public void testRunningTotal() {
         testCall(db, "RETURN apoc.coll.runningTotal([1,2,3,4,5.5,1]) as value",
                 (row) -> assertEquals(asList(1L, 3L, 6L, 10L, 15.5D, 16.5D), row.get("value")));
     }
 
     @Test
-    public void testStandardDeviation() throws Exception {
+    public void testStandardDeviation() {
         testCall(db, "RETURN apoc.coll.stdev([10, 12, 23, 23, 16, 23, 21, 16]) as value",
                 (row) -> assertEquals(5.237229365663817D, row.get("value")));
 
@@ -50,7 +50,7 @@ public class CollTest {
     }
 
     @Test
-    public void testZip() throws Exception {
+    public void testZip() {
         testCall(db, "RETURN apoc.coll.zip([1,2,3],[4,5]) as value",
                 (row) -> {
                     Object value = row.get("value");
@@ -60,43 +60,43 @@ public class CollTest {
     }
 
     @Test
-    public void testPairs() throws Exception {
+    public void testPairs() {
         testCall(db, "RETURN apoc.coll.pairs([1,2,3]) as value",
                 (row) -> assertEquals(asList(asList(1L, 2L), asList(2L, 3L), asList(3L, null)), row.get("value")));
     }
 
     @Test
-    public void testPairsMin() throws Exception {
+    public void testPairsMin() {
         testCall(db, "RETURN apoc.coll.pairsMin([1,2,3]) as value",
                 (row) -> assertEquals(asList(asList(1L, 2L), asList(2L, 3L)), row.get("value")));
     }
 
     @Test
-    public void testPairsMinListResult() throws Exception {
+    public void testPairsMinListResult() {
         testCall(db, "RETURN apoc.coll.pairsMin([1,2,3])[0][0] as result",
                 (row) -> assertEquals(1L, row.get("result")));
     }
 
     @Test
-    public void testToSet() throws Exception {
+    public void testToSet() {
         testCall(db, "RETURN apoc.coll.toSet([1,2,1,3]) as value",
                 (row) -> assertEquals(asList(1L, 2L, 3L), row.get("value")));
     }
 
     @Test
-    public void testSum() throws Exception {
+    public void testSum() {
         testCall(db, "RETURN apoc.coll.sum([1,2,3]) as value",
                 (row) -> assertEquals(6D, row.get("value")));
     }
 
     @Test
-    public void testAvg() throws Exception {
+    public void testAvg() {
         testCall(db, "RETURN apoc.coll.avg([1.4,2,3.2]) as value",
                 (row) -> assertEquals(2.2D, (double) row.get("value"), 0.1));
     }
 
     @Test
-    public void testMin() throws Exception {
+    public void testMin() {
         testCall(db, "RETURN apoc.coll.min([1,2]) as value",
                 (row) -> assertEquals(1L, row.get("value")));
         testCall(db, "RETURN apoc.coll.min([1,2,3]) as value",
@@ -106,7 +106,7 @@ public class CollTest {
     }
 
     @Test
-    public void testMax() throws Exception {
+    public void testMax() {
         testCall(db, "RETURN apoc.coll.max([1,2,3]) as value",
                 (row) -> assertEquals(3L, row.get("value")));
         testCall(db, "RETURN apoc.coll.max([0.5,1,2.3]) as value",
@@ -114,7 +114,7 @@ public class CollTest {
     }
 
     @Test
-    public void testMaxDate() throws Exception {
+    public void testMaxDate() {
         testCall(db, "RETURN apoc.coll.max([date('2020-04-01'), date('2020-03-01')]) as value",
                 (row) -> assertEquals("2020-04-01", row.get("value").toString()));
         testCall(db, "RETURN apoc.coll.max([datetime('2020-03-30T12:17:43.175Z'), datetime('2020-03-30T12:17:39.982Z')]) as value",
@@ -124,7 +124,7 @@ public class CollTest {
     }
 
     @Test
-    public void testPartitionProcedure() throws Exception {
+    public void testPartitionProcedure() {
         testResult(db, "CALL apoc.coll.partition([1,2,3,4,5],2)",
                 (result) -> {
                     Map<String, Object> row = result.next();
@@ -138,7 +138,7 @@ public class CollTest {
     }
 
     @Test
-    public void testPartitionFunction() throws Exception {
+    public void testPartitionFunction() {
         testResult(db, "UNWIND apoc.coll.partition([1,2,3,4,5],2) AS value RETURN value",
                 (result) -> {
                     Map<String, Object> row = result.next();
@@ -152,25 +152,25 @@ public class CollTest {
     }
 
     @Test
-    public void testSumLongs() throws Exception {
+    public void testSumLongs() {
         testCall(db, "RETURN apoc.coll.sumLongs([1,2,3]) AS value",
                 (row) -> assertEquals(6L, row.get("value")));
     }
 
     @Test
-    public void testSort() throws Exception {
+    public void testSort() {
         testCall(db, "RETURN apoc.coll.sort([3,2,1]) as value",
                 (row) -> assertEquals(asList(1L, 2L, 3L), row.get("value")));
     }
 
     @Test
-    public void testIN() throws Exception {
+    public void testIN() {
         testCall(db, "RETURN apoc.coll.contains([1,2,3],1) AS value",
                 (res) -> assertEquals(true, res.get("value")));
     }
 
     @Test
-    public void testIndexOf() throws Exception {
+    public void testIndexOf() {
         testCall(db, "RETURN apoc.coll.indexOf([1,2,3],1) AS value", r -> assertEquals(0L, r.get("value")));
         testCall(db, "RETURN apoc.coll.indexOf([1,2,3],2) AS value", r -> assertEquals(1L, r.get("value")));
         testCall(db, "RETURN apoc.coll.indexOf([1,2,3],3) AS value", r -> assertEquals(2L, r.get("value")));
@@ -180,7 +180,7 @@ public class CollTest {
     }
 
     @Test
-    public void testSplit() throws Exception {
+    public void testSplit() {
         testResult(db, "CALL apoc.coll.split([1,2,3,2,4,5],2)", r -> {
             assertEquals(asList(1L), r.next().get("value"));
             assertEquals(asList(3L), r.next().get("value"));
@@ -207,7 +207,7 @@ public class CollTest {
     }
 
     @Test
-    public void testSet() throws Exception {
+    public void testSet() {
         testCall(db, "RETURN apoc.coll.set(null,0,4) AS value", r -> assertNull(r.get("value")));
         testCall(db, "RETURN apoc.coll.set([1,2,3],-1,4) AS value", r -> assertEquals(asList(1L,2L,3L), r.get("value")));
         testCall(db, "RETURN apoc.coll.set([1,2,3],0,null) AS value", r -> assertEquals(asList(1L,2L,3L), r.get("value")));
@@ -218,7 +218,7 @@ public class CollTest {
     }
 
     @Test
-    public void testInsert() throws Exception {
+    public void testInsert() {
         testCall(db, "RETURN apoc.coll.insert(null,0,4) AS value", r -> assertNull(r.get("value")));
         testCall(db, "RETURN apoc.coll.insert([1,2,3],-1,4) AS value", r -> assertEquals(asList(1L,2L,3L), r.get("value")));
         testCall(db, "RETURN apoc.coll.insert([1,2,3],0,null) AS value", r -> assertEquals(asList(1L,2L,3L), r.get("value")));
@@ -229,7 +229,7 @@ public class CollTest {
     }
 
     @Test
-    public void testInsertList() throws Exception {
+    public void testInsertList() {
         testCall(db, "RETURN apoc.coll.insertAll(null,0,[4,5,6]) AS value", r -> assertNull(r.get("value")));
         testCall(db, "RETURN apoc.coll.insertAll([1,2,3],-1,[4,5,6]) AS value", r -> assertEquals(asList(1L,2L,3L), r.get("value")));
         testCall(db, "RETURN apoc.coll.insertAll([1,2,3],0,null) AS value", r -> assertEquals(asList(1L,2L,3L), r.get("value")));
@@ -240,7 +240,7 @@ public class CollTest {
     }
 
     @Test
-    public void testRemove() throws Exception {
+    public void testRemove() {
         testCall(db, "RETURN apoc.coll.remove(null,0,0) AS value", r -> assertNull(r.get("value")));
         testCall(db, "RETURN apoc.coll.remove([1,2,3],-1,0) AS value", r -> assertEquals(asList(1L,2L,3L), r.get("value")));
         testCall(db, "RETURN apoc.coll.remove([1,2,3],0,-1) AS value", r -> assertEquals(asList(1L,2L,3L), r.get("value")));
@@ -253,7 +253,7 @@ public class CollTest {
 
 
     @Test
-    public void testContainsAll() throws Exception {
+    public void testContainsAll() {
         testCall(db, "RETURN apoc.coll.containsAll([1,2,3],[1,2]) AS value", (res) -> assertEquals(true, res.get("value")));
         testCall(db, "RETURN apoc.coll.containsAll([1,2,3],[2,1]) AS value", (res) -> assertEquals(true, res.get("value")));
         testCall(db, "RETURN apoc.coll.containsAll([1,2,3],[1,4]) AS value", (res) -> assertEquals(false, res.get("value")));
@@ -267,7 +267,7 @@ public class CollTest {
     }
 
     @Test
-    public void testContainsAllSorted() throws Exception {
+    public void testContainsAllSorted() {
         testCall(db, "RETURN apoc.coll.containsAllSorted([1,2,3],[1,2]) AS value", (res) -> assertEquals(true, res.get("value")));
         testCall(db, "RETURN apoc.coll.containsAllSorted([1,2,3],[1,4]) AS value", (res) -> assertEquals(false, res.get("value")));
         testCall(db, "RETURN apoc.coll.containsAllSorted([1,2,3],[]) AS value", (res) -> assertEquals(true, res.get("value")));
@@ -276,7 +276,7 @@ public class CollTest {
     }
 
     @Test
-    public void testIsEqualCollection() throws Exception {
+    public void testIsEqualCollection() {
         testCall(db, "RETURN apoc.coll.isEqualCollection([1,2,3],[1,2,3]) AS value", (res) -> assertEquals(true, res.get("value")));
         testCall(db, "RETURN apoc.coll.isEqualCollection([1,2,3],[3,2,1]) AS value", (res) -> assertEquals(true, res.get("value")));
         testCall(db, "RETURN apoc.coll.isEqualCollection([1,1,2,2,3],[1,1,2,2,3]) AS value", (res) -> assertEquals(true, res.get("value")));
@@ -295,7 +295,7 @@ public class CollTest {
     }
 
     @Test
-    public void testIN2() throws Exception {
+    public void testIN2() {
         int elements = 1_000_000;
         ArrayList<Long> list = new ArrayList<>(elements);
         for (long i = 0; i < elements; i++) {
@@ -310,7 +310,7 @@ public class CollTest {
     }
 
     @Test
-    public void testContainsSorted() throws Exception {
+    public void testContainsSorted() {
         int elements = 1_000_000;
         ArrayList<Long> list = new ArrayList<>(elements);
         for (long i = 0; i < elements; i++) {
@@ -325,7 +325,7 @@ public class CollTest {
     }
 
     @Test
-    public void testSortNodes() throws Exception {
+    public void testSortNodes() {
         testCall(db,
                 "CREATE (n {name:'foo'}),(m {name:'bar'}) WITH n,m RETURN apoc.coll.sortNodes([n,m], 'name') AS nodes",
                 (row) -> {
@@ -336,7 +336,7 @@ public class CollTest {
     }
 
     @Test
-    public void testSortNodesReverse() throws Exception {
+    public void testSortNodesReverse() {
         testCall(db,
                 "CREATE (n {name:'foo'}),(m {name:'bar'}) WITH n,m RETURN apoc.coll.sortNodes([n,m], '^name') AS nodes",
                 (row) -> {
@@ -347,7 +347,7 @@ public class CollTest {
     }
 
     @Test
-    public void testElements() throws Exception {
+    public void testElements() {
         testCall(db,
                 "CREATE p=(n {name:'foo'})-[r:R]->(n) WITH n,r,p CALL apoc.coll.elements([0,null,n,r,p,42,3.14,true,[42],{a:42},13], 9,1) YIELD elements,_1,_7,_10,_2n,_3r,_4p,_5i,_5f,_6i,_6f,_7b,_8l,_9m RETURN *",
                 (row) -> {
@@ -368,7 +368,7 @@ public class CollTest {
     }
 
     @Test
-    public void testSortMaps() throws Exception {
+    public void testSortMaps() {
         testCall(db,
                 "RETURN apoc.coll.sortMaps([{name:'foo'},{name:'bar'}], 'name') as maps",
                 (row) -> {
@@ -379,7 +379,7 @@ public class CollTest {
     }
 
     @Test
-    public void testSortMapsMulti() throws Exception {
+    public void testSortMapsMulti() {
         testCall(db,
                 "RETURN apoc.coll.sortMulti([{name:'foo'},{name:'bar',age:32},{name:'bar',age:42}], ['^name','age'],1,1) as maps",
                 (row) -> {
@@ -391,7 +391,7 @@ public class CollTest {
     }
 
     @Test
-    public void testSortMapsCount() throws Exception {
+    public void testSortMapsCount() {
 
         testCall(db,
                 "WITH ['a','b','c','c','c','b','a','d'] AS l RETURN apoc.coll.sortMaps(apoc.coll.frequencies(l),'count') as maps",
@@ -406,7 +406,7 @@ public class CollTest {
     }
 
     @Test
-    public void testSortMapsCountReverse() throws Exception {
+    public void testSortMapsCountReverse() {
 
         testCall(db,
                 "WITH ['b','a','c','c','c','b','a','d'] AS l RETURN apoc.coll.sortMaps(apoc.coll.frequencies(l),'^count') as maps",
@@ -421,7 +421,7 @@ public class CollTest {
     }
 
     @Test
-    public void testSetOperations() throws Exception {
+    public void testSetOperations() {
         testCall(db, "RETURN apoc.coll.union([1,2],[3,2]) AS value", r -> assertEquals(asSet(asList(1L, 2L, 3L)), asSet((Iterable) r.get("value"))));
         testCall(db, "RETURN apoc.coll.intersection([1,2],[3,2]) AS value", r -> assertEquals(asSet(asList(2L)), asSet((Iterable) r.get("value"))));
         testCall(db, "RETURN apoc.coll.intersection([1,2],[2,3]) AS value", r -> assertEquals(asSet(asList(2L)), asSet((Iterable) r.get("value"))));
@@ -447,7 +447,7 @@ public class CollTest {
     }
 
     @Test
-    public void testShuffleOnNullAndEmptyList() throws Exception {
+    public void testShuffleOnNullAndEmptyList() {
         testCall(db, "RETURN apoc.coll.shuffle([]) as value",
                 (row) -> assertEquals(Collections.EMPTY_LIST, row.get("value")));
 
@@ -456,7 +456,7 @@ public class CollTest {
     }
 
     @Test
-    public void testShuffle() throws Exception {
+    public void testShuffle() {
         // with 10k elements, very remote chance of randomly getting same order
         int elements = 10_000;
         ArrayList<Long> original = new ArrayList<>(elements);
@@ -477,7 +477,7 @@ public class CollTest {
     }
 
     @Test
-    public void testRandomItemOnNullAndEmptyList() throws Exception {
+    public void testRandomItemOnNullAndEmptyList() {
         testCall(db, "RETURN apoc.coll.randomItem([]) as value",
                 (row) -> {
                     Object result = row.get("value");
@@ -492,7 +492,7 @@ public class CollTest {
     }
 
     @Test
-    public void testRandomItem() throws Exception {
+    public void testRandomItem() {
         testCall(db, "RETURN apoc.coll.randomItem([1,2,3,4,5]) as value",
                 (row) -> {
                     Long result = (Long) row.get("value");
@@ -501,7 +501,7 @@ public class CollTest {
     }
 
     @Test
-    public void testRandomItemsOnNullAndEmptyList() throws Exception {
+    public void testRandomItemsOnNullAndEmptyList() {
         testCall(db, "RETURN apoc.coll.randomItems([], 5) as value",
                 (row) -> {
                     List<Object> result = (List<Object>) row.get("value");
@@ -528,7 +528,7 @@ public class CollTest {
     }
 
     @Test
-    public void testRandomItems() throws Exception {
+    public void testRandomItems() {
         // with 100k elements, very remote chance of randomly getting same order
         int elements = 100_000;
         ArrayList<Long> original = new ArrayList<>(elements);
@@ -549,7 +549,7 @@ public class CollTest {
     }
 
     @Test
-    public void testRandomItemsLargerThanOriginal() throws Exception {
+    public void testRandomItemsLargerThanOriginal() {
         // with 10k elements, very remote chance of randomly getting same order
         int elements = 10_000;
         ArrayList<Long> original = new ArrayList<>(elements);
@@ -570,7 +570,7 @@ public class CollTest {
     }
 
     @Test
-    public void testRandomItemsLargerThanOriginalAllowingRepick() throws Exception {
+    public void testRandomItemsLargerThanOriginalAllowingRepick() {
         // with 100k elements, very remote chance of randomly getting same order
         int elements = 100_000;
         ArrayList<Long> original = new ArrayList<>(elements);
@@ -590,19 +590,19 @@ public class CollTest {
     }
 
     @Test
-    public void testContainsDuplicatesOnNullAndEmptyList() throws Exception {
+    public void testContainsDuplicatesOnNullAndEmptyList() {
         testCall(db, "RETURN apoc.coll.containsDuplicates([]) AS value", r -> assertEquals(false, r.get("value")));
         testCall(db, "RETURN apoc.coll.containsDuplicates(null) AS value", r -> assertEquals(false, r.get("value")));
     }
 
     @Test
-    public void testContainsDuplicates() throws Exception {
+    public void testContainsDuplicates() {
         testCall(db, "RETURN apoc.coll.containsDuplicates([1,2,3,9,7,5]) AS value", r -> assertEquals(false, r.get("value")));
         testCall(db, "RETURN apoc.coll.containsDuplicates([1,2,1,5,4]) AS value", r -> assertEquals(true, r.get("value")));
     }
 
     @Test
-    public void testDuplicatesOnNullAndEmptyList() throws Exception {
+    public void testDuplicatesOnNullAndEmptyList() {
         testCall(db, "RETURN apoc.coll.duplicates([]) as value",
                 (row) -> assertEquals(Collections.EMPTY_LIST, row.get("value")));
         testCall(db, "RETURN apoc.coll.duplicates(null) as value",
@@ -610,13 +610,13 @@ public class CollTest {
     }
 
     @Test
-    public void testDuplicates() throws Exception {
+    public void testDuplicates() {
         testCall(db, "RETURN apoc.coll.duplicates([1,2,1,3,2,5,2,3,1,2]) as value",
                 (row) -> assertEquals(asList(1L, 2L, 3L), row.get("value")));
     }
 
     @Test
-    public void testDuplicatesWithCountOnNullAndEmptyList() throws Exception {
+    public void testDuplicatesWithCountOnNullAndEmptyList() {
         testCall(db, "RETURN apoc.coll.duplicatesWithCount([]) as value",
                 (row) -> assertEquals(Collections.EMPTY_LIST, row.get("value")));
         testCall(db, "RETURN apoc.coll.duplicatesWithCount(null) as value",
@@ -624,7 +624,7 @@ public class CollTest {
     }
 
     @Test
-    public void testDuplicatesWithCount() throws Exception {
+    public void testDuplicatesWithCount() {
         testCall(db, "RETURN apoc.coll.duplicatesWithCount([1,2,1,3,2,5,2,3,1,2]) as value",
                 (row) -> {
                     Map<Long, Long> expectedMap = new HashMap<>(3);
@@ -650,7 +650,7 @@ public class CollTest {
     }
 
     @Test
-    public void testFrequenciesOnNullAndEmptyList() throws Exception {
+    public void testFrequenciesOnNullAndEmptyList() {
         testCall(db, "RETURN apoc.coll.frequencies([]) as value",
                 (row) -> assertEquals(Collections.EMPTY_LIST, row.get("value")));
         testCall(db, "RETURN apoc.coll.frequencies(null) as value",
@@ -658,7 +658,7 @@ public class CollTest {
     }
 
     @Test
-    public void testFrequencies() throws Exception {
+    public void testFrequencies() {
         testCall(db, "RETURN apoc.coll.frequencies([1,2,1,3,2,5,2,3,1,2]) as value",
                 (row) -> {
                     Map<Long, Long> expectedMap = new HashMap<>(4);
@@ -685,7 +685,7 @@ public class CollTest {
     }
 
     @Test
-    public void testFrequenciesAsMapAsMap() throws Exception {
+    public void testFrequenciesAsMapAsMap() {
         testCall(db, "RETURN apoc.coll.frequenciesAsMap([]) as value",
                 (row) -> assertEquals(Collections.emptyMap(), row.get("value")));
         testCall(db, "RETURN apoc.coll.frequenciesAsMap(null) as value",
@@ -724,7 +724,7 @@ public class CollTest {
     }
 
     @Test
-    public void testOccurrencesOnNullAndEmptyList() throws Exception {
+    public void testOccurrencesOnNullAndEmptyList() {
         testCall(db, "RETURN apoc.coll.occurrences([], 5) as value",
                 (row) -> assertEquals(0l, row.get("value")));
         testCall(db, "RETURN apoc.coll.occurrences(null, 5) as value",
@@ -732,7 +732,7 @@ public class CollTest {
     }
 
     @Test
-    public void testOccurrences() throws Exception {
+    public void testOccurrences() {
         testCall(db, "RETURN apoc.coll.occurrences([1,2,1,3,2,5,2,3,1,2], 1) as value",
                 (row) -> assertEquals(3l, row.get("value")));
         testCall(db, "RETURN apoc.coll.occurrences([1,2,1,3,2,5,2,3,1,2], 2) as value",
@@ -746,43 +746,43 @@ public class CollTest {
     }
 
     @Test
-    public void testFlatten() throws Exception {
+    public void testFlatten() {
         testCall(db, "RETURN apoc.coll.flatten([[1,2],[3,4],[4],[5,6,7]]) as value",
                 (row) -> assertEquals(asList(1L,2L,3L,4L,4L,5L,6L,7L), row.get("value")));
     }
 
     @Test
-    public void testCombinationsWith0() throws Exception {
+    public void testCombinationsWith0() {
         testCall(db, "RETURN apoc.coll.combinations([1,2,3,4,5], 0) as value",
                 (row) -> assertEquals(Collections.emptyList(), row.get("value")));
     }
 
     @Test
-    public void testCombinationsWithNegative() throws Exception {
+    public void testCombinationsWithNegative() {
         testCall(db, "RETURN apoc.coll.combinations([1,2,3,4,5], -1) as value",
                 (row) -> assertEquals(Collections.emptyList(), row.get("value")));
     }
 
     @Test
-    public void testCombinationsWithEmptyCollection() throws Exception {
+    public void testCombinationsWithEmptyCollection() {
         testCall(db, "RETURN apoc.coll.combinations([], 0) as value",
                 (row) -> assertEquals(Collections.emptyList(), row.get("value")));
     }
 
     @Test
-    public void testCombinationsWithNullCollection() throws Exception {
+    public void testCombinationsWithNullCollection() {
         testCall(db, "RETURN apoc.coll.combinations(null, 0) as value",
                 (row) -> assertEquals(Collections.emptyList(), row.get("value")));
     }
 
     @Test
-    public void testCombinationsWithTooLargeSelect() throws Exception {
+    public void testCombinationsWithTooLargeSelect() {
         testCall(db, "RETURN apoc.coll.combinations([1,2,3,4,5], 6) as value",
                 (row) -> assertEquals(Collections.emptyList(), row.get("value")));
     }
 
     @Test
-    public void testCombinationsWithListSizeSelect() throws Exception {
+    public void testCombinationsWithListSizeSelect() {
         testCall(db, "RETURN apoc.coll.combinations([1,2,3,4,5], 5) as value",
                 (row) -> {
                     List<List<Object>> result = new ArrayList<>();
@@ -792,7 +792,7 @@ public class CollTest {
     }
 
     @Test
-    public void testCombinationsWithSingleSelect() throws Exception {
+    public void testCombinationsWithSingleSelect() {
         testCall(db, "RETURN apoc.coll.combinations([1,2,3,4,5], 3) as value",
                 (row) -> {
                     List<List<Object>> result = new ArrayList<>();
@@ -811,7 +811,7 @@ public class CollTest {
     }
 
     @Test
-    public void testCombinationsWithMinSelectGreaterThanMax() throws Exception {
+    public void testCombinationsWithMinSelectGreaterThanMax() {
         testCall(db, "RETURN apoc.coll.combinations([1,2,3,4], 3, 2) as value",
                 (row) -> {
                     assertEquals(Collections.emptyList(), row.get("value"));
@@ -819,7 +819,7 @@ public class CollTest {
     }
 
     @Test
-    public void testCombinationsWithMinAndMaxSelect() throws Exception {
+    public void testCombinationsWithMinAndMaxSelect() {
         testCall(db, "RETURN apoc.coll.combinations([1,2,3,4], 2, 3) as value",
                 (row) -> {
                     List<List<Object>> result = new ArrayList<>();
@@ -839,7 +839,7 @@ public class CollTest {
     }
 
     @Test
-    public void testVerifyAllValuesAreDifferent() throws Exception {
+    public void testVerifyAllValuesAreDifferent() {
         testCall(db, "RETURN apoc.coll.different([1, 2, 3]) as value",
                 (row) -> {
                     assertEquals(true, row.get("value"));
@@ -855,7 +855,7 @@ public class CollTest {
     }
 
     @Test
-    public void testDropNeighboursNodes() throws Exception {
+    public void testDropNeighboursNodes() {
         db.executeTransactionally("CREATE (n:Person {name:'Foo'}) " +
                 "CREATE (b:Person {name:'Bar'}) " +
                 "CREATE (n)-[:KNOWS]->(n)-[:LIVES_WITH]->(n)");
@@ -867,7 +867,7 @@ public class CollTest {
     }
 
     @Test
-    public void testDropNeighboursNumbers() throws Exception {
+    public void testDropNeighboursNumbers() {
         testResult(db, "WITH [1,2,3,4,4,5,6,6,4,7] AS values RETURN apoc.coll.dropDuplicateNeighbors(values) as value",
                 (row) -> {
                     assertEquals(asList(1L,2L,3L,4L,5L,6L,4L,7L), row.next().get("value"));
@@ -875,7 +875,7 @@ public class CollTest {
     }
 
     @Test
-    public void testDropNeighboursStrings() throws Exception {
+    public void testDropNeighboursStrings() {
         testResult(db, "WITH ['a','a','hello','hello','hello','foo','bar','apoc','apoc!','hello'] AS values RETURN apoc.coll.dropDuplicateNeighbors(values) as value",
                 (row) -> {
                     assertEquals(asList("a","hello","foo","bar","apoc","apoc!","hello"), row.next().get("value"));
@@ -883,7 +883,7 @@ public class CollTest {
     }
 
     @Test
-    public void testDropNeighboursDifferentTypes() throws Exception {
+    public void testDropNeighboursDifferentTypes() {
         testResult(db, "WITH ['a','a',1,1,'hello','foo','bar','apoc','apoc!',1] AS values RETURN apoc.coll.dropDuplicateNeighbors(values) as value",
                 (row) -> {
                     assertEquals(asList("a",1L,"hello","foo","bar","apoc","apoc!",1L), row.next().get("value"));
@@ -891,7 +891,7 @@ public class CollTest {
     }
 
     @Test
-    public void testFill() throws Exception {
+    public void testFill() {
         testResult(db, "RETURN apoc.coll.fill('abc',2) as value",
                 (row) -> {
                     assertEquals(asList("abc","abc"), row.next().get("value"));
@@ -899,7 +899,7 @@ public class CollTest {
     }
 
     @Test
-    public void testSortText() throws Exception {
+    public void testSortText() {
         testCall(db, "RETURN apoc.coll.sortText(['b', 'a']) as value",
                 (row) -> assertEquals(asList("a", "b"), row.get("value")));
         testCall(db, "RETURN apoc.coll.sortText(['Єльська', 'Гусак'], {locale: 'ru'}) as value",
@@ -907,7 +907,7 @@ public class CollTest {
     }
 
     @Test
-    public void testPairWithOffsetFn() throws Exception {
+    public void testPairWithOffsetFn() {
         testCall(db, "RETURN apoc.coll.pairWithOffset([1,2,3,4], 2) AS value",
                 (row) -> assertEquals(asList(asList(1L, 3L), asList(2L, 4L), asList(3L, null), asList(4L, null)), row.get("value")));
         testCall(db, "RETURN apoc.coll.pairWithOffset([1,2,3,4], -2) AS value",
@@ -915,7 +915,7 @@ public class CollTest {
     }
 
     @Test
-    public void testPairWithOffset() throws Exception {
+    public void testPairWithOffset() {
         testResult(db, "CALL apoc.coll.pairWithOffset([1,2,3,4], 2)",
                 (result) -> {
                     assertEquals(asList(1L, 3L), result.next().get("value"));

--- a/core/src/test/java/apoc/coll/CollTest.java
+++ b/core/src/test/java/apoc/coll/CollTest.java
@@ -26,7 +26,7 @@ public class CollTest {
     public static DbmsRule db = new ImpermanentDbmsRule();
 
 
-    @BeforeClass public static void setUp() throws Exception {
+    @BeforeClass public static void setUp() {
         TestUtil.registerProcedure(db, Coll.class, Json.class);
     }
 

--- a/core/src/test/java/apoc/coll/EqualityTest.java
+++ b/core/src/test/java/apoc/coll/EqualityTest.java
@@ -26,7 +26,7 @@ public class EqualityTest {
     public static DbmsRule db = new ImpermanentDbmsRule();
 
     @Test
-    public void testSpecial() throws Exception {
+    public void testSpecial() {
         shouldNotMatch((byte) 23, 23.5);
     }
 
@@ -47,7 +47,7 @@ public class EqualityTest {
     }
 
     @Test
-    public void testPropertyEquality() throws Exception {
+    public void testPropertyEquality() {
         shouldMatch(true, true);
         shouldMatch(false, false);
         shouldNotMatch(true, false);
@@ -160,7 +160,7 @@ public class EqualityTest {
     }
 
     @Test
-    public void testGraphEntities() throws Exception {
+    public void testGraphEntities() {
 
         try (Transaction tx = db.beginTx()) {
             Node n1 = tx.createNode();
@@ -193,7 +193,7 @@ public class EqualityTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testIn() throws Exception {
+    public void testIn() {
         Set<Object> set = new HashSet(asList(0, 1, 2.0D, 3.0F, 4L, 'A', "B", new int[]{0, 1, 2, 3}, asList(0, 1L, 2F, 3D), true, null)) {
             @Override
             public boolean add(Object o) {

--- a/core/src/test/java/apoc/convert/ConvertJsonTest.java
+++ b/core/src/test/java/apoc/convert/ConvertJsonTest.java
@@ -123,17 +123,17 @@ public class ConvertJsonTest {
         }
     }
 
-    @Test public void testToJsonList() throws Exception {
+    @Test public void testToJsonList() {
 	    testCall(db, "RETURN apoc.convert.toJson([1,2,3]) as value",
 	             (row) -> assertEquals("[1,2,3]", row.get("value")) );
     }
-    @Test public void testToJsonMap() throws Exception {
+    @Test public void testToJsonMap() {
 	    testCall(db, "RETURN apoc.convert.toJson({a:42,b:\"foo\",c:[1,2,3]}) as value",
 	             (row) -> assertEquals("{\"a\":42,\"b\":\"foo\",\"c\":[1,2,3]}", row.get("value")) );
     }
 
     @Test
-    public void testToJsonNode() throws Exception {
+    public void testToJsonNode() {
 	    testCall(db, "CREATE (a:Test {foo: 7}) RETURN apoc.convert.toJson(a) AS value",
 	             (row) -> {
 	                Map<String, Object> valueAsMap = Util.readMap((String) row.get("value"));
@@ -154,7 +154,7 @@ public class ConvertJsonTest {
     }
 
     @Test
-    public void testToJsonNodeWithoutLabel() throws Exception {
+    public void testToJsonNodeWithoutLabel() {
         testCall(db, "CREATE (a {pippo:'pluto'}) RETURN apoc.convert.toJson(a) AS value",
                 (row) -> {
                     Map<String, Object> valueAsMap = Util.readMap((String) row.get("value"));
@@ -163,7 +163,7 @@ public class ConvertJsonTest {
     }
 
     @Test
-    public void testToJsonCollectNodes() throws Exception {
+    public void testToJsonCollectNodes() {
         db.executeTransactionally("CREATE (f:User {name:'Adam',age:42,male:true,kids:['Sam','Anna','Grace'], born:localdatetime('2015185T19:32:24'), place: point({x: 56.7, y: 12.78, z: 1.1, crs: 'wgs-84-3d'})}),(b:User {name:'Jim',age:42}),(c:User {age:12}),(d:User),(e {pippo:'pluto'})");
         String query = "MATCH (u) RETURN apoc.convert.toJson(collect(u)) as list";
         TestUtil.testCall(db, query, (row) -> {
@@ -203,13 +203,13 @@ public class ConvertJsonTest {
     }
 
     @Test
-    public void testToJsonProperties() throws Exception {
+    public void testToJsonProperties() {
         testCall(db, "CREATE (a:Test {foo: 7}) RETURN apoc.convert.toJson(properties(a)) AS value",
                 (row) -> assertMaps(Map.of("foo", 7L), Util.readMap((String) row.get("value"))) );
     }
 
     @Test
-    public void testToJsonMapOfNodes() throws Exception {
+    public void testToJsonMapOfNodes() {
         testCall(db, "CREATE (a:Test {foo: 7}), (b:Test {bar: 9}) RETURN apoc.convert.toJson({one: a, two: b}) AS value",
                 (row) -> {
                     Map<String, Object> map = Util.fromJson((String) row.get("value"), Map.class);
@@ -221,7 +221,7 @@ public class ConvertJsonTest {
     }
 
     @Test
-    public void testToJsonRel() throws Exception {
+    public void testToJsonRel() {
         testCall(db, "CREATE (f:User {name:'Adam'})-[rel:KNOWS {since: 1993.1, bffSince: duration('P5M1.5D')}]->(b:User {name:'Jim',age:42}) RETURN apoc.convert.toJson(rel) as value",
 	             (row) -> {
                      Map<String, Object> map = Util.fromJson((String) row.get("value"), Map.class);
@@ -233,7 +233,7 @@ public class ConvertJsonTest {
     }
 
     @Test
-    public void testToJsonPath() throws Exception {
+    public void testToJsonPath() {
 	    testCall(db, "CREATE p=(a:Test {foo: 7})-[:TEST]->(b:Baz {a:'b'})<-[:TEST_2 {aa:'bb'}]-(:Bar {one:'www', two:2, three: localdatetime('2020-01-01')}) RETURN apoc.convert.toJson(p) AS value",
 	             (row) -> {
                      List<String> test = List.of("Test");
@@ -261,7 +261,7 @@ public class ConvertJsonTest {
     }
 
     @Test
-    public void testToJsonListOfPath() throws Exception {
+    public void testToJsonListOfPath() {
         testCall( db, """
                           CREATE p=(a:Test {foo: 7})-[:TEST]->(b:Baa:Baz {a:'b'}), q=(:Omega {alpha: 'beta'})<-[:TEST_2 {aa:'bb'}]-(:Bar {one:'www'})
                           WITH collect(p) AS collectP, q RETURN apoc.convert.toJson(collectP+q) AS value""",
@@ -294,13 +294,13 @@ public class ConvertJsonTest {
                  });
     }
 
-    @Test public void testFromJsonList() throws Exception {
+    @Test public void testFromJsonList() {
 	    testCall(db, "RETURN apoc.convert.fromJsonList('[1,2,3]') as value",
 	             (row) -> assertEquals(asList(1L,2L,3L), row.get("value")) );
 	    testCall(db, "RETURN apoc.convert.fromJsonList('{\"foo\":[1,2,3]}','$.foo') as value",
 	             (row) -> assertEquals(asList(1L,2L,3L), row.get("value")) );
     }
-    @Test public void testFromJsonMap() throws Exception {
+    @Test public void testFromJsonMap() {
 	    testCall(db, "RETURN apoc.convert.fromJsonMap('{\"a\":42,\"b\":\"foo\",\"c\":[1,2,3]}')  as value",
 	             (row) -> {
 		           Map value = (Map)row.get("value");
@@ -310,25 +310,25 @@ public class ConvertJsonTest {
 		         });
     }
 
-    @Test public void testSetJsonProperty() throws Exception {
+    @Test public void testSetJsonProperty() {
         testCall(db, "CREATE (n) WITH n CALL apoc.convert.setJsonProperty(n, 'json', [1,2,3]) RETURN n",
                 (row) -> assertEquals("[1,2,3]", ((Node)row.get("n")).getProperty("json")));
     }
 
-    @Test public void testGetJsonProperty() throws Exception {
+    @Test public void testGetJsonProperty() {
         testCall(db, "CREATE (n {json:'[1,2,3]'}) RETURN apoc.convert.getJsonProperty(n, 'json') AS value",
                 (row) -> assertEquals(asList(1L,2L,3L), row.get("value")) );
         testCall(db, "CREATE (n {json:'{\"foo\":[1,2,3]}'}) RETURN apoc.convert.getJsonProperty(n, 'json','$.foo') AS value",
                 (row) -> assertEquals(asList(1L,2L,3L), row.get("value")) );
     }
-    @Test public void testGetJsonPropertyMap() throws Exception {
+    @Test public void testGetJsonPropertyMap() {
         testCall(db, "CREATE (n {json:'{a:[1,2,3]}'}) RETURN apoc.convert.getJsonProperty(n, 'json') as value",
                 (row) -> assertEquals(map("a",asList(1L,2L,3L)), row.get("value")) );
         testCall(db, "CREATE (n {json:'{a:[1,2,3]}'}) RETURN apoc.convert.getJsonProperty(n, 'json','$.a') as value",
                 (row) -> assertEquals(asList(1L,2L,3L), row.get("value")) );
     }
 
-    @Test public void testToTreeIssue1685() throws Exception {
+    @Test public void testToTreeIssue1685() {
         String movies = Util.readResourceFile("movies.cypher");
         db.executeTransactionally(movies);
 
@@ -380,7 +380,7 @@ public class ConvertJsonTest {
 	    db.executeTransactionally("MATCH (n:TreeNode) DETACH DELETE n");
     }
 
-    @Test public void testToTree() throws Exception {
+    @Test public void testToTree() {
         testCall(db, "CREATE p1=(m:Movie {title:'M'})<-[:ACTED_IN {role:'R1'}]-(:Actor {name:'A1'}), " +
                 " p2 = (m)<-[:ACTED_IN  {role:'R2'}]-(:Actor {name:'A2'}) WITH [p1,p2] as paths " +
                 " CALL apoc.convert.toTree(paths) YIELD value RETURN value",
@@ -394,7 +394,7 @@ public class ConvertJsonTest {
                     assertEquals(true, actors.get(0).get("acted_in.role").toString().matches("R[12]"));
                 });
     }
-    @Test public void testToTreeUpperCaseRels() throws Exception {
+    @Test public void testToTreeUpperCaseRels() {
         testCall(db, "CREATE p1=(m:Movie {title:'M'})<-[:ACTED_IN {role:'R1'}]-(:Actor {name:'A1'}), " +
                 " p2 = (m)<-[:ACTED_IN  {role:'R2'}]-(:Actor {name:'A2'}) WITH [p1,p2] as paths " +
                 " CALL apoc.convert.toTree(paths,false) YIELD value RETURN value",
@@ -408,7 +408,7 @@ public class ConvertJsonTest {
                     assertEquals(true, actors.get(0).get("ACTED_IN.role").toString().matches("R[12]"));
                 });
     }
-    @Test public void testTreeOfEmptyList() throws Exception {
+    @Test public void testTreeOfEmptyList() {
         testCall(db, " CALL apoc.convert.toTree([]) YIELD value RETURN value",
                 (row) -> {
                     Map root = (Map) row.get("value");
@@ -416,7 +416,7 @@ public class ConvertJsonTest {
                 });
     }
 
-    @Test public void testToTreeLeafNodes() throws Exception {
+    @Test public void testToTreeLeafNodes() {
         String createStatement = "CREATE\n" +
                 "  (c1:Category {name: 'PC'}),\n" +
                 "    (c1)-[:subcategory {id:1}]->(c2:Category {name: 'Parts'}),\n" +
@@ -446,12 +446,12 @@ public class ConvertJsonTest {
                     assertEquals("CPU", cpu.get("name"));
                 });
     }
-    @Test public void testToJsonMapSortingProperties() throws Exception {
+    @Test public void testToJsonMapSortingProperties() {
         testCall(db, "WITH {b:8, d:3, a:2, E: 12, C:9} as map RETURN apoc.convert.toSortedJsonMap(map, false) as value",
                 (row) -> assertEquals("{\"C\":9,\"E\":12,\"a\":2,\"b\":8,\"d\":3}", row.get("value")) );
     }
 
-    @Test public void testToJsonMapSortingPropertiesIgnoringCase() throws Exception {
+    @Test public void testToJsonMapSortingPropertiesIgnoringCase() {
         testCall(db, "WITH {b:8, d:3, a:2, E: 12, C:9} as map RETURN apoc.convert.toSortedJsonMap(map) as value",
                 (row) -> assertEquals("{\"a\":2,\"b\":8,\"C\":9,\"d\":3,\"E\":12}", row.get("value")) );
     }

--- a/core/src/test/java/apoc/convert/ConvertJsonTest.java
+++ b/core/src/test/java/apoc/convert/ConvertJsonTest.java
@@ -44,7 +44,8 @@ public class ConvertJsonTest {
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
 
-	@Before public void setUp() throws Exception {
+	@Before
+    public void setUp() {
         TestUtil.registerProcedure(db, Json.class);
     }
     

--- a/core/src/test/java/apoc/convert/ConvertTest.java
+++ b/core/src/test/java/apoc/convert/ConvertTest.java
@@ -28,12 +28,12 @@ public class ConvertTest {
     public static DbmsRule db = new ImpermanentDbmsRule();
 
     @BeforeClass
-    public static void initDb() throws Exception {
+    public static void initDb() {
         TestUtil.registerProcedure(db, Convert.class);
     }
 
     @Test
-    public void testToMap() throws Exception {
+    public void testToMap() {
         testCall(db, "return apoc.convert.toMap($a) as value", map("a", map("a", "b")), r -> assertEquals(map("a", "b"), r.get("value")));
         testCall(db, "return apoc.convert.toMap($a) as value", map("a", null), r -> assertEquals(null, r.get("value")));
         final Map<String, Object> props = map("name", "John", "age", 39);
@@ -41,7 +41,7 @@ public class ConvertTest {
     }
 
     @Test
-    public void testToList() throws Exception {
+    public void testToList() {
         testCall(db, "return apoc.convert.toList($a) as value", map("a", null), r -> assertEquals(null, r.get("value")));
         testCall(db, "return apoc.convert.toList($a) as value", map("a", new Object[]{"a"}), r -> assertEquals(singletonList("a"), r.get("value")));
         testCall(db, "return apoc.convert.toList($a) as value", map("a", singleton("a")), r -> assertEquals(singletonList("a"), r.get("value")));
@@ -50,21 +50,21 @@ public class ConvertTest {
     }
 
     @Test
-    public void testToNode() throws Exception {
+    public void testToNode() {
         testCall(db, "CREATE (n) WITH [n] as x RETURN apoc.convert.toNode(x[0]) as node",
                 r -> assertEquals(true, r.get("node") instanceof Node));
         testCall(db, "RETURN apoc.convert.toNode(null) AS node", r -> assertEquals(null, r.get("node")));
     }
 
     @Test
-    public void testToRelationship() throws Exception {
+    public void testToRelationship() {
         testCall(db, "CREATE (n)-[r:KNOWS]->(m) WITH [r] as x RETURN apoc.convert.toRelationship(x[0]) AS rel",
                 r -> assertEquals(true, r.get("rel") instanceof Relationship));
         testCall(db, "RETURN apoc.convert.toRelationship(null) AS rel", r -> assertEquals(null, r.get("rel")));
     }
 
     @Test
-    public void testToSet() throws Exception {
+    public void testToSet() {
         testCall(db, "return apoc.convert.toSet($a) as value", map("a", null), r -> assertEquals(null, r.get("value")));
         testCall(db, "return apoc.convert.toSet($a) as value", map("a", new Object[]{"a"}), r -> assertEquals(singletonList("a"), r.get("value")));
         testCall(db, "return apoc.convert.toSet($a) as value", map("a", singleton("a")), r -> assertEquals(singletonList("a"), r.get("value")));
@@ -73,7 +73,7 @@ public class ConvertTest {
     }
 
     @Test
-    public void testToNodeList() throws Exception {
+    public void testToNodeList() {
         testCall(db, "CREATE (n) WITH [n] as x RETURN apoc.convert.toNodeList(x) as nodes",
                 r -> {
 					assertEquals(true, r.get("nodes") instanceof List);
@@ -83,7 +83,7 @@ public class ConvertTest {
     }
 
     @Test
-    public void testToRelationshipList() throws Exception {
+    public void testToRelationshipList() {
         testCall(db, "CREATE (n)-[r:KNOWS]->(m) WITH [r] as x  RETURN apoc.convert.toRelationshipList(x) as rels",
                 r -> {
 					assertEquals(true, r.get("rels") instanceof List);

--- a/core/src/test/java/apoc/create/CreateTest.java
+++ b/core/src/test/java/apoc/create/CreateTest.java
@@ -41,7 +41,7 @@ public class CreateTest {
     }
 
     @Test
-    public void testCreateNode() throws Exception {
+    public void testCreateNode() {
         testCall(db, "CALL apoc.create.node(['Person'],{name:'John'})",
                 (row) -> {
                     Node node = (Node) row.get("node");
@@ -51,7 +51,7 @@ public class CreateTest {
     }
 
     @Test
-    public void testCreateNodeWithArrayProps() throws Exception {
+    public void testCreateNodeWithArrayProps() {
         testCall(db, "CALL apoc.create.node(['Person'],{name:['John','Doe'],kids:[],age:[32,10]})",
                 (row) -> {
                     Node node = (Node) row.get("node");
@@ -63,7 +63,7 @@ public class CreateTest {
     }
 
     @Test
-    public void testSetProperty() throws Exception {
+    public void testSetProperty() {
         testResult(db, "CREATE (n),(m) WITH n,m CALL apoc.create.setProperty([id(n),m],'name','John') YIELD node RETURN node",
                 (result) -> {
                     Map<String, Object> row = result.next();
@@ -75,7 +75,7 @@ public class CreateTest {
     }
 
     @Test
-    public void testRemoveProperty() throws Exception {
+    public void testRemoveProperty() {
         testCall(db, "CREATE (n:Foo {name:'foo'}) WITH n CALL apoc.create.setProperty(n,'name',null) YIELD node RETURN node",
                 (row) -> assertEquals(false, ((Node) row.get("node")).hasProperty("name")));
         testCall(db, "CREATE (n:Foo {name:'foo'}) WITH n CALL apoc.create.removeProperties(n,['name']) YIELD node RETURN node",
@@ -83,7 +83,7 @@ public class CreateTest {
     }
 
     @Test
-    public void testRemoveRelProperty() throws Exception {
+    public void testRemoveRelProperty() {
         testCall(db, "CREATE (n)-[r:TEST {name:'foo'}]->(m) WITH r CALL apoc.create.setRelProperty(r,'name',null) YIELD rel RETURN rel",
                 (row) -> assertEquals(false, ((Relationship) row.get("rel")).hasProperty("name")));
         testCall(db, "CREATE (n)-[r:TEST {name:'foo'}]->(m) WITH r CALL apoc.create.removeRelProperties(r,['name']) YIELD rel RETURN rel",
@@ -91,7 +91,7 @@ public class CreateTest {
     }
 
     @Test
-    public void testSetRelProperties() throws Exception {
+    public void testSetRelProperties() {
         testResult(db, "CREATE (n)-[r:X]->(m),(m)-[r2:Y]->(n) WITH r,r2 CALL apoc.create.setRelProperties([id(r),r2],['name','age'],['John',42]) YIELD rel RETURN rel",
                 (result) -> {
                     Map<String, Object> row = result.next();
@@ -107,7 +107,7 @@ public class CreateTest {
     }
 
     @Test
-    public void testSetRelProperty() throws Exception {
+    public void testSetRelProperty() {
         testResult(db, "CREATE (n)-[r:X]->(m),(m)-[r2:Y]->(n) WITH r,r2 CALL apoc.create.setRelProperty([id(r),r2],'name','John') YIELD rel RETURN rel",
                 (result) -> {
                     Map<String, Object> row = result.next();
@@ -119,7 +119,7 @@ public class CreateTest {
     }
 
     @Test
-    public void testSetProperties() throws Exception {
+    public void testSetProperties() {
         testResult(db, "CREATE (n),(m) WITH n,m CALL apoc.create.setProperties([id(n),m],['name','age'],['John',42]) YIELD node RETURN node",
                 (result) -> {
                     Map<String, Object> row = result.next();
@@ -133,7 +133,7 @@ public class CreateTest {
     }
 
     @Test
-    public void testVirtualNode() throws Exception {
+    public void testVirtualNode() {
         testCall(db, "CALL apoc.create.vNode(['Person'],{name:'John'})",
                 (row) -> {
                     Node node = (Node) row.get("node");
@@ -143,7 +143,7 @@ public class CreateTest {
     }
 
     @Test
-    public void testVirtualNodeFunction() throws Exception {
+    public void testVirtualNodeFunction() {
         testCall(db, "RETURN apoc.create.vNode(['Person'],{name:'John'}) as node",
                 (row) -> {
                     Node node = (Node) row.get("node");
@@ -153,7 +153,7 @@ public class CreateTest {
     }
 
     @Test
-    public void testCreateNodes() throws Exception {
+    public void testCreateNodes() {
         testResult(db, "CALL apoc.create.nodes(['Person'],[{name:'John'},{name:'Jane'}])",
                 (res) -> {
                     Node node = (Node) res.next().get("node");
@@ -167,7 +167,7 @@ public class CreateTest {
     }
 
     @Test
-    public void testCreateRelationship() throws Exception {
+    public void testCreateRelationship() {
         testCall(db, "CREATE (n),(m) WITH n,m CALL apoc.create.relationship(n,'KNOWS',{since:2010}, m) YIELD rel RETURN rel",
                 (row) -> {
                     Relationship rel = (Relationship) row.get("rel");
@@ -177,7 +177,7 @@ public class CreateTest {
     }
 
     @Test
-    public void testCreateVirtualRelationship() throws Exception {
+    public void testCreateVirtualRelationship() {
         testCall(db, "CREATE (n),(m) WITH n,m CALL apoc.create.vRelationship(n,'KNOWS',{since:2010}, m) YIELD rel RETURN rel",
                 (row) -> {
                     Relationship rel = (Relationship) row.get("rel");
@@ -187,7 +187,7 @@ public class CreateTest {
     }
 
     @Test
-    public void testCreateVirtualRelationshipFunction() throws Exception {
+    public void testCreateVirtualRelationshipFunction() {
         testCall(db, "CREATE (n),(m) WITH n,m RETURN apoc.create.vRelationship(n,'KNOWS',{since:2010}, m) AS rel",
                 (row) -> {
                     Relationship rel = (Relationship) row.get("rel");
@@ -197,7 +197,7 @@ public class CreateTest {
     }
 
     @Test
-    public void testCreatePattern() throws Exception {
+    public void testCreatePattern() {
         testCall(db, "CALL apoc.create.virtualPath(['Person'],{name:'John'},'KNOWS',{since:2010},['Person'],{name:'Jane'})",
                 (row) -> {
                     Node john = (Node) row.get("from");
@@ -213,7 +213,7 @@ public class CreateTest {
     }
 
     @Test
-    public void testVirtualFromNodeFunction() throws Exception {
+    public void testVirtualFromNodeFunction() {
         testCall(db, "CREATE (n:Person{name:'Vincent', born: 1974} )  RETURN apoc.create.virtual.fromNode(n, ['name']) as node",
                 (row) -> {
                     Node node = (Node) row.get("node");

--- a/core/src/test/java/apoc/create/CreateTest.java
+++ b/core/src/test/java/apoc/create/CreateTest.java
@@ -36,7 +36,7 @@ public class CreateTest {
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
 
-    @Before public void setUp() throws Exception {
+    @Before public void setUp() {
         TestUtil.registerProcedure(db,Create.class, Paths.class);
     }
 

--- a/core/src/test/java/apoc/data/url/ExtractURLTest.java
+++ b/core/src/test/java/apoc/data/url/ExtractURLTest.java
@@ -22,7 +22,7 @@ public class ExtractURLTest {
     private static HashMap<String,Map<String,Object>> testCases;
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, ExtractURL.class);
 
         // Test cases map URLs to an array of strings representing what their correct answers should

--- a/core/src/test/java/apoc/date/DateTest.java
+++ b/core/src/test/java/apoc/date/DateTest.java
@@ -51,46 +51,46 @@ public class DateTest {
 	private static final long SECONDS_PER_DAY = SECONDS_PER_HOUR * 24;
 
 	@BeforeClass
-	public static void sUp() throws Exception {
+	public static void sUp() {
 		TestUtil.registerProcedure(db, Date.class, TemporalProcedures.class);
 	}
 
-	@Test public void testToDays() throws Exception {
+	@Test public void testToDays() {
 		testCall(db,
 				"RETURN apoc.date.parse($date,'d') AS value",
 				map("date",testDateAsString),
 				row -> assertEquals(testDate.toInstant(), Instant.ofEpochSecond (SECONDS_PER_DAY * (long) row.get("value"))));
 	}
 
-	@Test public void testToHours() throws Exception {
+	@Test public void testToHours() {
 		testCall(db,
 				"RETURN apoc.date.parse($date,'h') AS value",
 				map("date",testDateAsString),
 				row -> assertEquals(testDate.toInstant(), Instant.ofEpochSecond (SECONDS_PER_HOUR * (long) row.get("value"))));
 	}
 
-	@Test public void testToMinutes() throws Exception {
+	@Test public void testToMinutes() {
 		testCall(db,
 				"RETURN apoc.date.parse($date,'m') AS value",
 				map("date",testDateAsString),
 				row -> assertEquals(testDate.toInstant(), Instant.ofEpochSecond (SECONDS_PER_MINUTE * (long) row.get("value"))));
 	}
 
-	@Test public void testToUnixtime() throws Exception {
+	@Test public void testToUnixtime() {
 		testCall(db,
 				"RETURN apoc.date.parse($date,'s') AS value",
 				map("date",epochAsString),
 				row -> assertEquals(Instant.EPOCH, Instant.ofEpochSecond((long) row.get("value"))));
 	}
 
-	@Test public void testToMillis() throws Exception {
+	@Test public void testToMillis() {
 		testCall(db,
 				"RETURN apoc.date.parse($date,'ms') AS value",
 				map("date",epochAsString),
 				row -> assertEquals(Instant.EPOCH, Instant.ofEpochMilli((long) row.get("value"))));
 	}
 
-	@Test public void testToUnixtimeWithCorrectFormat() throws Exception {
+	@Test public void testToUnixtimeWithCorrectFormat() {
 		String pattern = "MM/dd/yyyy HH:mm:ss";
 		SimpleDateFormat customFormat = formatInUtcZone(pattern);
 		String reference = customFormat.format(new java.util.Date(0L));
@@ -100,25 +100,25 @@ public class DateTest {
 				row -> assertEquals(Instant.EPOCH, Instant.ofEpochSecond((long) row.get("value"))));
 	}
 
-	@Test public void testToUnixtimeWithIncorrectPatternFormat() throws Exception {
+	@Test public void testToUnixtimeWithIncorrectPatternFormat() {
 		expected.expect(instanceOf(QueryExecutionException.class));
 		testCall(db,
 				"RETURN apoc.date.parse('12/12/1945 12:12:12','s','MM/dd/yyyy HH:mm:ss/neo4j') AS value",
 				row -> assertEquals(Instant.EPOCH, Instant.ofEpochSecond((long) row.get("value"))));
 	}
 
-	@Test public void testToUnixtimeWithNullInput() throws Exception {
+	@Test public void testToUnixtimeWithNullInput() {
 		testCall(db,
 				"RETURN apoc.date.parse(NULL,'s') AS value",
 				row -> assertNull(row.get("value")));
 	}
 
 	@Test 
-	public void testToUnixtimeWithEmptyInput() throws Exception {
+	public void testToUnixtimeWithEmptyInput() {
 		testCall(db, "RETURN apoc.date.parse(' ','s') AS value", row -> assertNull(row.get("value")));
 	}
 
-	@Test public void testFromUnixtime() throws Exception {
+	@Test public void testFromUnixtime() {
 		testCall(db,
 				"RETURN apoc.date.format(0,'s') AS value",
 				row -> {
@@ -130,34 +130,34 @@ public class DateTest {
 				});
 	}
 
-	@Test public void testFromUnixtimeWithNullInputReturnsNull() throws Exception {
+	@Test public void testFromUnixtimeWithNullInputReturnsNull() {
 		testCall(db,
 				"RETURN apoc.date.format(null,'s') AS value",
 				row -> assertEquals(null, row.get("value")));
 	}
 
-	@Test public void testParseAsZonedDateTimeWithCorrectFormat() throws Exception {
+	@Test public void testParseAsZonedDateTimeWithCorrectFormat() {
 		testCall(db,
 				"RETURN apoc.temporal.toZonedTemporal('03/23/1965 00:00:00','MM/dd/yyyy HH:mm:ss','America/New_York') AS value",
 				row -> assertEquals(ZonedDateTime.of(LocalDateTime.of(1965, 3, 23, 0, 0), ZoneId.of("America/New_York")),
 						row.get("value")));
 	}
 
-	@Test public void testParseAsZonedDateTimeWithDefaultTimezone() throws Exception {
+	@Test public void testParseAsZonedDateTimeWithDefaultTimezone() {
 		testCall(db,
 				"RETURN apoc.temporal.toZonedTemporal('03/23/1965 00:00:00','MM/dd/yyyy HH:mm:ss') AS value",
 				row -> assertEquals(ZonedDateTime.of(LocalDateTime.of(1965, 3, 23, 0, 0), ZoneId.of("UTC")),
 						row.get("value")));
 	}
 
-	@Test public void testParseAsZonedDateTimeWithDefaultFormatAndTimezone() throws Exception {
+	@Test public void testParseAsZonedDateTimeWithDefaultFormatAndTimezone() {
 		testCall(db,
 				"RETURN apoc.temporal.toZonedTemporal('1965-03-23 00:00:00') AS value",
 				row -> assertEquals(ZonedDateTime.of(LocalDateTime.of(1965, 3, 23, 0, 0), ZoneId.of("UTC")),
 						row.get("value")));
 	}
 
-	@Test public void testParseAsZonedDateTimeWithIncorrectPatternFormat() throws Exception {
+	@Test public void testParseAsZonedDateTimeWithIncorrectPatternFormat() {
 		expected.expect(instanceOf(QueryExecutionException.class));
 		testCall(db,
 				"RETURN apoc.temporal.toZonedTemporal('03/23/1965 00:00:00','MM/dd/yyyy HH:mm:ss/neo4j','America/New_York') AS value",
@@ -165,25 +165,25 @@ public class DateTest {
 						row.get("value")));
 	}
 
-	@Test public void testToZonedDateTimeWithNullInput() throws Exception {
+	@Test public void testToZonedDateTimeWithNullInput() {
 		testCall(db,
 				"RETURN apoc.temporal.toZonedTemporal(NULL) AS value",
 				row -> assertNull(row.get("value")));
 	}
 
-	@Test public void testToISO8601() throws Exception {
+	@Test public void testToISO8601() {
 		testCall(db,
 				"RETURN apoc.date.toISO8601(0) AS value",
 				row -> assertEquals("1970-01-01T00:00:00.000Z", row.get("value")));
 	}
 
-	@Test public void testFromISO8601() throws Exception {
+	@Test public void testFromISO8601() {
 		testCall(db,
 				"RETURN apoc.date.fromISO8601('1970-01-01T00:00:00.000Z') AS value",
 				row -> assertEquals(0L, row.get("value")));
 	}
 
-	@Test public void testFromUnixtimeWithCorrectFormat() throws Exception {
+	@Test public void testFromUnixtimeWithCorrectFormat() {
 		String pattern = "MM/dd/yyyy HH:mm:ss";
 		SimpleDateFormat customFormat = formatInUtcZone(pattern);
 		testCall(db,
@@ -198,7 +198,7 @@ public class DateTest {
 				});
 	}
 
-	@Test public void testFromUnixtimeWithCorrectFormatAndTimeZone() throws Exception {
+	@Test public void testFromUnixtimeWithCorrectFormatAndTimeZone() {
 		String pattern = "MM/dd/yyyy HH:mm:ss";
 		String timezone = "America/New_York";
 		SimpleDateFormat customFormat = formatInCustomTimeZone(pattern, timezone);
@@ -214,35 +214,35 @@ public class DateTest {
 				});
 	}
 
-	@Test public void testFromUnixtimeWithIncorrectPatternFormat() throws Exception {
+	@Test public void testFromUnixtimeWithIncorrectPatternFormat() {
 		expected.expect(instanceOf(QueryExecutionException.class));
 		testCall(db,
 				"RETURN apoc.date.format(0,'s','MM/dd/yyyy HH:mm:ss/neo4j') AS value",
 				row -> {});
 	}
 
-	@Test public void testFromUnixtimeWithIncorrectPatternFormatAndTimeZone() throws Exception {
+	@Test public void testFromUnixtimeWithIncorrectPatternFormatAndTimeZone() {
 		expected.expect(instanceOf(QueryExecutionException.class));
 		testCall(db,
 				"RETURN apoc.date.formatTimeZone(0,'s','MM/dd/yyyy HH:mm:ss/neo4j','Neo4j/Apoc') AS value",
 				row -> {});
 	}
 
-	@Test public void testFromUnixtimeWithNegativeInputDoesNotThrowException() throws Exception {
+	@Test public void testFromUnixtimeWithNegativeInputDoesNotThrowException() {
 		testCall(db, "RETURN apoc.date.format(-1,'s') AS value", row -> {});
 	}
 
-	@Test public void testWrongUnitDoesThrowException() throws Exception {
+	@Test public void testWrongUnitDoesThrowException() {
 		expected.expect(instanceOf(RuntimeException.class));
 		testCall(db, "RETURN apoc.date.format(-1,'wrong') AS value", row -> {});
 	}
 
-	@Test public void testWrongPatternDoesThrowException() throws Exception {
+	@Test public void testWrongPatternDoesThrowException() {
 		expected.expect(instanceOf(RuntimeException.class));
 		testCall(db, "RETURN apoc.date.format(-1,'s','aaaa-bb-cc') AS value", row -> {});
 	}
 
-	@Test public void testOrderByDate() throws Exception {
+	@Test public void testOrderByDate() {
 		SimpleDateFormat format = formatInUtcZone("yyyy-MM-dd HH:mm:ss");
 		try (Transaction tx = db.beginTx()) {
 			for (int i = 0 ; i < 8; i++) {
@@ -275,7 +275,7 @@ public class DateTest {
 	}
 
 	@Test
-	public void testfields() throws Exception {
+	public void testfields() {
 		testCall(db,
 				"RETURN apoc.date.fields('2015-01-02 03:04:05') AS value",
 				row -> {
@@ -291,7 +291,7 @@ public class DateTest {
 	}
 
 	@Test
-	public void testfieldsCustomFormat() throws Exception {
+	public void testfieldsCustomFormat() {
 		testCall(db,
 				"RETURN apoc.date.fields('2015-01-02 03:04:05 EET', 'yyyy-MM-dd HH:mm:ss zzz') AS m",
 				row -> {
@@ -339,7 +339,7 @@ public class DateTest {
 	}
 
 	@Test
-	public void testfieldsNullInput() throws Exception {
+	public void testfieldsNullInput() {
 		testCall(db,
 				"RETURN apoc.date.fields(NULL, 'yyyy-MM-dd HH:mm:ss zzz') AS value",
 				row -> {
@@ -349,7 +349,7 @@ public class DateTest {
 	}
 
 	@Test
-	public void testfield() throws Exception {
+	public void testfield() {
 		long epoch = LocalDateTime.of( 1982, 1, 23, 22, 30, 42 )
 				.atZone( ZoneId.of( "UTC" ) )
 				.toInstant()
@@ -360,7 +360,7 @@ public class DateTest {
 	}
 
 	@Test
-	public void testfieldCustomField() throws Exception {
+	public void testfieldCustomField() {
 		long epoch = LocalDateTime.of( 1982, 1, 23, 22, 30 )
 				.atZone( ZoneId.of( "UTC" ) )
 				.toInstant()
@@ -371,7 +371,7 @@ public class DateTest {
 	}
 
 	@Test
-	public void testfieldAll() throws Exception {
+	public void testfieldAll() {
 		long epoch = LocalDateTime.of(2015, 1, 2, 3, 4, 5)
 				.atZone(ZoneId.of("UTC"))
 				.toInstant()
@@ -395,31 +395,31 @@ public class DateTest {
 	}
 
 	@Test
-	public void testfieldNullInput() throws Exception {
+	public void testfieldNullInput() {
 		testCall(db,
 				"RETURN apoc.date.field(NULL) AS value",
 				row -> assertTrue(isNull(row.get("value"))));
 	}
 
 	@Test
-	public void testDateParserDifference() throws Exception {
+	public void testDateParserDifference() {
 		String dateDelta = "RETURN apoc.date.parse('2012-10-04','ms','yyyy-MM-dd') - apoc.date.parse('2012-10-04 00:00:00') as delta";
 		testCall(db, dateDelta, row -> assertTrue(3600*1000*24 > (long)row.get("delta")));
 	}
 
 	@Test
-	public void toYears() throws Exception {
+	public void toYears() {
 		testCall(db, "RETURN apoc.date.toYears('2012-10-04','YYYY-MM-dd') as years", row -> assertEquals(2012d, (double)row.get("years"),0.5d));
 		testCall(db, "RETURN apoc.date.toYears(apoc.date.parse('2012','ms','YYYY') - apoc.date.parse('2008','ms','YYYY')) as years", row -> assertEquals(4d, (double)row.get("years"),0.5d));
 	}
 
 	@Test
-	public void testGetTimezone() throws Exception {
+	public void testGetTimezone() {
 		testCall(db, "RETURN apoc.date.systemTimezone() as tz", row -> assertEquals(TimeZone.getDefault().getID(), row.get("tz").toString()));
 	}
 
 	@Test
-	public void testConvert() throws Exception {
+	public void testConvert() {
 		Long firstOf2017ms = 1483228800000l;
 		Long firstOf2017d = 17167l;
 		Map<String, Object> params = new HashMap<>();
@@ -428,7 +428,7 @@ public class DateTest {
 	}
 
 	@Test
-	public void testAdd() throws Exception {
+	public void testAdd() {
 		Long firstOf2017ms = 1483228800000l;
 		Long firstOf2017Plus5Daysms = 1483660800000l;
 		Map<String, Object> params = new HashMap<>();
@@ -437,7 +437,7 @@ public class DateTest {
 	}
 
 	@Test
-	public void testAddNegative() throws Exception {
+	public void testAddNegative() {
 		Long firstOf2017ms = 1483228800000l;
 		Long firstOf2017Minus5Daysms = 1482796800000l;
 		Map<String, Object> params = new HashMap<>();
@@ -446,7 +446,7 @@ public class DateTest {
 	}
 
 	@Test
-	public void testConvertFormats() throws Exception {
+	public void testConvertFormats() {
 		String rfcDateTime = "Tue, 14 May 2019 14:52:06 -0400";
 		String isoDateTime = "2019-05-14T14:52:06-04:00";
 		Map<String, Object> params = new HashMap<>();

--- a/core/src/test/java/apoc/diff/DiffTest.java
+++ b/core/src/test/java/apoc/diff/DiffTest.java
@@ -31,7 +31,7 @@ public class DiffTest {
     public static DbmsRule db = new ImpermanentDbmsRule();
 
     @BeforeClass
-    public static void setup() throws Exception {
+    public static void setup() {
         TestUtil.registerProcedure(db, Diff.class, Create.class);
 
         try (Transaction tx = db.beginTx()) {

--- a/core/src/test/java/apoc/example/ExamplesTest.java
+++ b/core/src/test/java/apoc/example/ExamplesTest.java
@@ -19,7 +19,7 @@ public class ExamplesTest {
     public DbmsRule db = new ImpermanentDbmsRule();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         TestUtil.registerProcedure(db,Examples.class);
     }
 

--- a/core/src/test/java/apoc/example/ExamplesTest.java
+++ b/core/src/test/java/apoc/example/ExamplesTest.java
@@ -24,7 +24,7 @@ public class ExamplesTest {
     }
 
     @Test
-    public void testMovies() throws Exception {
+    public void testMovies() {
         TestUtil.testCall(db,"CALL apoc.example.movies", r -> {
             assertEquals("movies.cypher",r.get("file"));
             assertEquals(169L,r.get("nodes"));

--- a/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
+++ b/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
@@ -46,7 +46,7 @@ public class ExportCoreSecurityTest {
             .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath());
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, ExportCSV.class, ExportJson.class, ExportGraphML.class, ExportCypher.class);
         ApocConfig.apocConfig().setProperty(ApocConfig.APOC_EXPORT_FILE_ENABLED, false);
     }

--- a/core/src/test/java/apoc/export/ExportStreamsStatementsTest.java
+++ b/core/src/test/java/apoc/export/ExportStreamsStatementsTest.java
@@ -25,7 +25,7 @@ public class ExportStreamsStatementsTest {
             .withSetting(newBuilder( "internal.dbms.debug.trace_cursors", BOOL, false ).build(), false);
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, ExportCSV.class, ExportCypher.class, ExportJson.class);
         db.executeTransactionally("CREATE (f:User:Customer {name:'Foo', age:42})-[:BOUGHT]->(b:Product {name:'Apple Watch Series 4'})");
     }

--- a/core/src/test/java/apoc/export/ExportStreamsStatementsTest.java
+++ b/core/src/test/java/apoc/export/ExportStreamsStatementsTest.java
@@ -26,7 +26,6 @@ public class ExportStreamsStatementsTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        //apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
         TestUtil.registerProcedure(db, ExportCSV.class, ExportCypher.class, ExportJson.class);
         db.executeTransactionally("CREATE (f:User:Customer {name:'Foo', age:42})-[:BOUGHT]->(b:Product {name:'Apple Watch Series 4'})");
     }

--- a/core/src/test/java/apoc/export/csv/ExportCsvIT.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvIT.java
@@ -8,7 +8,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.neo4j.driver.Session;
 
-import java.io.IOException;
 import java.util.List;
 
 import static apoc.util.MapUtil.map;
@@ -43,14 +42,14 @@ public class ExportCsvIT {
     }
 
     @AfterClass
-    public static void afterAll() throws IOException, InterruptedException {
+    public static void afterAll() {
         if (neo4jContainer != null && neo4jContainer.isRunning()) {
             neo4jContainer.close();
         }
     }
 
     @Test
-    public void testExportQueryCsvIssue1188() throws Exception {
+    public void testExportQueryCsvIssue1188() {
         String copyright = "\n" +
                 "(c) 2018 Hovsepian, Albanese, et al. \"\"ASCB(r),\"\" \"\"The American Society for Cell Biology(r),\"\" and \"\"Molecular Biology of the Cell(r)\"\" are registered trademarks of The American Society for Cell Biology.\n" +
                 "2018\n" +

--- a/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
@@ -142,7 +142,7 @@ public class ExportCsvNeo4jAdminTest {
     }
 
     @Test
-    public void testExportGraphNeo4jAdminCsv() throws Exception {
+    public void testExportGraphNeo4jAdminCsv() {
         String fileName = "graph.csv";
         File output = new File(directory, fileName);
         String separator = ";";
@@ -204,7 +204,7 @@ public class ExportCsvNeo4jAdminTest {
     }
 
     @Test(expected = RuntimeException.class)
-    public void testCypherExportCsvForAdminNeo4jImportExceptionBulk() throws Exception {
+    public void testCypherExportCsvForAdminNeo4jImportExceptionBulk() {
         String fileName = "query_nodes.csv";
         try {
             TestUtil.testCall(db, "CALL apoc.export.csv.query('MATCH (n) return (n)',$fileName,{bulkImport: true})",
@@ -228,7 +228,7 @@ public class ExportCsvNeo4jAdminTest {
     }
 
     @Test
-    public void testExportCypherWithIdField() throws Exception {
+    public void testExportCypherWithIdField() {
         // given
         db.executeTransactionally("MATCH (n) DETACH DELETE n");
         final Map<String, Object> map = db.executeTransactionally("CREATE (source:User:Larus{id: 1, name: 'Andrea'})-[:KNOWS{id: 10}]->(target:User:Neo4j{id: 2, name: 'Michael'})\n" +

--- a/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
@@ -88,7 +88,7 @@ public class ExportCsvNeo4jAdminTest {
             .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath());
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
         TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class);
         db.executeTransactionally("CREATE (f:User1:User {name:'foo',age:42,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})");

--- a/core/src/test/java/apoc/export/csv/ExportCsvS3Test.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvS3Test.java
@@ -3,7 +3,6 @@ package apoc.export.csv;
 import apoc.graph.Graphs;
 import apoc.util.TestUtil;
 import apoc.util.s3.S3TestUtil;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -106,10 +105,6 @@ public class ExportCsvS3Test {
         TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class);
         db.executeTransactionally("CREATE (f:User1:User {name:'foo',age:42,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})");
         db.executeTransactionally("CREATE (f:Address1:Address {name:'Andrea', city: 'Milano', street:'Via Garibaldi, 7'})-[:NEXT_DELIVERY]->(a:Address {name: 'Bar Sport'}), (b:Address {street: 'via Benni'})");
-    }
-
-    @AfterClass
-    public static void tearDown() {
     }
 
     private static String getS3Url(String key) {

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -143,7 +143,7 @@ public class ExportCsvTest {
     }
 
     @Test
-    public void testExportInvalidQuoteValue() throws Exception {
+    public void testExportInvalidQuoteValue() {
         try {
             String fileName = "all.csv";
             TestUtil.testCall(db, "CALL apoc.export.csv.all($file,{quotes: 'Invalid'})",
@@ -191,7 +191,7 @@ public class ExportCsvTest {
     }
 
     @Test
-    public void testExportAllCsv() throws Exception {
+    public void testExportAllCsv() {
         String fileName = "all.csv";
         TestUtil.testCall(db, "CALL apoc.export.csv.all($file,null)", map("file", fileName),
                 (r) -> assertResults(fileName, r, "database"));
@@ -222,7 +222,7 @@ public class ExportCsvTest {
     }
 
     @Test
-    public void testExportAllCsvWithQuotes() throws Exception {
+    public void testExportAllCsvWithQuotes() {
         String fileName = "all.csv";
         TestUtil.testCall(db, "CALL apoc.export.csv.all($file,{quotes: true})",
                 map("file", fileName),
@@ -231,7 +231,7 @@ public class ExportCsvTest {
     }
 
     @Test
-    public void testExportAllCsvWithoutQuotes() throws Exception {
+    public void testExportAllCsvWithoutQuotes() {
         String fileName = "all.csv";
         TestUtil.testCall(db, "CALL apoc.export.csv.all($file,{quotes: 'none'})",
                 map("file", fileName),
@@ -240,7 +240,7 @@ public class ExportCsvTest {
     }
 
     @Test
-    public void testExportAllCsvNeededQuotes() throws Exception {
+    public void testExportAllCsvNeededQuotes() {
         String fileName = "all.csv";
         TestUtil.testCall(db, "CALL apoc.export.csv.all($file,{quotes: 'ifNeeded'})",
                 map("file", fileName),
@@ -249,7 +249,7 @@ public class ExportCsvTest {
     }
 
     @Test
-    public void testExportGraphCsv() throws Exception {
+    public void testExportGraphCsv() {
         String fileName = "graph.csv";
         TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
                         "CALL apoc.export.csv.graph(graph, $file,{quotes: 'none'}) " +
@@ -260,7 +260,7 @@ public class ExportCsvTest {
     }
 
     @Test
-    public void testExportGraphCsvWithoutQuotes() throws Exception {
+    public void testExportGraphCsvWithoutQuotes() {
         String fileName = "graph.csv";
         TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
                         "CALL apoc.export.csv.graph(graph, $file,null) " +
@@ -271,7 +271,7 @@ public class ExportCsvTest {
     }
 
     @Test
-    public void testExportQueryCsv() throws Exception {
+    public void testExportQueryCsv() {
         String fileName = "query.csv";
         String query = "MATCH (u:User) return u.age, u.name, u.male, u.kids, labels(u)";
         TestUtil.testCall(db, "CALL apoc.export.csv.query($query,$file,null)",
@@ -286,7 +286,7 @@ public class ExportCsvTest {
     }
 
     @Test
-    public void testExportQueryCsvWithoutQuotes() throws Exception {
+    public void testExportQueryCsvWithoutQuotes() {
         String fileName = "query.csv";
         String query = "MATCH (u:User) return u.age, u.name, u.male, u.kids, labels(u)";
         TestUtil.testCall(db, "CALL apoc.export.csv.query($query,$file,{quotes: false})",
@@ -301,7 +301,7 @@ public class ExportCsvTest {
     }
 
     @Test
-    public void testExportQueryNodesCsv() throws Exception {
+    public void testExportQueryNodesCsv() {
         String fileName = "query_nodes.csv";
         String query = "MATCH (u:User) return u";
         TestUtil.testCall(db, "CALL apoc.export.csv.query($query,$file,null)",
@@ -316,7 +316,7 @@ public class ExportCsvTest {
     }
 
     @Test
-    public void testExportQueryNodesCsvParams() throws Exception {
+    public void testExportQueryNodesCsvParams() {
         String fileName = "query_nodes.csv";
         String query = "MATCH (u:User) WHERE u.age > $age return u";
         TestUtil.testCall(db, "CALL apoc.export.csv.query($query,$file,{params:{age:10}})", map("file", fileName,"query",query),
@@ -353,13 +353,13 @@ public class ExportCsvTest {
         assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
     }
 
-    @Test public void testExportAllCsvStreaming() throws Exception {
+    @Test public void testExportAllCsvStreaming() {
         String statement = "CALL apoc.export.csv.all(null,{stream:true,batchSize:2,useOptimizations:{unwindBatchSize:2}})";
         assertExportStreaming(statement, NONE);
     }
     
     @Test
-    public void testExportAllCsvStreamingCompressed() throws Exception {
+    public void testExportAllCsvStreamingCompressed() {
         final CompressionAlgo algo = GZIP;
         String statement = "CALL apoc.export.csv.all(null, {compression: '" + algo.name() + "',stream:true,batchSize:2,useOptimizations:{unwindBatchSize:2}})";
         assertExportStreaming(statement, algo);
@@ -411,7 +411,7 @@ public class ExportCsvTest {
         assertEquals(EXPECTED, sb.toString());
     }
 
-    @Test public void testCypherCsvStreaming() throws Exception {
+    @Test public void testCypherCsvStreaming() {
         String query = "MATCH (u:User) return u.age, u.name, u.male, u.kids, labels(u)";
         StringBuilder sb = new StringBuilder();
         testResult(db, "CALL apoc.export.csv.query($query,null,{stream:true,batchSize:2, useOptimizations:{unwindBatchSize:2}})", map("query",query),
@@ -419,7 +419,7 @@ public class ExportCsvTest {
         assertEquals(EXPECTED_QUERY, sb.toString());
     }
 
-    @Test public void testCypherCsvStreamingWithoutQuotes() throws Exception {
+    @Test public void testCypherCsvStreamingWithoutQuotes() {
         String query = "MATCH (u:User) return u.age, u.name, u.male, u.kids, labels(u)";
         StringBuilder sb = new StringBuilder();
         testResult(db, "CALL apoc.export.csv.query($query,null,{quotes: false, stream:true,batchSize:2, useOptimizations:{unwindBatchSize:2}})", map("query",query),
@@ -455,7 +455,7 @@ public class ExportCsvTest {
         };
     }
 
-    @Test public void testCypherCsvStreamingWithAlwaysQuotes() throws Exception {
+    @Test public void testCypherCsvStreamingWithAlwaysQuotes() {
         String query = "MATCH (a:Address) return a.name, a.city, a.street, labels(a)";
         StringBuilder sb = new StringBuilder();
         testResult(db, "CALL apoc.export.csv.query($query,null,{quotes: 'always', stream:true,batchSize:2, useOptimizations:{unwindBatchSize:2}})", map("query",query),
@@ -464,7 +464,7 @@ public class ExportCsvTest {
         assertEquals(EXPECTED_QUERY_QUOTES_ALWAYS, sb.toString());
     }
 
-    @Test public void testCypherCsvStreamingWithNeededQuotes() throws Exception {
+    @Test public void testCypherCsvStreamingWithNeededQuotes() {
         String query = "MATCH (a:Address) return a.name, a.city, a.street, labels(a)";
         StringBuilder sb = new StringBuilder();
         testResult(db, "CALL apoc.export.csv.query($query,null,{quotes: 'ifNeeded', stream:true,batchSize:2, useOptimizations:{unwindBatchSize:2}})", map("query",query),
@@ -473,7 +473,7 @@ public class ExportCsvTest {
         assertEquals(EXPECTED_QUERY_QUOTES_NEEDED, sb.toString());
     }
 
-    @Test public void testCypherCsvStreamingWithNoneQuotes() throws Exception {
+    @Test public void testCypherCsvStreamingWithNoneQuotes() {
         String query = "MATCH (a:Address) return a.name, a.city, a.street, labels(a)";
         StringBuilder sb = new StringBuilder();
         testResult(db, "CALL apoc.export.csv.query($query,null,{quotes: 'none', stream:true,batchSize:2, useOptimizations:{unwindBatchSize:2}})", map("query",query),
@@ -483,7 +483,7 @@ public class ExportCsvTest {
     }
 
     @Test
-    public void testExportQueryCsvIssue1188() throws Exception {
+    public void testExportQueryCsvIssue1188() {
         String copyright = "\n" +
                 "(c) 2018 Hovsepian, Albanese, et al. \"\"ASCB(r),\"\" \"\"The American Society for Cell Biology(r),\"\" and \"\"Molecular Biology of the Cell(r)\"\" are registered trademarks of The American Society for Cell Biology.\n" +
                 "2018\n" +

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -126,7 +126,7 @@ public class ExportCsvTest {
             .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath());
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class, Meta.class, ImportCsv.class);
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);

--- a/core/src/test/java/apoc/export/csv/ImportCsvLdbcTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvLdbcTest.java
@@ -133,7 +133,7 @@ public class ImportCsvLdbcTest {
     }
 
     @Test
-    public void testLdbc() throws Exception {
+    public void testLdbc() {
         final List<Map<String, Object>> nodes = new ArrayList<>();
         for (final Map.Entry<String, List<String>> nodeCsv : nodeCsvTypes.entrySet()) {
             final String fileName = nodeCsv.getKey();

--- a/core/src/test/java/apoc/export/cypher/ExportCypherMultiRelTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherMultiRelTest.java
@@ -50,7 +50,7 @@ public class ExportCypherMultiRelTest {
             .withSetting(newBuilder("internal.dbms.debug.track_cursor_close", BOOL, false).build(), false);
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         TestUtil.registerProcedure(db, ExportCypher.class, Cypher.class);
         db.executeTransactionally("create (pers:Person {name: 'MyName'})-[:WORKS_FOR {id: 1}]->(proj:Project {a: 1}), \n" +
                 "(pers)-[:WORKS_FOR {id: 2}]->(proj), " +

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -62,7 +62,7 @@ public class ExportCypherTest {
     private static final String ODD = "OddDataset";
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
         TestUtil.registerProcedure(db, ExportCypher.class, Graphs.class, Schemas.class);
         db.executeTransactionally("CREATE RANGE INDEX barIndex FOR (n:Bar) ON (n.first_name, n.last_name)");

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -484,7 +484,7 @@ public class ExportGraphMLTest {
     }
 
     @Test
-    public void testImportGraphMLNodeEdgeWithBinary() throws Exception {
+    public void testImportGraphMLNodeEdgeWithBinary() {
         db.executeTransactionally("MATCH (n) DETACH DELETE n");
         
         commonAssertionImportNodeEdge(null, "CALL apoc.import.graphml($file,{readLabels:true, compression: 'DEFLATE'})",
@@ -534,7 +534,7 @@ public class ExportGraphMLTest {
     }
 
     @Test
-    public void testExportDataGraphML() throws Exception {
+    public void testExportDataGraphML() {
         db.executeTransactionally("MATCH (n) DETACH DELETE n");
         db.executeTransactionally("CREATE (p:Person {name: 'Foo'})");
         db.executeTransactionally("CREATE (p:Person {name: 'Bar'})");
@@ -554,7 +554,7 @@ public class ExportGraphMLTest {
     }
 
     @Test
-    public void testExportAllGraphML() throws Exception {
+    public void testExportAllGraphML() {
         File output = new File(directory, "all.graphml");
         TestUtil.testCall(db, "CALL apoc.export.graphml.all($file,null)", map("file", output.getAbsolutePath()),
                 (r) -> assertResults(output, r, "database"));
@@ -607,7 +607,7 @@ public class ExportGraphMLTest {
     }
 
     @Test
-    public void testExportGraphGraphML() throws Exception {
+    public void testExportGraphGraphML() {
         File output = new File(directory, "graph.graphml");
         TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
                         "CALL apoc.export.graphml.graph(graph, $file,null) " +
@@ -648,7 +648,7 @@ public class ExportGraphMLTest {
     }
 
     @Test
-    public void testExportGraphGraphMLTypes() throws Exception {
+    public void testExportGraphGraphMLTypes() {
         File output = new File(directory, "graph.graphml");
         TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
                         "CALL apoc.export.graphml.graph(graph, $file,{useTypes:true}) " +
@@ -659,7 +659,7 @@ public class ExportGraphMLTest {
     }
 
     @Test(expected = QueryExecutionException.class)
-    public void testExportGraphGraphMLTypesWithNoExportConfig() throws Exception {
+    public void testExportGraphGraphMLTypesWithNoExportConfig() {
         File output = new File(directory, "all.graphml");
         try {
             TestUtil.testCall(db, "CALL apoc.export.graphml.all($file,null)", map("file", output.getAbsolutePath()), (r) -> assertResults(output, r, "database"));
@@ -713,7 +713,7 @@ public class ExportGraphMLTest {
     }
 
     @Test
-    public void testExportGraphGraphMLQueryGephi() throws Exception {
+    public void testExportGraphGraphMLQueryGephi() {
         File output = new File(directory, "query.graphml");
         TestUtil.testCall(db, "call apoc.export.graphml.query('MATCH p=()-[r]->() RETURN p limit 1000',$file,{useTypes:true, format: 'gephi'}) ", map("file", output.getAbsolutePath()),
                 (r) -> {
@@ -732,7 +732,7 @@ public class ExportGraphMLTest {
     }
 
     @Test
-    public void testExportGraphGraphMLQueryGephiWithArrayCaption() throws Exception {
+    public void testExportGraphGraphMLQueryGephiWithArrayCaption() {
         File output = new File(directory, "query.graphml");
         TestUtil.testCall(db, "call apoc.export.graphml.query('MATCH p=()-[r]->() RETURN p limit 1000',$file,{useTypes:true, format: 'gephi', caption: ['bar','name','foo']}) ", map("file", output.getAbsolutePath()),
                 (r) -> {
@@ -751,7 +751,7 @@ public class ExportGraphMLTest {
     }
 
     @Test
-    public void testExportGraphGraphMLQueryGephiWithArrayCaptionWrong() throws Exception {
+    public void testExportGraphGraphMLQueryGephiWithArrayCaptionWrong() {
         File output = new File(directory, "query.graphml");
         TestUtil.testCall(db, "call apoc.export.graphml.query('MATCH p=()-[r]->() RETURN p limit 1000',$file,{useTypes:true, format: 'gephi', caption: ['c','d','e']}) ", map("file", output.getAbsolutePath()),
                 (r) -> {
@@ -770,7 +770,7 @@ public class ExportGraphMLTest {
     }
 
     @Test
-    public void testExportAllGraphMLTinker() throws Exception {
+    public void testExportAllGraphMLTinker() {
         File output = new File(directory, "all.graphml");
         TestUtil.testCall(db, "CALL apoc.export.graphml.all($file, {format:'tinkerpop'})", map("file", output.getAbsolutePath()),
                 (r) -> assertResults(output, r, "database"));
@@ -778,7 +778,7 @@ public class ExportGraphMLTest {
     }
 
     @Test
-    public void testExportGraphGraphMLQueryTinkerPop() throws Exception {
+    public void testExportGraphGraphMLQueryTinkerPop() {
         File output = new File(directory, "query.graphml");
         TestUtil.testCall(db, "call apoc.export.graphml.query('MATCH p=()-[r]->() RETURN p limit 1000',$file,{useTypes:true, format: 'tinkerpop'}) ", map("file", output.getAbsolutePath()),
                 (r) -> {
@@ -797,7 +797,7 @@ public class ExportGraphMLTest {
     }
 
     @Test
-    public void testExportGraphGraphMLQueryTinkerPopWithArrayCaption() throws Exception {
+    public void testExportGraphGraphMLQueryTinkerPopWithArrayCaption() {
         File output = new File(directory, "query.graphml");
         TestUtil.testCall(db, "call apoc.export.graphml.query('MATCH p=()-[r]->() RETURN p limit 1000',$file,{useTypes:true, format: 'tinkerpop', caption: ['bar','name','foo']}) ", map("file", output.getAbsolutePath()),
                 (r) -> {
@@ -816,7 +816,7 @@ public class ExportGraphMLTest {
     }
 
     @Test
-    public void testExportGraphGraphMLQueryTinkerPopWithArrayCaptionWrong() throws Exception {
+    public void testExportGraphGraphMLQueryTinkerPopWithArrayCaptionWrong() {
         File output = new File(directory, "query.graphml");
         TestUtil.testCall(db, "call apoc.export.graphml.query('MATCH p=()-[r]->() RETURN p limit 1000',$file,{useTypes:true, format: 'tinkerpop', caption: ['c','d','e']}) ", map("file", output.getAbsolutePath()),
                 (r) -> {
@@ -835,7 +835,7 @@ public class ExportGraphMLTest {
     }
 
     @Test(expected = QueryExecutionException.class)
-    public void testExportGraphGraphMLQueryGephiWithStringCaption() throws Exception {
+    public void testExportGraphGraphMLQueryGephiWithStringCaption() {
         File output = new File(directory, "query.graphml");
         try {
         TestUtil.testCall(db, "call apoc.export.graphml.query('MATCH p=()-[r]->() RETURN p limit 1000',$file,{useTypes:true, format: 'gephi', caption: 'name'}) ", map("file", output.getAbsolutePath()),
@@ -895,7 +895,7 @@ public class ExportGraphMLTest {
     }
 
     @Test
-    public void testExportAllGraphMLStream() throws Exception {
+    public void testExportAllGraphMLStream() {
         TestUtil.testCall(db, "CALL apoc.export.graphml.all(null, {stream: true})",
                 (r) -> {
                     assertStreamResults(r, "database");

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -29,7 +29,6 @@ import org.xmlunit.util.Nodes;
 
 import javax.xml.namespace.QName;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -203,7 +202,7 @@ public class ExportGraphMLTest {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         TestUtil.registerProcedure(db, ExportGraphML.class, Graphs.class);
 
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, Boolean.toString(!testName.getMethodName().endsWith(TEST_WITH_NO_EXPORT)));
@@ -459,7 +458,7 @@ public class ExportGraphMLTest {
     }
 
     @Test(expected = QueryExecutionException.class)
-    public void testImportGraphMLWithNoImportConfig() throws Exception {
+    public void testImportGraphMLWithNoImportConfig() {
         File output = new File(directory, "all.graphml");
         try {
             TestUtil.testCall(db, "CALL apoc.import.graphml($file,{readLabels:true})", map("file", output.getAbsolutePath()), (r) -> assertResults(output, r, "database"));
@@ -849,7 +848,7 @@ public class ExportGraphMLTest {
     }
 
     @Test
-    public void testExportGraphmlQueryWithStringCaptionCamelCase() throws FileNotFoundException {
+    public void testExportGraphmlQueryWithStringCaptionCamelCase() {
         db.executeTransactionally("MATCH (n) detach delete (n)");
         db.executeTransactionally("CREATE (f:Foo:Foo2:Foo0 {firstName:'foo'})-[:KNOWS]->(b:Bar {name:'bar',ageNow:42}),(c:Bar {age:12,values:[1,2,3]})");
         File output = new File(directory, "query.graphml");

--- a/core/src/test/java/apoc/export/json/ExportJsonTest.java
+++ b/core/src/test/java/apoc/export/json/ExportJsonTest.java
@@ -60,7 +60,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportAllJson() throws Exception {
+    public void testExportAllJson() {
         String filename = "all.json";
         TestUtil.testCall(db, "CALL apoc.export.json.all($file,null)",
                 map("file", filename),
@@ -177,7 +177,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportPointMapDatetimeJson() throws Exception {
+    public void testExportPointMapDatetimeJson() {
         String filename = "mapPointDatetime.json";
         String query = "return {data: 1, value: {age: 12, name:'Mike', data: {number: [1,3,5], born: date('2018-10-29'), place: point({latitude: 13.1, longitude: 33.46789})}}} as map, " +
                 "datetime('2015-06-24T12:50:35.556+0100') AS theDateTime, " +
@@ -198,7 +198,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportPointMapDatetimeStreamJson() throws Exception {
+    public void testExportPointMapDatetimeStreamJson() {
         String filename = "mapPointDatetime.json";
         String query = "return {data: 1, value: {age: 12, name:'Mike', data: {number: [1,3,5], born: date('2018-10-29'), place: point({latitude: 13.1, longitude: 33.46789})}}} as map, " +
                 "datetime('2015-06-24T12:50:35.556+0100') AS theDateTime, " +
@@ -216,7 +216,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportListNode() throws Exception {
+    public void testExportListNode() {
         String filename = "listNode.json";
 
         String query = "MATCH (u:User) RETURN COLLECT(u) as list";
@@ -247,7 +247,7 @@ public class ExportJsonTest {
     }
     
     @Test
-    public void testExportListRel() throws Exception {
+    public void testExportListRel() {
         String filename = "listRel.json";
 
         String query = "MATCH (u:User)-[rel:KNOWS]->(u2:User) RETURN COLLECT(rel) as list";
@@ -262,7 +262,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportListPath() throws Exception {
+    public void testExportListPath() {
         String filename = "listPath.json";
 
         String query = "MATCH p = (u:User)-[rel]->(u2:User) RETURN COLLECT(p) as list";
@@ -278,7 +278,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportMap() throws Exception {
+    public void testExportMap() {
         String filename = "MapNode.json";
 
         String query = "MATCH (u:User)-[r:KNOWS]->(d:User) RETURN u {.*}, d {.*}, r {.*}";
@@ -293,7 +293,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportMapPath() throws Exception {
+    public void testExportMapPath() {
         db.executeTransactionally("CREATE (f:User {name:'Mike',age:78,male:true})-[:KNOWS {since: 1850}]->(b:User {name:'John',age:18}),(c:User {age:39})");
         String filename = "MapPath.json";
 
@@ -310,7 +310,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportMapRel() throws Exception {
+    public void testExportMapRel() {
         String filename = "MapRel.json";
 
         String query = "MATCH p = (u:User)-[rel:KNOWS]->(u2:User) RETURN rel {.*}";
@@ -326,7 +326,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportMapComplex() throws Exception {
+    public void testExportMapComplex() {
         String filename = "MapComplex.json";
 
         String query = "RETURN {value:1, data:[10,'car',null, point({ longitude: 56.7, latitude: 12.78 }), point({ longitude: 56.7, latitude: 12.78, height: 8 }), point({ x: 2.3, y: 4.5 }), point({ x: 2.3, y: 4.5, z: 2 }),date('2018-10-10'), datetime('2018-10-18T14:21:40.004Z'), localdatetime({ year:1984, week:10, dayOfWeek:3, hour:12, minute:31, second:14, millisecond: 645 }), {x:1, y:[1,2,3,{age:10}]}]} as key";
@@ -342,7 +342,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportGraphJson() throws Exception {
+    public void testExportGraphJson() {
         String filename = "graph.json";
         TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
                         "CALL apoc.export.json.graph(graph, $file) " +
@@ -353,7 +353,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportQueryJson() throws Exception {
+    public void testExportQueryJson() {
         String filename = "query.json";
         String query = "MATCH (u:User) return u.age, u.name, u.male, u.kids, labels(u)";
         TestUtil.testCall(db, "CALL apoc.export.json.query($query,$file)",
@@ -367,7 +367,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportQueryNodesJson() throws Exception {
+    public void testExportQueryNodesJson() {
         String filename = "query_nodes.json";
         String query = "MATCH (u:User) return u";
         TestUtil.testCall(db, "CALL apoc.export.json.query($query,$file)",
@@ -381,7 +381,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportQueryTwoNodesJson() throws Exception {
+    public void testExportQueryTwoNodesJson() {
         String filename = "query_two_nodes.json";
         String query = "MATCH (u:User{name:'Adam'}), (l:User{name:'Jim'}) return u, l";
         TestUtil.testCall(db, "CALL apoc.export.json.query($query,$file)", map("file", filename, "query", query),
@@ -395,7 +395,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportQueryNodesJsonParams() throws Exception {
+    public void testExportQueryNodesJsonParams() {
         String filename = "query_nodes_param.json";
         String query = "MATCH (u:User) WHERE u.age > $age return u";
         TestUtil.testCall(db, "CALL apoc.export.json.query($query,$file,{params:{age:10}})",
@@ -409,7 +409,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportQueryNodesJsonCount() throws Exception {
+    public void testExportQueryNodesJsonCount() {
         String filename = "query_nodes_count.json";
         String query = "MATCH (n) return count(n)";
         TestUtil.testCall(db, "CALL apoc.export.json.query($query,$file)",
@@ -423,7 +423,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportData() throws Exception {
+    public void testExportData() {
         String filename = "data.json";
         TestUtil.testCall(db, "MATCH (nod:User) " +
                         "MATCH ()-[reels:KNOWS]->() " +
@@ -440,7 +440,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportDataPath() throws Exception {
+    public void testExportDataPath() {
         String filename = "query_nodes_path.json";
         String query = "MATCH p = (u:User)-[rel]->(u2:User) return u, rel, u2, p, u.name";
         TestUtil.testCall(db, "CALL apoc.export.json.query($query,$file)",
@@ -453,7 +453,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportAllWithWriteNodePropertiesJson() throws Exception {
+    public void testExportAllWithWriteNodePropertiesJson() {
         String filename = "with_node_properties.json";
         String query = "MATCH p = (u:User)-[rel:KNOWS]->(u2:User) RETURN rel";
 
@@ -468,7 +468,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportAllWithDefaultWriteNodePropertiesJson() throws Exception {
+    public void testExportAllWithDefaultWriteNodePropertiesJson() {
         String filename = "with_node_properties.json";
         String query = "MATCH p = (u:User)-[rel:KNOWS]->(u2:User) RETURN rel";
 
@@ -484,7 +484,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportAllWithoutWriteNodePropertiesJson() throws Exception {
+    public void testExportAllWithoutWriteNodePropertiesJson() {
         String filename = "without_node_properties.json";
         String query = "MATCH p = (u:User)-[rel:KNOWS]->(u2:User) RETURN rel";
 
@@ -499,7 +499,7 @@ public class ExportJsonTest {
     }
 
     @Test
-    public void testExportQueryOrderJson() throws Exception {
+    public void testExportQueryOrderJson() {
         db.executeTransactionally("CREATE (f:User12:User1:User0:User {name:'Alan'})");
         String filename = "query_node_labels.json";
         String query = "MATCH (u:User) WHERE u.name='Alan' RETURN u";

--- a/core/src/test/java/apoc/export/json/ImportJsonTest.java
+++ b/core/src/test/java/apoc/export/json/ImportJsonTest.java
@@ -67,7 +67,7 @@ public class ImportJsonTest {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         TestUtil.registerProcedure(db, ImportJson.class, Schemas.class, Utils.class);
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
     }

--- a/core/src/test/java/apoc/export/json/ImportJsonTest.java
+++ b/core/src/test/java/apoc/export/json/ImportJsonTest.java
@@ -78,7 +78,7 @@ public class ImportJsonTest {
     }
 
     @Test
-    public void shouldImportAllJson() throws Exception {
+    public void shouldImportAllJson() {
         shouldImportAllCommon(Collections.emptyMap(), 9, 1L);
     }
 
@@ -98,7 +98,7 @@ public class ImportJsonTest {
     }
 
     @Test
-    public void shouldImportAllJsonWithPropertyMappings() throws Exception {
+    public void shouldImportAllJsonWithPropertyMappings() {
         db.executeTransactionally("CREATE CONSTRAINT FOR (n:User) REQUIRE n.neo4jImportId IS UNIQUE");
         // given
         String filename = "all.json";

--- a/core/src/test/java/apoc/graph/GraphsTest.java
+++ b/core/src/test/java/apoc/graph/GraphsTest.java
@@ -66,13 +66,13 @@ public class GraphsTest {
     }
 
     @Test
-    public void testFromData() throws Exception {
+    public void testFromData() {
         TestUtil.testCall(db,"MATCH (n)-[r]->(m) CALL apoc.graph.fromData([n,m],[r],'test',{answer:42}) YIELD graph RETURN *",
                 r -> assertEquals(graph, r.get("graph")));
     }
 
     @Test
-    public void testFromPath() throws Exception {
+    public void testFromPath() {
         TestUtil.testCall(db,"MATCH path = (n)-[r]->(m) CALL apoc.graph.fromPath(path,'test',{answer:42}) YIELD graph RETURN *",
                 r -> assertEquals(graph, r.get("graph")));
     }
@@ -98,7 +98,7 @@ public class GraphsTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testFromDB() throws Exception {
+    public void testFromDB() {
         TestUtil.testCall(db," CALL apoc.graph.fromDB('test',{answer:42})",
                 r -> {
                     Map graph1 = new HashMap((Map)r.get("graph"));
@@ -109,7 +109,7 @@ public class GraphsTest {
     }
 
     @Test
-    public void testFromCypher() throws Exception {
+    public void testFromCypher() {
         TestUtil.testCall(db,"CALL apoc.graph.fromCypher('MATCH (n)-[r]->(m) RETURN *',null,'test',{answer:42}) YIELD graph RETURN *",
                 r -> assertEquals(graph, r.get("graph")));
     }
@@ -489,7 +489,7 @@ public class GraphsTest {
     }
 
     @Test
-    public void testValidateDocumentWithCutErrorFormatter() throws Exception {
+    public void testValidateDocumentWithCutErrorFormatter() {
         String json = "{\"quiz\":{\"sport\":{\"q1\":{\"question\":\"Which one is correct team name in NBA?\",\"options\":[\"New York Bulls\",\"Los Angeles Kings\",\"Golden State Warriros\",\"Huston Rocket\"],\"answer\":\"Huston Rocket\"}},\"maths\":{\"q1\":{\"question\":\"5 + 7 = ?\",\"options\":[\"10\",\"11\",\"12\",\"13\"],\"answer\":\"12\"},\"q2\":{\"question\":\"12 - 8 = ?\",\"options\":[\"1\",\"2\",\"3\",\"4\"],\"answer\":\"4\"}}}}";
 
         Set<String> errors = new HashSet<>();
@@ -579,7 +579,7 @@ public class GraphsTest {
     }
 
     @Test
-    public void testFromDocumentWithNestedStructure() throws Exception {
+    public void testFromDocumentWithNestedStructure() {
         Map<String, Object> jamesMap = Util.map("id", 1L, "type", "Father", "name", "James");
         Map<String, Object> johnMap = Util.map("id", 2L, "type", "Father", "name", "John");
         Map<String, Object> robertMap = Util.map("id", 1L, "type", "Person", "name", "Robert");

--- a/core/src/test/java/apoc/graph/GraphsTest.java
+++ b/core/src/test/java/apoc/graph/GraphsTest.java
@@ -56,7 +56,7 @@ public class GraphsTest {
             .withSetting(SettingImpl.newBuilder("internal.dbms.debug.trace_cursors", SettingValueParsers.BOOL, false).build(), false);
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         TestUtil.registerProcedure(db,Graphs.class);
         db.executeTransactionally("CREATE (a:Actor {name:'Tom Hanks'})-[r:ACTED_IN {roles:'Forrest'}]->(m:Movie {title:'Forrest Gump'}) RETURN [a,m] as nodes, [r] as relationships", Collections.emptyMap(),
                 result -> {
@@ -958,7 +958,7 @@ public class GraphsTest {
     }
 
     @Test
-    public void testIncludeMappingsAsProperties() throws IOException {
+    public void testIncludeMappingsAsProperties() {
         Map<String, Object> json = map("id", 1,
                 "text", "Text",
                 "data", "02-11-2019",
@@ -991,7 +991,7 @@ public class GraphsTest {
     }
 
     @Test
-    public void testValidationCustomIdAsProperties() throws IOException {
+    public void testValidationCustomIdAsProperties() {
         Map<String, Object> json = map("id", 1,
                 "text", "Text",
                 "data", "02-11-2019",

--- a/core/src/test/java/apoc/help/HelpTest.java
+++ b/core/src/test/java/apoc/help/HelpTest.java
@@ -27,7 +27,7 @@ public class HelpTest {
     }
 
     @Test
-    public void info() throws Exception {
+    public void info() {
         TestUtil.testCall(db,"CALL apoc.help($text)",map("text","bitwise"), (row) -> {
             assertEquals("function",row.get("type"));
             assertEquals("apoc.bitwise.op",row.get("name"));

--- a/core/src/test/java/apoc/help/HelpTest.java
+++ b/core/src/test/java/apoc/help/HelpTest.java
@@ -22,7 +22,7 @@ public class HelpTest {
     public DbmsRule db = new ImpermanentDbmsRule();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         TestUtil.registerProcedure(db, Help.class, BitwiseOperations.class,Coll.class);
     }
 

--- a/core/src/test/java/apoc/index/SchemaIndexTest.java
+++ b/core/src/test/java/apoc/index/SchemaIndexTest.java
@@ -39,7 +39,7 @@ SchemaIndexTest {
     private static final int lastPerson = 200;
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, SchemaIndex.class);
         db.executeTransactionally("CREATE (city:City {name:'London'}) WITH city UNWIND range("+firstPerson+","+lastPerson+") as id CREATE (:Person {name:'name'+id, id:id, age:id % 100, address:id+'Main St.'})-[:LIVES_IN]->(city)");
         //

--- a/core/src/test/java/apoc/index/SchemaIndexTest.java
+++ b/core/src/test/java/apoc/index/SchemaIndexTest.java
@@ -64,7 +64,7 @@ SchemaIndexTest {
     }
 
     @Test
-    public void testDistinctPropertiesOnFirstIndex() throws Exception {
+    public void testDistinctPropertiesOnFirstIndex() {
         testCall(db,"CALL apoc.schema.properties.distinct($label, $key)",
                 map("label", "Person","key", "name"),
                 (row) -> assertEquals(new HashSet<>(personNames), new HashSet<>((Collection<String>) row.get("value")))
@@ -72,7 +72,7 @@ SchemaIndexTest {
     }
 
     @Test
-    public void testDistinctPropertiesOnSecondIndex() throws Exception {
+    public void testDistinctPropertiesOnSecondIndex() {
         testCall(db,"CALL apoc.schema.properties.distinct($label, $key)",
                 map("label", "Person","key", "address"),
                 (row) -> assertEquals(new HashSet<>(personAddresses), new HashSet<>((Collection<String>) row.get("value")))
@@ -80,7 +80,7 @@ SchemaIndexTest {
     }
 
     @Test
-    public void testDistinctCountPropertiesOnFirstIndex() throws Exception {
+    public void testDistinctCountPropertiesOnFirstIndex() {
         String label = "Person";
         String key = "name";
         testResult(db,"CALL apoc.schema.properties.distinctCount($label, $key) YIELD label,key,value,count RETURN * ORDER BY value",
@@ -92,7 +92,7 @@ SchemaIndexTest {
     }
 
     @Test
-    public void testDistinctCountPropertiesOnSecondIndex() throws Exception {
+    public void testDistinctCountPropertiesOnSecondIndex() {
         String label = "Person";
         String key = "address";
         testResult(db,"CALL apoc.schema.properties.distinctCount($label, $key) YIELD label,key,value,count RETURN * ORDER BY value",
@@ -104,7 +104,7 @@ SchemaIndexTest {
     }
 
     @Test
-    public void testDistinctCountPropertiesOnEmptyLabel() throws Exception {
+    public void testDistinctCountPropertiesOnEmptyLabel() {
         String key = "name";
         testResult(db,"CALL apoc.schema.properties.distinctCount($label, $key) YIELD label,key,value,count RETURN * ORDER BY value",
                 map("label","","key",key),
@@ -115,7 +115,7 @@ SchemaIndexTest {
     }
 
     @Test
-    public void testDistinctCountPropertiesOnEmptyKey() throws Exception {
+    public void testDistinctCountPropertiesOnEmptyKey() {
         String label = "Person";
         testResult(db,"CALL apoc.schema.properties.distinctCount($label, $key) YIELD label,key,value,count RETURN * ORDER BY key,value",
                 map("label",label,"key",""),
@@ -129,7 +129,7 @@ SchemaIndexTest {
     }
 
     @Test
-    public void testDistinctCountPropertiesOnEmptyLabelAndEmptyKey() throws Exception {
+    public void testDistinctCountPropertiesOnEmptyLabelAndEmptyKey() {
         testResult(db,"CALL apoc.schema.properties.distinctCount($label, $key) YIELD label,key,value,count RETURN * ORDER BY label,key,value",
                 map("label","","key",""),
                 (result) -> {

--- a/core/src/test/java/apoc/label/LabelTest.java
+++ b/core/src/test/java/apoc/label/LabelTest.java
@@ -21,7 +21,7 @@ public class LabelTest {
     }
 
     @Test
-    public void testVerifyNodeLabelExistence() throws Exception {
+    public void testVerifyNodeLabelExistence() {
 
         db.executeTransactionally("create (a:Person{name:'Foo'})");
 
@@ -36,7 +36,7 @@ public class LabelTest {
     }
 
     @Test
-    public void testVerifyRelTypeExistence() throws Exception {
+    public void testVerifyRelTypeExistence() {
 
         db.executeTransactionally("create (a:Person{name:'Foo'}), (b:Person{name:'Bar'}), (a)-[:LOVE{since:2010}]->(b)");
 

--- a/core/src/test/java/apoc/label/LabelTest.java
+++ b/core/src/test/java/apoc/label/LabelTest.java
@@ -16,7 +16,7 @@ public class LabelTest {
     public static DbmsRule db = new ImpermanentDbmsRule();
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, Label.class);
     }
 

--- a/core/src/test/java/apoc/load/LoadCoreSecurityTest.java
+++ b/core/src/test/java/apoc/load/LoadCoreSecurityTest.java
@@ -51,7 +51,7 @@ public class LoadCoreSecurityTest {
             .withSetting(GraphDatabaseSettings.load_csv_file_url_root, import_folder);
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, LoadJson.class, Xml.class);
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, false);
     }

--- a/core/src/test/java/apoc/load/LoadJsonTest.java
+++ b/core/src/test/java/apoc/load/LoadJsonTest.java
@@ -62,7 +62,7 @@ public class LoadJsonTest {
     public DbmsRule db = new ImpermanentDbmsRule()
             .withSetting(GraphDatabaseInternalSettings.cypher_ip_blocklist, List.of(new IPAddressString("127.168.0.0/8")));
 
-	@Before public void setUp() throws Exception {
+	@Before public void setUp() {
 	    apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
 	    apocConfig().setProperty(APOC_IMPORT_FILE_USE_NEO4J_CONFIG, false);
 	    apocConfig().setProperty("apoc.json.zip.url", "https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/3.4/src/test/resources/testload.zip?raw=true!person.json");

--- a/core/src/test/java/apoc/load/LoadJsonTest.java
+++ b/core/src/test/java/apoc/load/LoadJsonTest.java
@@ -70,7 +70,7 @@ public class LoadJsonTest {
         TestUtil.registerProcedure(db, LoadJson.class);
     }
 
-    @Test public void testLoadJson() throws Exception {
+    @Test public void testLoadJson() {
 		URL url = ClassLoader.getSystemResource("map.json");
 		testCall(db, "CALL apoc.load.json($url)",map("url",url.toString()), // 'file:map.json' YIELD value RETURN value
                 (row) -> {
@@ -86,7 +86,7 @@ public class LoadJsonTest {
                 this::commonAssertionsLoadJsonMulti);
     }
 
-    @Test public void testLoadMultiJson() throws Exception {
+    @Test public void testLoadMultiJson() {
         URL url = ClassLoader.getSystemResource("multi.json");
         testResult(db, "CALL apoc.load.json($url)",map("url",url.toString()), // 'file:map.json' YIELD value RETURN value
                 (result) -> {
@@ -106,7 +106,7 @@ public class LoadJsonTest {
         assertFalse(result.hasNext());
     }
     
-    @Test public void testLoadJsonFromBlockedIpRange() throws Exception {
+    @Test public void testLoadJsonFromBlockedIpRange() {
         var protocols = List.of("https", "http", "ftp");
 
         for (var protocol: protocols) {
@@ -120,19 +120,19 @@ public class LoadJsonTest {
             assertTrue(e.getMessage().contains("access to /127.168.0.0 is blocked via the configuration property internal.dbms.cypher_ip_blocklist"));
         }
     }
-    @Test public void testLoadMultiJsonPaths() throws Exception {
+    @Test public void testLoadMultiJsonPaths() {
 		URL url = ClassLoader.getSystemResource("multi.json");
 		testResult(db, "CALL apoc.load.json($url,'$')",map("url",url.toString()), // 'file:map.json' YIELD value RETURN value
                 this::commonAssertionsLoadJsonMulti);
     }
-    @Test public void testLoadJsonPath() throws Exception {
+    @Test public void testLoadJsonPath() {
 		URL url = ClassLoader.getSystemResource("map.json");
 		testCall(db, "CALL apoc.load.json($url,'$.foo')",map("url",url.toString()), // 'file:map.json' YIELD value RETURN value
                 (row) -> {
                     assertEquals(map("result",asList(1L,2L,3L)), row.get("value"));
                 });
     }
-    @Test public void testLoadJsonPathRoot() throws Exception {
+    @Test public void testLoadJsonPathRoot() {
 		URL url = ClassLoader.getSystemResource("map.json");
 		testCall(db, "CALL apoc.load.json($url,'$')",map("url",url.toString()), // 'file:map.json' YIELD value RETURN value
                 (row) -> {
@@ -141,7 +141,7 @@ public class LoadJsonTest {
     }
     
     @Test
-    public void testLoadJsonWithPathOptions() throws Exception {
+    public void testLoadJsonWithPathOptions() {
         URL url = ClassLoader.getSystemResource("columns.json");
 
         // -- load.json
@@ -169,14 +169,14 @@ public class LoadJsonTest {
                 (res) -> assertEquals(List.of(EXPECTED_AS_PATH_LIST), Iterators.asList(res.columnAs("value"))));
     }
     
-    @Test public void testLoadJsonArrayPath() throws Exception {
+    @Test public void testLoadJsonArrayPath() {
 		URL url = ClassLoader.getSystemResource("map.json");
 		testCall(db, "CALL apoc.load.jsonArray($url,'$.foo')",map("url",url.toString()), // 'file:map.json' YIELD value RETURN value
                 (row) -> {
                     assertEquals(asList(1L,2L,3L), row.get("value"));
                 });
     }
-    @Test public void testLoadJsonArrayPathRoot() throws Exception {
+    @Test public void testLoadJsonArrayPathRoot() {
 		URL url = ClassLoader.getSystemResource("map.json");
 		testCall(db, "CALL apoc.load.jsonArray($url,'$')",map("url",url.toString()), // 'file:map.json' YIELD value RETURN value
                 (row) -> {
@@ -184,7 +184,7 @@ public class LoadJsonTest {
                 });
     }
 
-    @Test public void testLoadJsonStackOverflow() throws Exception {
+    @Test public void testLoadJsonStackOverflow() {
         String url = "https://api.stackexchange.com/2.2/questions?pagesize=10&order=desc&sort=creation&tagged=neo4j&site=stackoverflow&filter=!5-i6Zw8Y)4W7vpy91PMYsKM-k9yzEsSC1_Uxlf";
         testCall(db, "CALL apoc.load.json($url)",map("url", url), // 'file:map.json' YIELD value RETURN value
                 (row) -> {
@@ -196,7 +196,7 @@ public class LoadJsonTest {
     }
 
 
-    @Test public void testLoadJsonNoFailOnError() throws Exception {
+    @Test public void testLoadJsonNoFailOnError() {
         String url = "file.json";
         testResult(db, "CALL apoc.load.json($url,null, {failOnError:false})",map("url", url), // 'file:map.json' YIELD value RETURN value
                 (row) -> {
@@ -204,7 +204,7 @@ public class LoadJsonTest {
                 });
     }
 
-    @Test public void testLoadJsonZip() throws Exception {
+    @Test public void testLoadJsonZip() {
         URL url = ClassLoader.getSystemResource("testload.zip");
         testCall(db, "CALL apoc.load.json($url)",map("url",url.toString()+"!person.json"),
                 (row) -> {
@@ -215,7 +215,7 @@ public class LoadJsonTest {
                 });
     }
 
-    @Test public void testLoadJsonTar() throws Exception {
+    @Test public void testLoadJsonTar() {
         URL url = ClassLoader.getSystemResource("testload.tar");
         testCall(db, "CALL apoc.load.json($url)",map("url",url.toString()+"!person.json"),
                 (row) -> {
@@ -226,7 +226,7 @@ public class LoadJsonTest {
                 });
     }
 
-    @Test public void testLoadJsonTarGz() throws Exception {
+    @Test public void testLoadJsonTarGz() {
         URL url = ClassLoader.getSystemResource("testload.tar.gz");
         testCall(db, "CALL apoc.load.json($url)",map("url",url.toString()+"!person.json"),
                 (row) -> {
@@ -237,7 +237,7 @@ public class LoadJsonTest {
                 });
     }
 
-    @Test public void testLoadJsonTgz() throws Exception {
+    @Test public void testLoadJsonTgz() {
         URL url = ClassLoader.getSystemResource("testload.tgz");
         testCall(db, "CALL apoc.load.json($url)",map("url",url.toString()+"!person.json"),
                 (row) -> {
@@ -292,7 +292,7 @@ public class LoadJsonTest {
                 });
     }
 
-    @Test public void testLoadJsonZipByUrlInConfigFile() throws Exception {
+    @Test public void testLoadJsonZipByUrlInConfigFile() {
         testCall(db, "CALL apoc.load.json($key)",map("key","zip"),
                 (row) -> {
                     Map<String,Object> r = (Map<String, Object>) row.get("value");
@@ -302,7 +302,7 @@ public class LoadJsonTest {
                 });
     }
 
-    @Test public void testLoadJsonByUrlInConfigFile() throws Exception {
+    @Test public void testLoadJsonByUrlInConfigFile() {
 
         testCall(db, "CALL apoc.load.json($key)",map("key","simpleJson"), // 'file:map.json' YIELD value RETURN value
                 (row) -> {
@@ -311,7 +311,7 @@ public class LoadJsonTest {
     }
 
     @Test(expected = QueryExecutionException.class)
-    public void testLoadJsonByUrlInConfigFileWrongKey() throws Exception {
+    public void testLoadJsonByUrlInConfigFileWrongKey() {
 
         try {
             testResult(db, "CALL apoc.load.json($key)",map("key","foo"), (r) -> r.hasNext());
@@ -386,7 +386,7 @@ public class LoadJsonTest {
     }
 
     @Test
-    public void testLoadJsonParams() throws Exception {
+    public void testLoadJsonParams() {
         new MockServerClient("localhost", 1080)
                 .when(
                         request()

--- a/core/src/test/java/apoc/load/XmlTest.java
+++ b/core/src/test/java/apoc/load/XmlTest.java
@@ -47,7 +47,7 @@ public class XmlTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
         apocConfig().setProperty(APOC_IMPORT_FILE_USE_NEO4J_CONFIG, false);
         TestUtil.registerProcedure(db, Xml.class);

--- a/core/src/test/java/apoc/load/relative/LoadRelativePathTest.java
+++ b/core/src/test/java/apoc/load/relative/LoadRelativePathTest.java
@@ -34,7 +34,8 @@ public class LoadRelativePathTest {
     public LoadRelativePathTest() throws URISyntaxException {
     }
 
-    @Before public void setUp() throws Exception {
+    @Before
+    public void setUp() {
         TestUtil.registerProcedure(db, LoadJson.class, Xml.class);
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
     }

--- a/core/src/test/java/apoc/lock/LockTest.java
+++ b/core/src/test/java/apoc/lock/LockTest.java
@@ -26,7 +26,7 @@ public class LockTest {
             .withSetting(GraphDatabaseSettings.lock_acquisition_timeout, Duration.ofSeconds(1));
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, Lock.class);
     }
 

--- a/core/src/test/java/apoc/log/Neo4jLogStreamTest.java
+++ b/core/src/test/java/apoc/log/Neo4jLogStreamTest.java
@@ -22,7 +22,7 @@ public class Neo4jLogStreamTest {
     private GraphDatabaseService db;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         DatabaseManagementService dbManagementService = new TestDatabaseManagementServiceBuilder(
                 Paths.get("target", UUID.randomUUID().toString()).toAbsolutePath()).build();
         apocConfig().setProperty("server.directories.logs", "");

--- a/core/src/test/java/apoc/map/MapsTest.java
+++ b/core/src/test/java/apoc/map/MapsTest.java
@@ -33,7 +33,7 @@ public class MapsTest {
     }
 
     @Test
-    public void testFromNodes() throws Exception {
+    public void testFromNodes() {
         db.executeTransactionally("UNWIND range(1,3) as id create (:Person {name:'name'+id})");
         TestUtil.testCall(db, "RETURN apoc.map.fromNodes('Person','name') as value", (r) -> {
             Map<String,Node> map = (Map<String, Node>) r.get("value");
@@ -43,7 +43,7 @@ public class MapsTest {
     }
 
     @Test
-    public void testValues() throws Exception {
+    public void testValues() {
         TestUtil.testCall(db, "RETURN apoc.map.values({b:42,a:'foo',c:false},['a','b','d']) as value", (r) -> {
             assertEquals(asList("foo",42L),r.get("value"));
         });
@@ -58,65 +58,65 @@ public class MapsTest {
         });
     }
     @Test
-    public void testGroupBy() throws Exception {
+    public void testGroupBy() {
         TestUtil.testCall(db, "RETURN apoc.map.groupBy([{id:0,a:1},{id:1, b:false},{id:0,c:2}],'id') as value", (r) -> {
             assertEquals(map("0",map("id",0L,"c",2L),"1",map("id",1L,"b",false)),r.get("value"));
         });
     }
     @Test
-    public void testGroupByMulti() throws Exception {
+    public void testGroupByMulti() {
         TestUtil.testCall(db, "RETURN apoc.map.groupByMulti([{id:0,a:1},{id:1, b:false},{id:0,c:2}],'id') as value", (r) -> {
             assertEquals(map("0",asList(map("id",0L,"a",1L),map("id",0L,"c",2L)),"1",asList(map("id",1L,"b",false))),r.get("value"));
         });
     }
     @Test
-    public void testMerge() throws Exception {
+    public void testMerge() {
         TestUtil.testCall(db, "RETURN apoc.map.merge({a:1},{b:false}) AS value", (r) -> {
             assertEquals(map("a",1L,"b",false),r.get("value"));
         });
     }
 
     @Test
-    public void testMergeList() throws Exception {
+    public void testMergeList() {
         TestUtil.testCall(db, "RETURN apoc.map.mergeList([{a:1},{b:false}]) as value", (r) -> {
             assertEquals(map("a",1L,"b",false),r.get("value"));
         });
     }
 
     @Test
-    public void testFromPairs() throws Exception {
+    public void testFromPairs() {
         TestUtil.testCall(db, "RETURN apoc.map.fromPairs([['a',1],['b',false]]) AS value", (r) -> {
             assertEquals(map("a",1L,"b",false),r.get("value"));
         });
     }
     @Test
-    public void testFromValues() throws Exception {
+    public void testFromValues() {
         TestUtil.testCall(db, "RETURN apoc.map.fromValues(['a',1,'b',false]) AS value", (r) -> {
             assertEquals(map("a",1L,"b",false),r.get("value"));
         });
     }
 
     @Test
-    public void testFromLists() throws Exception {
+    public void testFromLists() {
         TestUtil.testCall(db, "RETURN apoc.map.fromLists(['a','b'],[1,false]) AS value", (r) -> {
             assertEquals(map("a",1L,"b",false),r.get("value"));
         });
     }
     @Test
-    public void testSetPairs() throws Exception {
+    public void testSetPairs() {
         TestUtil.testCall(db, "RETURN apoc.map.setPairs({}, [['a',1],['b',false]]) AS value", (r) -> {
             assertEquals(map("a",1L,"b",false),r.get("value"));
         });
     }
     @Test
-    public void testSetValues() throws Exception {
+    public void testSetValues() {
         TestUtil.testCall(db, "RETURN apoc.map.setValues({}, ['a',1,'b',false]) AS value", (r) -> {
             assertEquals(map("a",1L,"b",false),r.get("value"));
         });
     }
 
     @Test
-    public void testSetLists() throws Exception {
+    public void testSetLists() {
         TestUtil.testCall(db, "RETURN apoc.map.setLists({}, ['a','b'],[1,false]) AS value", (r) -> {
             assertEquals(map("a",1L,"b",false),r.get("value"));
         });
@@ -125,7 +125,7 @@ public class MapsTest {
 
 
     @Test
-    public void testGet() throws Exception {
+    public void testGet() {
         TestUtil.testCall(db, "RETURN apoc.map.get({a:1},'a') AS value", (r) -> {
             assertEquals(1L,r.get("value"));
         });
@@ -139,7 +139,7 @@ public class MapsTest {
     }
 
     @Test
-    public void testSubMap() throws Exception {
+    public void testSubMap() {
         TestUtil.testCall(db, "RETURN apoc.map.submap({a:1,b:1},['a']) AS value", (r) -> {
             assertEquals(map("a",1L),r.get("value"));
         });
@@ -157,7 +157,7 @@ public class MapsTest {
     }
 
     @Test
-    public void testMGet() throws Exception {
+    public void testMGet() {
         TestUtil.testCall(db, "RETURN apoc.map.mget({a:1,b:1},['a']) AS value", (r) -> {
             assertEquals(asList(1L),r.get("value"));
         });
@@ -175,110 +175,110 @@ public class MapsTest {
     }
 
     @Test
-    public void testSetKey() throws Exception {
+    public void testSetKey() {
         TestUtil.testCall(db, "RETURN apoc.map.setKey({a:1},'a',2) AS value", (r) -> {
             assertEquals(map("a",2L),r.get("value"));
         });
     }
     @Test
-    public void testSetEntry() throws Exception {
+    public void testSetEntry() {
         TestUtil.testCall(db, "RETURN apoc.map.setEntry({a:1},'a',2) AS value", (r) -> {
             assertEquals(map("a",2L),r.get("value"));
         });
     }
 
     @Test
-    public void testRemoveKey() throws Exception {
+    public void testRemoveKey() {
         TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1,b:2},'a') AS value", (r) -> {
             assertEquals(map("b",2L),r.get("value"));
         });
     }
 
     @Test
-    public void testRemoveLastKey() throws Exception {
+    public void testRemoveLastKey() {
         TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1},'a') AS value", (r) -> {
             assertEquals(map(),r.get("value"));
         });
     }
 
     @Test
-    public void testRemoveKeyRecursively() throws Exception {
+    public void testRemoveKeyRecursively() {
         TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1,b:2,c:{a:3,b:4}},'a', {recursive:true}) AS value", (r) -> {
             assertEquals(map("b",2L, "c", map("b",4L)),r.get("value"));
         });
     }
 
     @Test
-    public void testRemoveKeyRecursivelySimpleProperties() throws Exception {
+    public void testRemoveKeyRecursivelySimpleProperties() {
         TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1,b:2},'b', {recursive:true}) AS value", (r) -> {
             assertEquals(map("a",1L), r.get("value"));
         });
     }
 
     @Test
-    public void testRemoveLastKeyRecursively() throws Exception {
+    public void testRemoveLastKeyRecursively() {
         TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1,b:2,c:{a:3}},'a', {recursive:true}) AS value", (r) -> {
             assertEquals(map("b",2L),r.get("value"));
         });
     }
 
     @Test
-    public void testRemoveKeyRecursivelyIncludingCollectionOfMaps() throws Exception {
+    public void testRemoveKeyRecursivelyIncludingCollectionOfMaps() {
         TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1,b:2,c:[{a:3,b:4}, {a:4,b:5}]},'a', {recursive:true}) AS value", (r) -> {
             assertEquals(map("b",2L, "c", asList(map("b",4L), map("b",5L))), r.get("value"));
         });
     }
 
     @Test
-    public void testRemoveKeyRecursivelyIncludingCollectionOfStrings() throws Exception {
+    public void testRemoveKeyRecursivelyIncludingCollectionOfStrings() {
         TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1,b:2,c:['a', 'b']},'a', {recursive:true}) AS value", (r) -> {
             assertEquals(map("b", 2L, "c", asList("a", "b")), r.get("value"));
         });
     }
 
     @Test
-    public void testRemoveAllKeys() throws Exception {
+    public void testRemoveAllKeys() {
         TestUtil.testCall(db, "RETURN apoc.map.removeKeys({a:1,b:2},['a','b']) AS value", (r) -> {
             assertEquals(map(),r.get("value"));
         });
     }
 
     @Test
-    public void testRemoveKeysRecursively() throws Exception {
+    public void testRemoveKeysRecursively() {
         TestUtil.testCall(db, "RETURN apoc.map.removeKeys({a:1,b:2,c:{a:3,b:4}},['a','b'], {recursive:true}) AS value", (r) -> {
             assertEquals(map(),r.get("value"));
         });
     }
 
     @Test
-    public void testRemoveKeysRecursivelyIncludingCollectionOfMaps() throws Exception {
+    public void testRemoveKeysRecursivelyIncludingCollectionOfMaps() {
         TestUtil.testCall(db, "RETURN apoc.map.removeKeys({a:1,b:2,c:[{a:3,b:4,d:1}, {a:4,b:5,d:3}]},['a','b'],{recursive:true}) AS value", (r) -> {
             assertEquals(map("c", asList(map("d",1L),map("d",3L))), r.get("value"));
         });
     }
     @Test
-    public void testRemoveKeysRecursivelyRemovingCollectionCompletely() throws Exception {
+    public void testRemoveKeysRecursivelyRemovingCollectionCompletely() {
         TestUtil.testCall(db, "RETURN apoc.map.removeKeys({a:1,b:2,c:[{d:1}, {b:5,d:3}]},['d','b'],{recursive:true}) AS value", (r) -> {
             assertEquals(map("a", 1L), r.get("value"));
         });
     }
 
     @Test
-    public void testRemoveKeysRecursivelyIncludingCollectionOfInts() throws Exception {
+    public void testRemoveKeysRecursivelyIncludingCollectionOfInts() {
         TestUtil.testCall(db, "RETURN apoc.map.removeKeys({a:1,b:2,c:[1,2,3]},['a','b'],{recursive:true}) AS value", (r) -> {
             assertEquals(map("c", asList(1L, 2L, 3L)), r.get("value"));
         });
     }
 
     @Test
-    public void testClean() throws Exception {
+    public void testClean() {
         TestUtil.testCall(db, "RETURN apoc.map.clean({a:1,b:'',c:null,x:1234,z:false},['x'],['',false]) AS value", (r) -> {
             assertEquals(map("a",1L),r.get("value"));
         });
     }
 
     @Test
-    public void testUpdateTree() throws Exception {
+    public void testUpdateTree() {
         TestUtil.testCall(db, "RETURN apoc.map.updateTree({id:1,c:{id:2},d:[{id:3}]},'id',[[1,{a:1}],[2,{a:2}],[3,{a:3}]]) AS value", (r) -> {
             assertEquals(map("id",1L,"a",1L,"c",map("id",2L,"a",2L),"d",asList(map("id",3L,"a",3L))),r.get("value"));
         });

--- a/core/src/test/java/apoc/map/MapsTest.java
+++ b/core/src/test/java/apoc/map/MapsTest.java
@@ -28,7 +28,7 @@ public class MapsTest {
     public DbmsRule db = new ImpermanentDbmsRule();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         TestUtil.registerProcedure(db,Maps.class);
     }
 

--- a/core/src/test/java/apoc/math/MathsTest.java
+++ b/core/src/test/java/apoc/math/MathsTest.java
@@ -17,7 +17,7 @@ public class MathsTest {
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule();
 
-    @BeforeClass public static void setUp() throws Exception {
+    @BeforeClass public static void setUp() {
         TestUtil.registerProcedure(db,Maths.class);
     }
 

--- a/core/src/test/java/apoc/math/RegressionTest.java
+++ b/core/src/test/java/apoc/math/RegressionTest.java
@@ -24,7 +24,7 @@ public static DbmsRule db = new ImpermanentDbmsRule();
     }
 
     @Test
-    public void testCalculateRegr() throws Throwable {
+    public void testCalculateRegr() {
         db.executeTransactionally("CREATE " +
                 "(:REGR_TEST {x_property: 1 , y_property: 2 })," +
                 "(:REGR_TEST {x_property: 2 , y_property: 3 })," +
@@ -48,7 +48,7 @@ public static DbmsRule db = new ImpermanentDbmsRule();
     }
 
     @Test
-    public void testRegrR2isOne() throws Throwable {
+    public void testRegrR2isOne() {
         db.executeTransactionally("CREATE " +
                 "(:REGR_TEST2 {x_property: 1 , y_property: 1 })," +
                 "(:REGR_TEST2 {x_property: 1 , y_property: 1 })," +

--- a/core/src/test/java/apoc/math/RegressionTest.java
+++ b/core/src/test/java/apoc/math/RegressionTest.java
@@ -19,7 +19,7 @@ public class RegressionTest {
 public static DbmsRule db = new ImpermanentDbmsRule();
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, Regression.class);
     }
 

--- a/core/src/test/java/apoc/merge/MergeTest.java
+++ b/core/src/test/java/apoc/merge/MergeTest.java
@@ -23,7 +23,7 @@ public class MergeTest {
 
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         TestUtil.registerProcedure(db, Merge.class);
     }
 

--- a/core/src/test/java/apoc/merge/MergeTest.java
+++ b/core/src/test/java/apoc/merge/MergeTest.java
@@ -28,7 +28,7 @@ public class MergeTest {
     }
 
     @Test
-    public void testMergeNode() throws Exception {
+    public void testMergeNode() {
         testMergeNodeCommon(false);
     }
 
@@ -58,7 +58,7 @@ public class MergeTest {
     }
 
     @Test
-    public void testMergeNodeWithPreExisting() throws Exception {
+    public void testMergeNodeWithPreExisting() {
         db.executeTransactionally("CREATE (p:Person{ssid:'123', name:'Jim'})");
         testCall(db, "CALL apoc.merge.node(['Person'],{ssid:'123'}, {name:'John'}) YIELD node RETURN node",
                 (row) -> {
@@ -74,7 +74,7 @@ public class MergeTest {
     }
 
     @Test
-    public void testMergeRelationships() throws Exception {
+    public void testMergeRelationships() {
         db.executeTransactionally("create (:Person{name:'Foo'}), (:Person{name:'Bar'})");
 
         testCall(db, "MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e CALL apoc.merge.relationship(s, 'KNOWS', {rid:123}, {since:'Thu'}, e) YIELD rel RETURN rel",
@@ -152,7 +152,7 @@ public class MergeTest {
 
 
     @Test
-    public void testMergeEagerNode() throws Exception {
+    public void testMergeEagerNode() {
         testMergeEagerCommon(false);
     }
     
@@ -181,7 +181,7 @@ public class MergeTest {
     }
 
     @Test
-    public void testMergeEagerNodeWithOnCreate() throws Exception {
+    public void testMergeEagerNodeWithOnCreate() {
         testCall(db, "CALL apoc.merge.node.eager(['Person','Bastard'],{ssid:'123'}, {name:'John'},{occupation:'juggler'}) YIELD node RETURN node",
                 (row) -> {
                     Node node = (Node) row.get("node");
@@ -194,7 +194,7 @@ public class MergeTest {
     }
 
     @Test
-    public void testMergeEagerNodeWithOnMatch() throws Exception {
+    public void testMergeEagerNodeWithOnMatch() {
         db.executeTransactionally("CREATE (p:Person:Bastard {ssid:'123'})");
         testCall(db, "CALL apoc.merge.node.eager(['Person','Bastard'],{ssid:'123'}, {name:'John'}, {occupation:'juggler'}) YIELD node RETURN node",
                 (row) -> {
@@ -208,7 +208,7 @@ public class MergeTest {
     }
 
     @Test
-    public void testMergeEagerNodesWithOnMatchCanMergeOnMultipleMatches() throws Exception {
+    public void testMergeEagerNodesWithOnMatchCanMergeOnMultipleMatches() {
         db.executeTransactionally("UNWIND range(1,5) as index MERGE (:Person:`Bastard Man`{ssid:'123', index:index})");
 
         try (Transaction tx = db.beginTx()) {
@@ -229,7 +229,7 @@ public class MergeTest {
     }
 
     @Test
-    public void testMergeEagerRelationships() throws Exception {
+    public void testMergeEagerRelationships() {
         testMergeRelsCommon(false);
     }
     
@@ -289,7 +289,7 @@ public class MergeTest {
     }
 
     @Test
-    public void testMergeEagerRelationshipsWithOnMatch() throws Exception {
+    public void testMergeEagerRelationshipsWithOnMatch() {
         db.executeTransactionally("create (:Person{name:'Foo'}), (:Person{name:'Bar'})");
 
         testCall(db, "MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e CALL apoc.merge.relationship.eager(s, 'KNOWS', {rid:123}, {since:'Thu'}, e,{until:'Saturday'}) YIELD rel RETURN rel",
@@ -311,7 +311,7 @@ public class MergeTest {
     }
 
     @Test
-    public void testMergeEagerRelationshipsWithOnMatchCanMergeOnMultipleMatches() throws Exception {
+    public void testMergeEagerRelationshipsWithOnMatchCanMergeOnMultipleMatches() {
         db.executeTransactionally("CREATE (foo:Person{name:'Foo'}), (bar:Person{name:'Bar'}) WITH foo, bar UNWIND range(1,3) as index CREATE (foo)-[:KNOWS {rid:123}]->(bar)");
 
         try (Transaction tx = db.beginTx()) {

--- a/core/src/test/java/apoc/meta/CollEnterpriseTest.java
+++ b/core/src/test/java/apoc/meta/CollEnterpriseTest.java
@@ -44,14 +44,14 @@ public class CollEnterpriseTest {
     }
 
     @RepeatedTest(50)
-    public void testMin() throws Exception {
+    public void testMin() {
         assertEquals(1L, session.run("RETURN apoc.coll.min([1,2]) as value").next().get("value").asLong());
         assertEquals(1L, session.run("RETURN apoc.coll.min([1,2,3]) as value").next().get("value").asLong());
         assertEquals(0.5D, session.run("RETURN apoc.coll.min([0.5,1,2.3]) as value").next().get("value").asDouble(), 0.1);
     }
 
     @RepeatedTest(50)
-    public void testMax() throws Exception {
+    public void testMax() {
         assertEquals(3L, session.run("RETURN apoc.coll.max([1,2,3]) as value").next().get("value").asLong());
         assertEquals(2.3D, session.run("RETURN apoc.coll.max([0.5,1,2.3]) as value").next().get("value").asDouble(), 0.1);
     }

--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -70,7 +70,7 @@ public class MetaTest {
             .withSetting(newBuilder( "internal.dbms.debug.trace_cursors", BOOL, false ).build(), false);
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         TestUtil.registerProcedure(db, Meta.class, Graphs.class);
     }
 

--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -158,7 +158,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testMetaGraphExtraRels() throws Exception {
+    public void testMetaGraphExtraRels() {
         db.executeTransactionally("CREATE (a:S1 {SomeName1:'aaa'})\n" +
                 "CREATE (b:S2 {SomeName2:'bbb'})\n" +
                 "CREATE (c:S3 {SomeName3:'ccc'})\n" +
@@ -174,7 +174,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testMetaType() throws Exception {
+    public void testMetaType() {
         try (Transaction tx = db.beginTx()) {
             Node node = tx.createNode();
             Relationship rel = node.createRelationshipTo(node, RelationshipType.withName("FOO"));
@@ -197,7 +197,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testMetaTypeArray() throws Exception {
+    public void testMetaTypeArray() {
         testTypeName(asList(1,2), "LIST OF INTEGER");
         testTypeName(asList(LocalDate.of(2018, 1, 1),2), "LIST OF ANY");
         testTypeName(new Integer[] {1, 2}, "LIST OF INTEGER");
@@ -210,7 +210,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testMetaIsType() throws Exception {
+    public void testMetaIsType() {
         try (Transaction tx = db.beginTx()) {
             Node node = tx.createNode();
             Relationship rel = node.createRelationshipTo(node, RelationshipType.withName("FOO"));
@@ -232,7 +232,7 @@ public class MetaTest {
         testIsTypeName(null, "NULL");
     }
     @Test
-    public void testMetaTypes() throws Exception {
+    public void testMetaTypes() {
 
         Map<String, Object> param = map("MAP", singletonMap("a", 10),
                 "LIST OF INTEGER", asList(1, 2),
@@ -258,7 +258,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testMetaStats() throws Exception {
+    public void testMetaStats() {
         db.executeTransactionally("CREATE (:Actor)-[:ACTED_IN]->(:Movie) ");
         TestUtil.testCall(db, "CALL apoc.meta.stats()", r -> {
             assertEquals(2L,r.get("labelCount"));
@@ -274,7 +274,7 @@ public class MetaTest {
         });
     }
     @Test
-    public void testMetaGraph() throws Exception {
+    public void testMetaGraph() {
         db.executeTransactionally("CREATE (a:Actor)-[:ACTED_IN]->(m1:Movie),(a)-[:ACTED_IN]->(m2:Movie)");
         TestUtil.testCall(db, "CALL apoc.meta.graph()",
                 (row) -> {
@@ -295,7 +295,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testMetaGraph2() throws Exception {
+    public void testMetaGraph2() {
         db.executeTransactionally("CREATE (:Actor)-[:ACTED_IN]->(:Movie) ");
         TestUtil.testCall(db, "CALL apoc.meta.graphSample()",
                 (row) -> {
@@ -316,7 +316,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testMetaData() throws Exception {
+    public void testMetaData() {
         db.executeTransactionally("create index for (n:Movie) on (n.title)");
         db.executeTransactionally("create constraint for (a:Actor) require a.name is unique");
         db.executeTransactionally("CREATE (actor1:Actor {name:'Tom Hanks'})-[:ACTED_IN {roles:'Forrest'}]->(movie1:Movie {title:'Forrest Gump'}), \n" +
@@ -555,7 +555,7 @@ public class MetaTest {
     }
     
     @Test
-    public void testSubGraphNoLimits() throws Exception {
+    public void testSubGraphNoLimits() {
         db.executeTransactionally("CREATE (:A)-[:X]->(b:B),(b)-[:Y]->(:C)");
         testCall(db,"CALL apoc.meta.subGraph({})", (row) -> {
             List<Node> nodes = (List<Node>) row.get("nodes");
@@ -567,7 +567,7 @@ public class MetaTest {
         });
     }
     @Test
-    public void testSubGraphLimitLabels() throws Exception {
+    public void testSubGraphLimitLabels() {
         db.executeTransactionally("CREATE (:A)-[:X]->(b:B),(b)-[:Y]->(:C)");
         testCall(db,"CALL apoc.meta.subGraph({labels:['A','B']})", (row) -> {
             List<Node> nodes = (List<Node>) row.get("nodes");
@@ -579,7 +579,7 @@ public class MetaTest {
         });
     }
     @Test
-    public void testSubGraphLimitRelTypes() throws Exception {
+    public void testSubGraphLimitRelTypes() {
         db.executeTransactionally("CREATE (:A)-[:X]->(b:B),(b)-[:Y]->(:C)");
         testCall(db,"CALL apoc.meta.subGraph({rels:['X']})", (row) -> {
             List<Node> nodes = (List<Node>) row.get("nodes");
@@ -591,7 +591,7 @@ public class MetaTest {
         });
     }
     @Test
-    public void testSubGraphExcludes() throws Exception {
+    public void testSubGraphExcludes() {
         db.executeTransactionally("CREATE (:A)-[:X]->(b:B),(b)-[:Y]->(:C)");
         testCall(db,"CALL apoc.meta.subGraph({excludes:['B']})", (row) -> {
             List<Node> nodes = (List<Node>) row.get("nodes");
@@ -603,7 +603,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testMetaDate() throws Exception {
+    public void testMetaDate() {
 
         Map<String, Object> param = map(
                 "DATE", DateValue.now(Clock.systemDefaultZone()),
@@ -626,7 +626,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testMetaArray() throws Exception {
+    public void testMetaArray() {
 
         Map<String, Object> param = map(
                 "ARRAY", new String[]{"a","b","c"},
@@ -655,7 +655,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testMetaNumber() throws Exception {
+    public void testMetaNumber() {
 
         Map<String, Object> param = map(
                 "INTEGER", 1L,
@@ -674,7 +674,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testMeta() throws Exception {
+    public void testMeta() {
 
         Map<String, Object> param = map(
                 "LIST", asList(1.2, 2.1),
@@ -708,7 +708,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testMetaList() throws Exception {
+    public void testMetaList() {
 
         Map<String, Object> param = map(
                 "LIST FLOAT", asList(1.2F, 2.1F),
@@ -741,21 +741,21 @@ public class MetaTest {
     }
 
     @Test
-    public void testMetaPoint() throws Exception {
+    public void testMetaPoint() {
         db.executeTransactionally("CREATE (:TEST {born:point({ longitude: 56.7, latitude: 12.78, height: 100 })})");
 
         TestUtil.testCall(db, "MATCH (t:TEST) WITH t.born as born RETURN apoc.meta.cypher.type(born) AS value", row -> assertEquals("POINT", row.get("value")));
     }
 
     @Test
-    public void testMetaDuration() throws Exception {
+    public void testMetaDuration() {
         db.executeTransactionally("CREATE (:TEST {duration:duration('P5M1DT12H')})");
 
         TestUtil.testCall(db, "MATCH (t:TEST) WITH t.duration as duration RETURN apoc.meta.cypher.type(duration) AS value", row -> assertEquals("DURATION", row.get("value")));
     }
 
     @Test
-    public void testMetaDataWithSample() throws Exception {
+    public void testMetaDataWithSample() {
         db.executeTransactionally("create index for (n:Person) on (n.name)");
         db.executeTransactionally("CREATE (:Person {name:'Tom'})");
         db.executeTransactionally("CREATE (:Person {name:'John', surname:'Brown'})");
@@ -776,7 +776,7 @@ public class MetaTest {
 
 
     @Test
-    public void testMetaDataWithSampleNormalized() throws Exception {
+    public void testMetaDataWithSampleNormalized() {
         db.executeTransactionally("create index for (n:Person) on (n.name)");
         db.executeTransactionally("CREATE (:Person {name:'Tom'})");
         db.executeTransactionally("CREATE (:Person {name:'John'})");
@@ -811,7 +811,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testMetaDataWithSample5() throws Exception {
+    public void testMetaDataWithSample5() {
         db.executeTransactionally("create index for (n:Person) on (n.name)");
         db.executeTransactionally("CREATE (:Person {name:'John', surname:'Brown'})");
         db.executeTransactionally("CREATE (:Person {name:'Daisy', surname:'Bob'})");
@@ -896,7 +896,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testMetaGraphExtraRelsWithSample() throws Exception {
+    public void testMetaGraphExtraRelsWithSample() {
         db.executeTransactionally("CREATE (:S1 {name:'Tom'})");
         db.executeTransactionally("CREATE (:S2 {name:'John', surname:'Brown'})-[:KNOWS{since:2012}]->(:S7)");
         db.executeTransactionally("CREATE (:S1 {name:'Nick'})");
@@ -1353,7 +1353,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testMetaDataOf() throws Exception {
+    public void testMetaDataOf() {
         db.executeTransactionally("create index for (n:Movie) on (n.title)");
         db.executeTransactionally("create constraint for (a:Actor) require a.name is unique");
         db.executeTransactionally("CREATE (p:Person {name:'Tom Hanks'}), (m:Movie {title:'Forrest Gump'}), (pr:Product{name: 'Awesome Product'}), " +
@@ -1392,7 +1392,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testMetaGraphOf() throws Exception {
+    public void testMetaGraphOf() {
         db.executeTransactionally("CREATE (p:Person {name:'Tom Hanks'}), (m:Movie {title:'Forrest Gump'}), (pr:Product{name: 'Awesome Product'}), " +
                 "(p)-[:VIEWED]->(m), (p)-[:BOUGHT{quantity: 10}]->(pr)");
 

--- a/core/src/test/java/apoc/neighbors/NeighborsTest.java
+++ b/core/src/test/java/apoc/neighbors/NeighborsTest.java
@@ -20,7 +20,7 @@ public class NeighborsTest {
     public DbmsRule db = new ImpermanentDbmsRule();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         TestUtil.registerProcedure(db, Neighbors.class);
         db.executeTransactionally("CREATE (a:First), " +
                 "(b:Neighbor{name: 'b'}), " +

--- a/core/src/test/java/apoc/nodes/GroupingTest.java
+++ b/core/src/test/java/apoc/nodes/GroupingTest.java
@@ -47,7 +47,7 @@ public class GroupingTest {
     }
 
     @Test
-    public void testGroupAllNodes() throws Exception {
+    public void testGroupAllNodes() {
       createGraph();
       Map<String, Object> female = map("gender", "female", "count_*", 2L, "min_age", 28L);
       Map<String, Object> male = map("gender", "male", "count_*", 1L, "min_age", 42L);
@@ -95,7 +95,7 @@ public class GroupingTest {
     }
 
     @Test
-    public void testGroupNode() throws Exception {
+    public void testGroupNode() {
         createGraph();
         Map<String, Object> female = map("gender", "female", "count_*", 2L, "sum_kids", 3L, "min_age", 28L, "max_age", 32L, "avg_age", 30D);
         Map<String, Object> male = map("gender", "male", "count_*", 1L, "sum_kids", 3L, "min_age", 42L, "max_age", 42L, "avg_age", 42D);
@@ -133,14 +133,14 @@ public class GroupingTest {
     }
 
     @Test
-    public void testRemoveOrphans() throws Exception {
+    public void testRemoveOrphans() {
         db.executeTransactionally("CREATE (u:User {gender:'male'})");
         TestUtil.testCallCount(db, "CALL apoc.nodes.group(['User'],['gender'],null,{orphans:false})", 0);
         TestUtil.testCallCount(db, "CALL apoc.nodes.group(['User'],['gender'],null,{orphans:true})", 1);
     }
 
     @Test
-    public void testSelfRels() throws Exception {
+    public void testSelfRels() {
         db.executeTransactionally("CREATE (u:User {gender:'male'})-[:REL]->(u)");
 
         Relationship rel = TestUtil.singleResultFirstColumn(db, "CALL apoc.nodes.group(['User'],['gender'],null,{selfRels:true}) yield relationship return relationship");
@@ -151,7 +151,7 @@ public class GroupingTest {
     }
 
     @Test
-    public void testFilterMin() throws Exception {
+    public void testFilterMin() {
         db.executeTransactionally("CREATE (:User {name:'Joe',gender:'male'}), (:User {gender:'female',name:'Jane'}), (:User {gender:'female',name:'Jenny'})");
         TestUtil.testResult(db, "CALL apoc.nodes.group(['User'],['gender'],null,{filter:{`User.count_*.min`:2}})",
                 result -> {
@@ -162,7 +162,7 @@ public class GroupingTest {
     }
 
     @Test
-    public void testFilterMax() throws Exception {
+    public void testFilterMax() {
         db.executeTransactionally("CREATE (:User {name:'Joe',gender:'male'}), (:User {gender:'female',name:'Jane'}), (:User {gender:'female',name:'Jenny'})");
         TestUtil.testResult(db, "CALL apoc.nodes.group(['User'],['gender'],null,{filter:{`User.count_*.max`:1}})",
                 result -> {
@@ -173,19 +173,19 @@ public class GroupingTest {
     }
 
     @Test
-    public void testFilterRelationshipsInclude() throws Exception {
+    public void testFilterRelationshipsInclude() {
         db.executeTransactionally("CREATE (u:User {name:'Joe',gender:'male'})-[:KNOWS]->(u), (u)-[:LOVES]->(u)");
         assertEquals("KNOWS", TestUtil.singleResultFirstColumn(db, "CALL apoc.nodes.group(['User'],['gender'],null,{includeRels:'KNOWS'}) yield relationship return type(relationship)"));
     }
 
     @Test
-    public void testFilterRelationshipsExclude() throws Exception {
+    public void testFilterRelationshipsExclude() {
         db.executeTransactionally("CREATE (u:User {name:'Joe',gender:'male'})-[:KNOWS]->(u), (u)-[:LOVES]->(u)");
         assertEquals("KNOWS", TestUtil.singleResultFirstColumn(db, "CALL apoc.nodes.group(['User'],['gender'],null,{excludeRels:'LOVES'}) yield relationship return type(relationship)"));
     }
 
     @Test
-    public void testGroupAllLabels() throws Exception {
+    public void testGroupAllLabels() {
         db.executeTransactionally("CREATE (u:User {name:'Joe',gender:'male'})");
         TestUtil.testResult(db, "CALL apoc.nodes.group(['*'],['gender'])",
                 result -> {
@@ -195,7 +195,7 @@ public class GroupingTest {
     }
 
     @Test
-    public void testLimitNodes() throws Exception {
+    public void testLimitNodes() {
         db.executeTransactionally("CREATE (:User {name:'Joe',gender:'male'}), (:User {name:'Jane',gender:'female'})");
         TestUtil.testResult(db, "CALL apoc.nodes.group(['User'],['gender'],null, {limitNodes:1})",
                 result -> {
@@ -205,7 +205,7 @@ public class GroupingTest {
     }
 
     @Test
-    public void testLimitRelsNodes() throws Exception {
+    public void testLimitRelsNodes() {
         db.executeTransactionally("CREATE (u:User {name:'Joe',gender:'male'})-[:KNOWS]->(u), (u)-[:LOVES]->(u), (u)-[:HATES]->(u)");
         TestUtil.testResult(db, "CALL apoc.nodes.group(['User'],['gender'],null, {relsPerNode:1})",
                 result -> {

--- a/core/src/test/java/apoc/nodes/GroupingTest.java
+++ b/core/src/test/java/apoc/nodes/GroupingTest.java
@@ -27,7 +27,7 @@ public class GroupingTest {
     public DbmsRule db = new ImpermanentDbmsRule();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         TestUtil.registerProcedure(db, Grouping.class);
     }
 

--- a/core/src/test/java/apoc/nodes/NodesTest.java
+++ b/core/src/test/java/apoc/nodes/NodesTest.java
@@ -62,7 +62,7 @@ public class NodesTest {
     }
 
     @Test
-    public void isDense() throws Exception {
+    public void isDense() {
         db.executeTransactionally("CREATE (f:Foo) CREATE (b:Bar) WITH f UNWIND range(1,100) as id CREATE (f)-[:SELF]->(f)");
 
         TestUtil.testCall(db, "MATCH (n) WITH n, apoc.nodes.isDense(n) as dense " +
@@ -199,7 +199,7 @@ public class NodesTest {
     }
 
     @Test
-    public void link() throws Exception {
+    public void link() {
         db.executeTransactionally("UNWIND range(1,10) as id CREATE (n:Foo {id:id}) WITH collect(n) as nodes call apoc.nodes.link(nodes,'BAR') RETURN size(nodes) as len");
 
         long len = TestUtil.singleResultFirstColumn( db,"MATCH (n:Foo {id:1})-[r:BAR*9]->() RETURN size(r) as len");
@@ -232,7 +232,7 @@ public class NodesTest {
     }
 
     @Test
-    public void types() throws Exception {
+    public void types() {
         db.executeTransactionally("CREATE (f:Foo) CREATE (b:Bar) CREATE (f)-[:Y]->(f) CREATE (f)-[:X]->(f)");
         TestUtil.testCall(db, "MATCH (n:Foo) RETURN apoc.node.relationship.types(n) AS value", (r) -> assertEquals(asSet("X","Y"), asSet(((List)r.get("value")).toArray())));
         TestUtil.testCall(db, "MATCH (n:Foo) RETURN apoc.node.relationship.types(n,'X') AS value", (r) -> assertEquals(asList("X"), r.get("value")));
@@ -242,7 +242,7 @@ public class NodesTest {
     }
 
     @Test
-    public void nodesTypes() throws Exception {
+    public void nodesTypes() {
         // given
         db.executeTransactionally("CREATE (f:Foo), (f)-[:Y]->(f), (f)-[:X]->(f)");
         db.executeTransactionally("CREATE (f:Bar), (f)-[:YY]->(f), (f)-[:XX]->(f)");
@@ -266,7 +266,7 @@ public class NodesTest {
     }
 
     @Test
-    public void nodesHasRelationship() throws Exception {
+    public void nodesHasRelationship() {
         // given
         db.executeTransactionally("CREATE (f:Foo), (f)-[:X]->(f)");
         db.executeTransactionally("CREATE (b:Bar), (b)-[:Y]->(b)");
@@ -295,7 +295,7 @@ public class NodesTest {
 
 
     @Test
-    public void hasRelationhip() throws Exception {
+    public void hasRelationhip() {
         db.executeTransactionally("CREATE (:Foo)-[:Y]->(:Bar),(n:FooBar) WITH n UNWIND range(1,100) as _ CREATE (n)-[:X]->(n)");
         TestUtil.testCall(db,"MATCH (n:Foo) RETURN apoc.node.relationship.exists(n,'Y') AS value",(r)-> assertEquals(true,r.get("value")));
         TestUtil.testCall(db,"MATCH (n:Foo) RETURN apoc.node.relationship.exists(n,'Y>') AS value", (r)-> assertEquals(true,r.get("value")));
@@ -314,7 +314,7 @@ public class NodesTest {
     }
 
     @Test
-    public void hasRelationhips() throws Exception {
+    public void hasRelationhips() {
         db.executeTransactionally("CREATE (:Foo)-[:Y]->(:Bar),(n:FooBar) WITH n UNWIND range(1,100) as _ CREATE (n)-[:X]->(n)");
         TestUtil.testCall(db,"MATCH (n:Foo) RETURN apoc.node.relationships.exist(n,'Y') AS value",(r)-> assertEquals(map("Y",true),r.get("value")));
         TestUtil.testCall(db,"MATCH (n:Foo) RETURN apoc.node.relationships.exist(n,'Y>') AS value", (r)-> assertEquals(map("Y>",true),r.get("value")));
@@ -333,7 +333,7 @@ public class NodesTest {
     }
 
     @Test
-    public void testConnected() throws Exception {
+    public void testConnected() {
         db.executeTransactionally("CREATE (st:StartThin),(et:EndThin),(ed:EndDense)");
         int relCount = 20;
         for (int rel=0;rel<relCount;rel++) {

--- a/core/src/test/java/apoc/nodes/NodesTest.java
+++ b/core/src/test/java/apoc/nodes/NodesTest.java
@@ -57,7 +57,7 @@ public class NodesTest {
             .withSetting(GraphDatabaseSettings.procedure_unrestricted, singletonList("apoc.*"));
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         TestUtil.registerProcedure(db, Nodes.class, Create.class);
     }
 
@@ -221,7 +221,7 @@ public class NodesTest {
     }
 
     @Test
-    public void delete() throws Exception {
+    public void delete() {
         db.executeTransactionally("UNWIND range(1,100) as id CREATE (n:Foo {id:id})-[:X]->(n)");
 
         long count = TestUtil.singleResultFirstColumn(db, "MATCH (n:Foo) WITH collect(n) as nodes call apoc.nodes.delete(nodes,1) YIELD value as count RETURN count");

--- a/core/src/test/java/apoc/number/ArabicRomanTest.java
+++ b/core/src/test/java/apoc/number/ArabicRomanTest.java
@@ -9,6 +9,7 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import static apoc.util.TestUtil.testCall;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class ArabicRomanTest {
 
@@ -22,22 +23,22 @@ public class ArabicRomanTest {
     }
 
     @Test
-    public void testToArabic() throws Exception {
-        testCall(db, "RETURN apoc.number.romanToArabic('MCMXXXII') AS value", row -> assertEquals(new Integer(1932), row.get("value")));
-        testCall(db, "RETURN apoc.number.romanToArabic('C') AS value", row -> assertEquals(new Integer(100), row.get("value")));
-        testCall(db, "RETURN apoc.number.romanToArabic('mmx') AS value", row -> assertEquals(new Integer(2010), row.get("value")));
-        testCall(db, "RETURN apoc.number.romanToArabic('MXXIV') AS value", row -> assertEquals(new Integer(1024), row.get("value")));
-        testCall(db, "RETURN apoc.number.romanToArabic('aaa') AS value", row -> assertEquals(new Integer(0),  row.get("value")));
-        testCall(db, "RETURN apoc.number.romanToArabic('') AS value", row -> assertEquals(new Integer(0),  row.get("value")));
-        testCall(db, "RETURN apoc.number.romanToArabic(null) AS value", row -> assertEquals(new Integer(0),  row.get("value")));
+    public void testToArabic() {
+        testCall(db, "RETURN apoc.number.romanToArabic('MCMXXXII') AS value", row -> assertEquals(1932, row.get("value")));
+        testCall(db, "RETURN apoc.number.romanToArabic('C') AS value", row -> assertEquals(100, row.get("value")));
+        testCall(db, "RETURN apoc.number.romanToArabic('mmx') AS value", row -> assertEquals(2010, row.get("value")));
+        testCall(db, "RETURN apoc.number.romanToArabic('MXXIV') AS value", row -> assertEquals(1024, row.get("value")));
+        testCall(db, "RETURN apoc.number.romanToArabic('aaa') AS value", row -> assertEquals(0,  row.get("value")));
+        testCall(db, "RETURN apoc.number.romanToArabic('') AS value", row -> assertEquals(0,  row.get("value")));
+        testCall(db, "RETURN apoc.number.romanToArabic(null) AS value", row -> assertEquals(0,  row.get("value")));
     }
 
     @Test
-    public void testToRoman() throws Exception {
+    public void testToRoman() {
         testCall(db, "RETURN apoc.number.arabicToRoman(1932) AS value", row -> assertEquals("MCMXXXII", row.get("value")));
         testCall(db, "RETURN apoc.number.arabicToRoman(100) AS value", row -> assertEquals("C", row.get("value")));
         testCall(db, "RETURN apoc.number.arabicToRoman(2010) AS value", row -> assertEquals("MMX", row.get("value")));
         testCall(db, "RETURN apoc.number.arabicToRoman(1024) AS value", row -> assertEquals("MXXIV", row.get("value")));
-        testCall(db, "RETURN apoc.number.arabicToRoman(null) AS value", row -> assertEquals(null,  row.get("value")));
+        testCall(db, "RETURN apoc.number.arabicToRoman(null) AS value", row -> assertNull(row.get("value")));
     }
 }

--- a/core/src/test/java/apoc/number/ArabicRomanTest.java
+++ b/core/src/test/java/apoc/number/ArabicRomanTest.java
@@ -18,7 +18,7 @@ public class ArabicRomanTest {
 
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, ArabicRoman.class);
     }
 

--- a/core/src/test/java/apoc/number/NumbersTest.java
+++ b/core/src/test/java/apoc/number/NumbersTest.java
@@ -26,12 +26,12 @@ public class NumbersTest {
     public static DbmsRule db = new ImpermanentDbmsRule();
 
     @BeforeClass
-    public static void sUp() throws Exception {
+    public static void sUp() {
         TestUtil.registerProcedure(db, Numbers.class);
     }
 
     @Test
-    public void testFormat() throws Exception {
+    public void testFormat() {
         testCall(db, "RETURN apoc.number.format(12345) AS value", row -> assertEquals("12,345", row.get("value")));
         testCall(db, "RETURN apoc.number.format('aaa') AS value", row -> assertEquals(null, row.get("value")));
         testCall(db, "RETURN apoc.number.format(12345, '', 'it') AS value", row -> assertEquals("12.345", row.get("value")));
@@ -45,7 +45,7 @@ public class NumbersTest {
     }
 
     @Test
-    public void testParseInt() throws Exception {
+    public void testParseInt() {
         testCall(db, "RETURN apoc.number.parseInt('12,345') AS value", row -> assertEquals(new Long(12345), row.get("value")));
         testCall(db, "RETURN apoc.number.parseInt('12.345', '' ,'it') AS value", row -> assertEquals(new Long(12345), row.get("value")));
         testCall(db, "RETURN apoc.number.parseInt('12,345', '#,##0.00;(#,##0.00)') AS value", row -> assertEquals(new Long(12345), row.get("value")));
@@ -57,7 +57,7 @@ public class NumbersTest {
     // Parse Double
 
     @Test
-    public void testParseFloat() throws Exception {
+    public void testParseFloat() {
         testCall(db, "RETURN apoc.number.parseFloat('12,345.67') AS value", row -> assertEquals(new Double(12345.67), row.get("value")));
         testCall(db, "RETURN apoc.number.parseFloat('12.345,67', '', 'it') AS value", row -> assertEquals(new Double(12345.67), row.get("value")));
         testCall(db, "RETURN apoc.number.parseFloat('12,345.67', '#,##0.00;(#,##0.00)') AS value", row -> assertEquals(new Double(12345.67), row.get("value")));

--- a/core/src/test/java/apoc/number/exact/ExactTest.java
+++ b/core/src/test/java/apoc/number/exact/ExactTest.java
@@ -25,7 +25,7 @@ public class ExactTest {
 	@ClassRule
 	public static DbmsRule db = new ImpermanentDbmsRule();
 
-	@BeforeClass public static void sUp() throws Exception {
+	@BeforeClass public static void sUp() {
 		TestUtil.registerProcedure(db, Exact.class);
 	}
 

--- a/core/src/test/java/apoc/path/ExpandPathTest.java
+++ b/core/src/test/java/apoc/path/ExpandPathTest.java
@@ -30,7 +30,7 @@ public class ExpandPathTest {
 	public static DbmsRule db = new ImpermanentDbmsRule();
 
 	@BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, PathExplorer.class);
         String movies = Util.readResourceFile("movies.cypher");
 		String bigbrother = "MATCH (per:Person) MERGE (bb:BigBrother {name : 'Big Brother' })  MERGE (bb)-[:FOLLOWS]->(per)";

--- a/core/src/test/java/apoc/path/ExpandPathTest.java
+++ b/core/src/test/java/apoc/path/ExpandPathTest.java
@@ -29,9 +29,6 @@ public class ExpandPathTest {
     @ClassRule
 	public static DbmsRule db = new ImpermanentDbmsRule();
 
-	public ExpandPathTest() throws Exception {
-	}  
-	
 	@BeforeClass
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, PathExplorer.class);
@@ -50,7 +47,7 @@ public class ExpandPathTest {
 	}
 
 	@Test
-	public void testExplorePathAnyRelTypeTest() throws Throwable {
+	public void testExplorePathAnyRelTypeTest() {
 		TestUtil.testCall(db,
 				"MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.expand(m,'>','',0,2) yield path return count(*) as c",
 				(row) -> assertEquals(1L,row.get("c")));
@@ -67,19 +64,19 @@ public class ExpandPathTest {
 	}
 
 	@Test
-	public void testExplorePathRelationshipsTest() throws Throwable {
+	public void testExplorePathRelationshipsTest() {
 		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.expand(m,'<ACTED_IN|PRODUCED>|FOLLOWS','',0,2) yield path return count(*) as c";
 		TestUtil.testCall(db, query, (row) -> assertEquals(11L,row.get("c")));
 	}
 
 	@Test
-	public void testExplorePathLabelWhiteListTest() throws Throwable {
+	public void testExplorePathLabelWhiteListTest() {
 		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.expand(m,'ACTED_IN|PRODUCED|FOLLOWS','+Person|+Movie',0,3) yield path return count(*) as c";
 		TestUtil.testCall(db, query, (row) -> assertEquals(107L,row.get("c"))); // 59 with Uniqueness.RELATIONSHIP_GLOBAL
 	}
 
 	@Test
-	public void testExplorePathLabelBlackListTest() throws Throwable {
+	public void testExplorePathLabelBlackListTest() {
 		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.expand(m,null,'-BigBrother',0,2) yield path return count(*) as c";
 		TestUtil.testCall(db, query, (row) -> assertEquals(44L,row.get("c")));
 	}
@@ -102,7 +99,7 @@ public class ExpandPathTest {
 	}
 
 	@Test
-	public void testExplorePathWithFilterStartNodeFalseIgnoresLabelFilter() throws Throwable {
+	public void testExplorePathWithFilterStartNodeFalseIgnoresLabelFilter() {
 		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.expandConfig(m,{labelFilter:'+Person', maxLevel:2, filterStartNode:false}) yield path return count(*) as c";
 		TestUtil.testCall(db, query, (row) -> assertEquals(9L,row.get("c")));
 	}
@@ -295,7 +292,7 @@ public class ExpandPathTest {
 	}
 
 	@Test
-	public void testFilterStartNodeFalseDoesNotFilterStartNodeWhenBelowMinLevel() throws Throwable {
+	public void testFilterStartNodeFalseDoesNotFilterStartNodeWhenBelowMinLevel() {
 		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.expandConfig(m,{labelFilter:'+Person', minLevel:1, maxLevel:2, filterStartNode:false}) yield path return count(*) as c";
 		TestUtil.testCall(db, query, (row) -> assertEquals(8L,row.get("c")));
 	}
@@ -311,7 +308,7 @@ public class ExpandPathTest {
 	}
 
 	@Test
-	public void testFilterStartNodeDefaultsToFalse() throws Throwable {
+	public void testFilterStartNodeDefaultsToFalse() {
 		// was default true prior to 3.2.x
 		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.expandConfig(m,{labelFilter:'+Person'}) yield path return count(*) as c";
 		TestUtil.testCall(db, query, (row) -> assertEquals(9L,row.get("c")));

--- a/core/src/test/java/apoc/path/LabelSequenceTest.java
+++ b/core/src/test/java/apoc/path/LabelSequenceTest.java
@@ -23,7 +23,7 @@ public class LabelSequenceTest {
             .withSetting(newBuilder( "internal.dbms.debug.trace_cursors", BOOL, false ).build(), false);
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, PathExplorer.class);
         db.executeTransactionally("create (s:Start{name:'start'})-[:REL]->(:A{name:'a'})-[:REL]->(:B{name:'b'})-[:REL]->(:A:C{name:'ac'})-[:REL]->(:B:A{name:'ba'})-[:REL]->(:D:A{name:'da'})");
     }

--- a/core/src/test/java/apoc/path/LabelSequenceTest.java
+++ b/core/src/test/java/apoc/path/LabelSequenceTest.java
@@ -29,7 +29,7 @@ public class LabelSequenceTest {
     }
 
     @Test
-    public void testBasicSequence() throws Throwable {
+    public void testBasicSequence() {
         String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelFilter:'A,B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
@@ -39,7 +39,7 @@ public class LabelSequenceTest {
     }
 
     @Test
-    public void testNoMatchWhenImproperlyStartingSequenceAtStart() throws Throwable {
+    public void testNoMatchWhenImproperlyStartingSequenceAtStart() {
         String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelFilter:'A,B', beginSequenceAtStart:true, filterStartNode:true}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
@@ -48,7 +48,7 @@ public class LabelSequenceTest {
     }
 
     @Test
-    public void testMatchWhenProperlyStartingSequenceAtStart() throws Throwable {
+    public void testMatchWhenProperlyStartingSequenceAtStart() {
         String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelFilter:'Start,A,B', beginSequenceAtStart:true, filterStartNode:true}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
@@ -58,7 +58,7 @@ public class LabelSequenceTest {
     }
 
     @Test
-    public void testSequenceWithBlacklist() throws Throwable {
+    public void testSequenceWithBlacklist() {
         String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelFilter:'A|-C,B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
@@ -68,7 +68,7 @@ public class LabelSequenceTest {
     }
 
     @Test
-    public void testSequenceWithTerminatorNode() throws Throwable {
+    public void testSequenceWithTerminatorNode() {
         String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelFilter:'/A|C,B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
@@ -78,7 +78,7 @@ public class LabelSequenceTest {
     }
 
     @Test
-    public void testSequenceWithEndNode() throws Throwable {
+    public void testSequenceWithEndNode() {
         String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelFilter:'>A|C,B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
@@ -88,7 +88,7 @@ public class LabelSequenceTest {
     }
 
     @Test
-    public void testSequenceWithEndNodeAndLimit() throws Throwable {
+    public void testSequenceWithEndNodeAndLimit() {
         String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelFilter:'>A|C,B', beginSequenceAtStart:false, limit:2}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
@@ -98,7 +98,7 @@ public class LabelSequenceTest {
     }
 
     @Test
-    public void testSequenceWithTerminatorNodeAsStartNodeWithoutFilteringStartNode() throws Throwable {
+    public void testSequenceWithTerminatorNodeAsStartNodeWithoutFilteringStartNode() {
         String query = "MATCH (a:A {name: 'a'}) CALL apoc.path.subgraphNodes(a,{labelFilter:'/A, B', filterStartNode:false}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
@@ -108,7 +108,7 @@ public class LabelSequenceTest {
     }
 
     @Test
-    public void testSequenceWithTerminatorNodeAndEndNode() throws Throwable {
+    public void testSequenceWithTerminatorNodeAndEndNode() {
         String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelFilter:'>A|C|/A:C, B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
@@ -118,7 +118,7 @@ public class LabelSequenceTest {
     }
 
     @Test
-    public void testSequenceWithTerminatorNodeWhenUsingMinLevel() throws Throwable {
+    public void testSequenceWithTerminatorNodeWhenUsingMinLevel() {
         String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.expandConfig(s,{labelFilter:'/A, B', beginSequenceAtStart:false, minLevel:3}) yield path return collect(distinct last(nodes(path)).name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");

--- a/core/src/test/java/apoc/path/NodeFilterTest.java
+++ b/core/src/test/java/apoc/path/NodeFilterTest.java
@@ -26,7 +26,7 @@ public class NodeFilterTest {
     public static DbmsRule db = new ImpermanentDbmsRule();
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, PathExplorer.class);
         String movies = Util.readResourceFile("movies.cypher");
         try (Transaction tx = db.beginTx()) {

--- a/core/src/test/java/apoc/path/NodeFilterTest.java
+++ b/core/src/test/java/apoc/path/NodeFilterTest.java
@@ -25,9 +25,6 @@ public class NodeFilterTest {
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule();
 
-    public NodeFilterTest() throws Exception {
-    }
-
     @BeforeClass
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, PathExplorer.class);
@@ -325,13 +322,13 @@ public class NodeFilterTest {
 
 
     @Test
-    public void testStartNodeWithFilterStartNodeFalseIgnoresBlacklistNodes() throws Throwable {
+    public void testStartNodeWithFilterStartNodeFalseIgnoresBlacklistNodes() {
         String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.expandConfig(m,{blacklistNodes:[m], maxLevel:2, filterStartNode:false}) yield path return count(*) as c";
         TestUtil.testCall(db, query, (row) -> assertEquals(44L,row.get("c")));
     }
 
     @Test
-    public void testBlacklistNodesStillAppliesBelowMinLevel() throws Throwable {
+    public void testBlacklistNodesStillAppliesBelowMinLevel() {
         db.executeTransactionally("MATCH (c:Person) WHERE c.name in ['Clint Eastwood', 'Gene Hackman'] SET c:Western");
 
         TestUtil.testResult(db,
@@ -346,13 +343,13 @@ public class NodeFilterTest {
     }
 
     @Test
-    public void testStartNodeWithFilterStartNodeFalseIgnoresWhitelistNodesFilter() throws Throwable {
+    public void testStartNodeWithFilterStartNodeFalseIgnoresWhitelistNodesFilter() {
         String query = "MATCH (m:Movie {title: 'The Matrix'}), (k:Person {name:'Keanu Reeves'}) CALL apoc.path.expandConfig(m,{whitelistNodes:[k], minLevel:1, maxLevel:1, filterStartNode:false}) yield path return count(*) as c";
         TestUtil.testCall(db, query, (row) -> assertEquals(1L,row.get("c")));
     }
 
     @Test
-    public void testWhitelistNodesStillAppliesBelowMinLevel() throws Throwable {
+    public void testWhitelistNodesStillAppliesBelowMinLevel() {
         db.executeTransactionally("MATCH (c:Person) WHERE c.name in ['Clint Eastwood', 'Gene Hackman'] SET c:Western");
 
         TestUtil.testResult(db,
@@ -367,25 +364,25 @@ public class NodeFilterTest {
     }
 
     @Test
-    public void testStartNodeWithFilterStartNodeFalseIgnoresTerminatorNodesFilter() throws Throwable {
+    public void testStartNodeWithFilterStartNodeFalseIgnoresTerminatorNodesFilter() {
         String query = "MATCH (m:Movie {title: 'The Matrix'}), (k:Person {name:'Keanu Reeves'}) CALL apoc.path.expandConfig(m,{terminatorNodes:[m,k], maxLevel:2, filterStartNode:false}) yield path WITH k, path WHERE last(nodes(path)) = k RETURN count(*) as c";
         TestUtil.testCall(db, query, (row) -> assertEquals(1L,row.get("c")));
     }
 
     @Test
-    public void testTerminatorNodesDoesNotApplyBelowMinLevel() throws Throwable {
+    public void testTerminatorNodesDoesNotApplyBelowMinLevel() {
         String query = "MATCH (m:Movie {title: 'The Matrix'}), (k:Person {name:'Keanu Reeves'}) CALL apoc.path.expandConfig(m,{terminatorNodes:[m,k], minLevel:1, maxLevel:2, filterStartNode:true}) yield path WITH k, path WHERE last(nodes(path)) = k RETURN count(*) as c";
         TestUtil.testCall(db, query, (row) -> assertEquals(1L,row.get("c")));
     }
 
     @Test
-    public void testStartNodeWithFilterStartNodeFalseIgnoresEndNodesFilter() throws Throwable {
+    public void testStartNodeWithFilterStartNodeFalseIgnoresEndNodesFilter() {
         String query = "MATCH (m:Movie {title: 'The Matrix'}), (k:Person {name:'Keanu Reeves'}) CALL apoc.path.expandConfig(m,{endNodes:[m,k], maxLevel:2, filterStartNode:false}) yield path RETURN count(DISTINCT last(nodes(path))) as c";
         TestUtil.testCall(db, query, (row) -> assertEquals(1L,row.get("c")));
     }
 
     @Test
-    public void testEndNodesDoesNotApplyBelowMinLevel() throws Throwable {
+    public void testEndNodesDoesNotApplyBelowMinLevel() {
         String query = "MATCH (m:Movie {title: 'The Matrix'}), (k:Person {name:'Keanu Reeves'}) CALL apoc.path.expandConfig(m,{endNodes:[m,k], minLevel:1, maxLevel:2, filterStartNode:true}) yield path RETURN count(DISTINCT last(nodes(path))) as c";
         TestUtil.testCall(db, query, (row) -> assertEquals(1L,row.get("c")));
     }

--- a/core/src/test/java/apoc/path/PathsTest.java
+++ b/core/src/test/java/apoc/path/PathsTest.java
@@ -23,7 +23,7 @@ public class PathsTest {
     public static DbmsRule db = new ImpermanentDbmsRule();
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, Paths.class);
         db.executeTransactionally("CREATE (a:A)-[:NEXT]->(b:B)-[:NEXT]->(c:C)-[:NEXT]->(d:D)");
     }

--- a/core/src/test/java/apoc/path/PathsTest.java
+++ b/core/src/test/java/apoc/path/PathsTest.java
@@ -29,11 +29,11 @@ public class PathsTest {
     }
 
     @Test
-    public void createFull() throws Exception {
+    public void createFull() {
         TestUtil.testCall(db, "MATCH path = (a:A)-[:NEXT*]->(d:D) RETURN apoc.path.create(a, relationships(path)) as p",(row) -> assertPath(row, 3, "A", "D"));
     }
     @Test
-    public void createEmpty() throws Exception {
+    public void createEmpty() {
         TestUtil.testCall(db, "RETURN apoc.path.create(null) as p",(row) -> assertNull(row.get("p")));
 
         TestUtil.testCall(db, "MATCH (a:A) RETURN apoc.path.create(a) as p",(row) -> assertPath(row, 0, "A", "A"));
@@ -42,7 +42,7 @@ public class PathsTest {
     }
 
     @Test
-    public void slice() throws Exception {
+    public void slice() {
         TestUtil.testCall(db, "MATCH path = (a:A)-[:NEXT*]->(d:D) RETURN apoc.path.slice(path,1,1) as p",(row) -> assertPath(row, 1, "B", "C"));
         TestUtil.testCall(db, "MATCH path = (a:A)-[:NEXT*]->(d:D) RETURN apoc.path.slice(path,1) as p",(row) -> assertPath(row, 2, "B", "D"));
         TestUtil.testCall(db, "MATCH path = (a:A)-[:NEXT*]->(d:D) RETURN apoc.path.slice(path,1,100) as p",(row) -> assertPath(row, 2, "B", "D"));
@@ -52,18 +52,18 @@ public class PathsTest {
     }
 
     @Test(expected = QueryExecutionException.class)
-    public void combineFail() throws Exception {
+    public void combineFail() {
         TestUtil.testCall(db, "MATCH p1 = (a:A)-[:NEXT]->(b:B), p2 = (c:C)-[:NEXT]->() RETURN apoc.path.combine(p1,p2) AS p", (row) -> fail("Should have failed"));
     }
     @Test
-    public void combine() throws Exception {
+    public void combine() {
         TestUtil.testCall(db, "MATCH p1 = (a:A)-[:NEXT]->(b:B), p2 = (b)-[:NEXT]->() RETURN apoc.path.combine(p1,p2) as p",(row) -> assertPath(row, 2, "A", "C"));
         TestUtil.testCall(db, "MATCH p1 = (a:A)-[:NEXT]->(b:B) RETURN apoc.path.combine(p1,null) as p",(row) -> assertPath(row, 1, "A", "B"));
         TestUtil.testCall(db, "MATCH p1 = (a:A)-[:NEXT]->(b:B) RETURN apoc.path.combine(null,p1) as p",(row) -> assertPath(row, 1, "A", "B"));
     }
 
     @Test
-    public void elements() throws Exception {
+    public void elements() {
         TestUtil.testCall(db, "MATCH p = (a:A) RETURN apoc.path.elements(p) as e",(row) -> {
             List<Entity> pc = (List<Entity>) row.get("e");
             assertEquals(1,pc.size());

--- a/core/src/test/java/apoc/path/RelSequenceTest.java
+++ b/core/src/test/java/apoc/path/RelSequenceTest.java
@@ -25,7 +25,7 @@ public class RelSequenceTest {
     public static DbmsRule db = new ImpermanentDbmsRule();
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, PathExplorer.class);
         String movies = Util.readResourceFile("movies.cypher");
         String additionalLink = "match (p:Person{name:'Nora Ephron'}), (m:Movie{title:'When Harry Met Sally'}) create (p)-[:ACTED_IN]->(m)";

--- a/core/src/test/java/apoc/path/RelSequenceTest.java
+++ b/core/src/test/java/apoc/path/RelSequenceTest.java
@@ -37,7 +37,7 @@ public class RelSequenceTest {
     }
 
     @Test
-    public void testBasicRelSequence() throws Throwable {
+    public void testBasicRelSequence() {
         String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{relationshipFilter:'ACTED_IN>,<DIRECTED', labelFilter:'>Person,Movie'}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
         TestUtil.testCall(db, query, (row) -> {
             List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "Tom Hanks", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
@@ -48,7 +48,7 @@ public class RelSequenceTest {
     }
 
     @Test
-    public void testRelSequenceWithMinLevel() throws Throwable {
+    public void testRelSequenceWithMinLevel() {
         String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{relationshipFilter:'ACTED_IN>,<DIRECTED', labelFilter:'>Person,Movie', minLevel:3}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
         TestUtil.testCall(db, query, (row) -> {
             List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
@@ -59,7 +59,7 @@ public class RelSequenceTest {
     }
 
     @Test
-    public void testRelSequenceWithMaxLevel() throws Throwable {
+    public void testRelSequenceWithMaxLevel() {
         String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{relationshipFilter:'ACTED_IN>,<DIRECTED', labelFilter:'>Person,Movie', maxLevel:2}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
         TestUtil.testCall(db, query, (row) -> {
             List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Tom Hanks"));
@@ -70,7 +70,7 @@ public class RelSequenceTest {
     }
 
     @Test
-    public void testRelSequenceWhenNotBeginningAtStart() throws Throwable {
+    public void testRelSequenceWhenNotBeginningAtStart() {
         String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{relationshipFilter:'ACTED_IN>,<DIRECTED,ACTED_IN>', labelFilter:'Movie,>Person', beginSequenceAtStart:false}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
         TestUtil.testCall(db, query, (row) -> {
             List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "Tom Hanks", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));

--- a/core/src/test/java/apoc/path/SequenceTest.java
+++ b/core/src/test/java/apoc/path/SequenceTest.java
@@ -34,7 +34,7 @@ public class SequenceTest {
     }
 
     @Test
-    public void testBasicSequence() throws Throwable {
+    public void testBasicSequence() {
         String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{sequence:'>Person, ACTED_IN>, Movie, <DIRECTED'}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
         TestUtil.testCall(db, query, (row) -> {
             List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "Tom Hanks", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
@@ -45,7 +45,7 @@ public class SequenceTest {
     }
 
     @Test
-    public void testSequenceWithMinLevel() throws Throwable {
+    public void testSequenceWithMinLevel() {
         String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{sequence:'>Person, ACTED_IN>, Movie, <DIRECTED', minLevel:3}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
         TestUtil.testCall(db, query, (row) -> {
             List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
@@ -56,7 +56,7 @@ public class SequenceTest {
     }
 
     @Test
-    public void testSequenceWithMaxLevel() throws Throwable {
+    public void testSequenceWithMaxLevel() {
         String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{sequence:'>Person, ACTED_IN>, Movie, <DIRECTED', maxLevel:2}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
         TestUtil.testCall(db, query, (row) -> {
             List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Tom Hanks"));
@@ -67,7 +67,7 @@ public class SequenceTest {
     }
 
     @Test
-    public void testSequenceWhenNotBeginningAtStart() throws Throwable {
+    public void testSequenceWhenNotBeginningAtStart() {
         String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{sequence:'ACTED_IN>, Movie, <DIRECTED, >Person, ACTED_IN>', beginSequenceAtStart:false}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
         TestUtil.testCall(db, query, (row) -> {
             List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "Tom Hanks", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
@@ -78,7 +78,7 @@ public class SequenceTest {
     }
 
     @Test
-    public void testExpandWithSequenceIgnoresRelFilter() throws Throwable {
+    public void testExpandWithSequenceIgnoresRelFilter() {
         String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{sequence:'>Person, ACTED_IN>, Movie, <DIRECTED', relationshipFilter:'NONEXIST'}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
         TestUtil.testCall(db, query, (row) -> {
             List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "Tom Hanks", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
@@ -89,7 +89,7 @@ public class SequenceTest {
     }
 
     @Test
-    public void testExpandWithSequenceIgnoresLabelFilter() throws Throwable {
+    public void testExpandWithSequenceIgnoresLabelFilter() {
         String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{sequence:'>Person, ACTED_IN>, Movie, <DIRECTED', labelFilter:'-Person,-Movie'}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
         TestUtil.testCall(db, query, (row) -> {
             List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "Tom Hanks", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));

--- a/core/src/test/java/apoc/path/SequenceTest.java
+++ b/core/src/test/java/apoc/path/SequenceTest.java
@@ -22,7 +22,7 @@ public class SequenceTest {
     public static DbmsRule db = new ImpermanentDbmsRule();
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, PathExplorer.class);
         String movies = Util.readResourceFile("movies.cypher");
         String additionalLink = "match (p:Person{name:'Nora Ephron'}), (m:Movie{title:'When Harry Met Sally'}) create (p)-[:ACTED_IN]->(m)";

--- a/core/src/test/java/apoc/path/SubgraphTest.java
+++ b/core/src/test/java/apoc/path/SubgraphTest.java
@@ -34,7 +34,7 @@ public class SubgraphTest {
 	public static DbmsRule db = new ImpermanentDbmsRule();
 
 	@BeforeClass
-	public static void setUp() throws Exception {
+	public static void setUp() {
 		TestUtil.registerProcedure(db, PathExplorer.class, Cover.class);
 		String movies = Util.readResourceFile("movies.cypher");
 		String bigbrother = "MATCH (per:Person) MERGE (bb:BigBrother {name : 'Big Brother' })  MERGE (bb)-[:FOLLOWS]->(per)";

--- a/core/src/test/java/apoc/path/SubgraphTest.java
+++ b/core/src/test/java/apoc/path/SubgraphTest.java
@@ -59,13 +59,13 @@ public class SubgraphTest {
 	public ExpectedException thrown = ExpectedException.none();
 
 	@Test
-	public void testFullSubgraphShouldContainAllNodes() throws Throwable {
+	public void testFullSubgraphShouldContainAllNodes() {
 		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.subgraphNodes(m,{}) yield node return count(distinct node) as cnt";
 		TestUtil.testCall(db, query, (row) -> assertEquals(fullGraphCount, row.get("cnt")));
 	}
 	
 	@Test
-	public void testSubgraphWithMaxDepthShouldContainExpectedNodes() throws Throwable {
+	public void testSubgraphWithMaxDepthShouldContainExpectedNodes() {
 		String controlQuery = "MATCH (m:Movie {title: 'The Matrix'})-[*0..3]-(subgraphNode) return collect(distinct subgraphNode) as subgraph";
 		List<NodeResult> subgraph;
 		try (Transaction tx = db.beginTx()) {
@@ -82,7 +82,7 @@ public class SubgraphTest {
 	}
 	
 	@Test
-	public void testSubgraphWithLabelFilterShouldContainExpectedNodes() throws Throwable {
+	public void testSubgraphWithLabelFilterShouldContainExpectedNodes() {
 		String controlQuery = "MATCH path = (:Person {name: 'Keanu Reeves'})-[*0..3]-(subgraphNode) where all(node in nodes(path) where node:Person) return collect(distinct subgraphNode) as subgraph";
 		List<NodeResult> subgraph;
 		try (Transaction tx = db.beginTx()) {
@@ -99,7 +99,7 @@ public class SubgraphTest {
 	}
 	
 	@Test
-	public void testSubgraphWithRelationshipFilterShouldContainExpectedNodes() throws Throwable {
+	public void testSubgraphWithRelationshipFilterShouldContainExpectedNodes() {
 		String controlQuery = "MATCH path = (:Person {name: 'Keanu Reeves'})-[:ACTED_IN*0..3]-(subgraphNode) return collect(distinct subgraphNode) as subgraph";
 		List<NodeResult> subgraph;
 		try (Transaction tx = db.beginTx()) {
@@ -116,7 +116,7 @@ public class SubgraphTest {
 	}
 
 	@Test
-	public void testOptionalSubgraphNodesShouldReturnNull() throws Throwable {
+	public void testOptionalSubgraphNodesShouldReturnNull() {
 		String query =
 				"MATCH (k:Person {name: 'Keanu Reeves'}) " +
 						"CALL apoc.path.subgraphNodes(k,{labelFilter:'+nonExistent', maxLevel:3, optional:true, filterStartNode:true}) yield node " +
@@ -129,7 +129,7 @@ public class SubgraphTest {
 	}
 
 	@Test
-	public void testSubgraphAllShouldContainExpectedNodesAndRels() throws Throwable {
+	public void testSubgraphAllShouldContainExpectedNodesAndRels() {
 		String controlQuery =
 				"MATCH path = (:Person {name: 'Keanu Reeves'})-[*0..3]-(subgraphNode) " +
 				"with collect(distinct subgraphNode) as subgraph " +
@@ -159,7 +159,7 @@ public class SubgraphTest {
 	}
 
 	@Test
-	public void testOptionalSubgraphAllWithNoResultsShouldReturnEmptyLists() throws Throwable {
+	public void testOptionalSubgraphAllWithNoResultsShouldReturnEmptyLists() {
 		String query =
 				"MATCH (k:Person {name: 'Keanu Reeves'}) " +
 						"CALL apoc.path.subgraphAll(k,{labelFilter:'+nonExistent', maxLevel:3, optional:true, filterStartNode:true}) yield nodes, relationships " +
@@ -173,7 +173,7 @@ public class SubgraphTest {
 	}
 
 	@Test
-	public void testSubgraphAllWithNoResultsShouldReturnEmptyLists() throws Throwable {
+	public void testSubgraphAllWithNoResultsShouldReturnEmptyLists() {
 		String query =
 				"MATCH (k:Person {name: 'Keanu Reeves'}) " +
 						"CALL apoc.path.subgraphAll(k,{labelFilter:'+nonExistent', maxLevel:3, filterStartNode:true}) yield nodes, relationships " +
@@ -187,7 +187,7 @@ public class SubgraphTest {
 	}
 
 	@Test
-	public void testSpanningTreeShouldHaveOnlyOnePathToEachNode() throws Throwable {
+	public void testSpanningTreeShouldHaveOnlyOnePathToEachNode() {
 		String controlQuery = "MATCH (m:Movie {title: 'The Matrix'})-[*0..4]-(subgraphNode) return collect(distinct subgraphNode) as subgraph";
 		List<NodeResult> subgraph;
 		try (Transaction tx = db.beginTx()) {
@@ -214,7 +214,7 @@ public class SubgraphTest {
 	}
 
 	@Test
-	public void testOptionalSpanningTreeWithNoResultsShouldReturnNull() throws Throwable {
+	public void testOptionalSpanningTreeWithNoResultsShouldReturnNull() {
 		String query =
 				"MATCH (k:Person {name: 'Keanu Reeves'}) " +
 						"CALL apoc.path.spanningTree(k,{labelFilter:'+nonExistent', maxLevel:3, optional:true, filterStartNode:true}) yield path " +
@@ -227,7 +227,7 @@ public class SubgraphTest {
 	}
 
 	@Test
-	public void testOptionalSubgraphWithResultsShouldYieldExpectedResults() throws Throwable {
+	public void testOptionalSubgraphWithResultsShouldYieldExpectedResults() {
 		String controlQuery = "MATCH (m:Movie {title: 'The Matrix'})-[*0..3]-(subgraphNode) return collect(distinct subgraphNode) as subgraph";
 		List<NodeResult> subgraph;
 		try (Transaction tx = db.beginTx()) {
@@ -244,57 +244,57 @@ public class SubgraphTest {
 	}
 
 	@Test
-	public void testSubgraphNodesAllowsMinLevel0() throws Throwable {
+	public void testSubgraphNodesAllowsMinLevel0() {
 		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.subgraphNodes(m,{minLevel:0}) yield node return count(distinct node) as cnt";
 		TestUtil.testCall(db, query, (row) -> assertEquals(fullGraphCount, row.get("cnt")));
 	}
 
 	@Test
-	public void testSubgraphNodesAllowsMinLevel1() throws Throwable {
+	public void testSubgraphNodesAllowsMinLevel1() {
 		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.subgraphNodes(m,{minLevel:1}) yield node return count(distinct node) as cnt";
 		TestUtil.testCall(db, query, (row) -> assertEquals(fullGraphCount - 1, row.get("cnt")));
 	}
 
 	@Test
-	public void testSubgraphNodesErrorsAboveMinLevel1() throws Throwable {
+	public void testSubgraphNodesErrorsAboveMinLevel1() {
 		thrown.expect(QueryExecutionException.class);
 		thrown.expect(new RootCauseMatcher<>(IllegalArgumentException.class, "minLevel can only be 0 or 1 in subgraphNodes()"));
 		TestUtil.singleResultFirstColumn(db, "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.subgraphNodes(m,{minLevel:2}) yield node return count(distinct node) as cnt");
 	}
 
 	@Test
-	public void testSubgraphAllAllowsMinLevel0() throws Throwable {
+	public void testSubgraphAllAllowsMinLevel0() {
 		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.subgraphAll(m,{minLevel:0}) yield nodes return size(nodes) as cnt";
 		TestUtil.testCall(db, query, (row) -> assertEquals(fullGraphCount, row.get("cnt")));
 	}
 
 	@Test
-	public void testSubgraphAllAllowsMinLevel1() throws Throwable {
+	public void testSubgraphAllAllowsMinLevel1() {
 		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.subgraphAll(m,{minLevel:1}) yield nodes return size(nodes) as cnt";
 		TestUtil.testCall(db, query, (row) -> assertEquals(fullGraphCount - 1, row.get("cnt")));
 	}
 
 	@Test
-	public void testSubgraphAllErrorsAboveMinLevel1() throws Throwable {
+	public void testSubgraphAllErrorsAboveMinLevel1() {
 		thrown.expect(QueryExecutionException.class);
 		thrown.expect(new RootCauseMatcher<>(IllegalArgumentException.class, "minLevel can only be 0 or 1 in subgraphAll()"));
 		TestUtil.singleResultFirstColumn(db, "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.subgraphAll(m,{minLevel:2}) yield nodes return size(nodes) as cnt");
 	}
 
 	@Test
-	public void testSpanningTreeAllowsMinLevel0() throws Throwable {
+	public void testSpanningTreeAllowsMinLevel0() {
 		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.spanningTree(m,{minLevel:0}) yield path return count(distinct path) as cnt";
 		TestUtil.testCall(db, query, (row) -> assertEquals(fullGraphCount, row.get("cnt")));
 	}
 
 	@Test
-	public void testSpanningTreeAllowsMinLevel1() throws Throwable {
+	public void testSpanningTreeAllowsMinLevel1() {
 		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.spanningTree(m,{minLevel:1}) yield path return count(distinct path) as cnt";
 		TestUtil.testCall(db, query, (row) -> assertEquals(fullGraphCount - 1, row.get("cnt")));
 	}
 
 	@Test
-	public void testSpanningTreeErrorsAboveMinLevel1() throws Throwable {
+	public void testSpanningTreeErrorsAboveMinLevel1() {
 		thrown.expect(QueryExecutionException.class);
 		thrown.expect(new RootCauseMatcher<>(IllegalArgumentException.class, "minLevel can only be 0 or 1 in spanningTree()"));
 		TestUtil.singleResultFirstColumn(db, "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.spanningTree(m,{minLevel:2}) yield path return count(distinct path) as cnt");

--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -54,7 +54,7 @@ public class PeriodicTest {
     public DbmsRule db = new ImpermanentDbmsRule();
 
     @Before
-    public void initDb() throws Exception {
+    public void initDb() {
         TestUtil.registerProcedure(db, Periodic.class, Schemas.class, Cypher.class);
         db.executeTransactionally("call apoc.periodic.list() yield name call apoc.periodic.cancel(name) yield name as name2 return count(*)");
     }
@@ -154,7 +154,7 @@ public class PeriodicTest {
     }
 
     @Test
-    public void testSlottedRuntime() throws Exception {
+    public void testSlottedRuntime() {
         assertEquals("cypher runtime=slotted MATCH (n:cypher) RETURN n", Periodic.slottedRuntime("MATCH (n:cypher) RETURN n"));
         assertTrue(Periodic.slottedRuntime("MATCH (n) RETURN n").contains("cypher runtime=slotted "));
         assertFalse(Periodic.slottedRuntime(" cypher runtime=compiled MATCH (n) RETURN n").contains("cypher runtime=slotted "));
@@ -165,7 +165,7 @@ public class PeriodicTest {
 
     }
     @Test
-    public void testTerminateCommit() throws Exception {
+    public void testTerminateCommit() {
         PeriodicTestUtils.testTerminatePeriodicQuery(db, "CALL apoc.periodic.commit('UNWIND range(0,1000) as id WITH id CREATE (n:Foo {id: id}) RETURN n limit 1000', {})");
     }
 
@@ -175,7 +175,7 @@ public class PeriodicTest {
     }
 
     @Test
-    public void testRunDown() throws Exception {
+    public void testRunDown() {
         db.executeTransactionally("UNWIND range(1,$count) AS id CREATE (n:Person {id:id})", MapUtil.map("count", RUNDOWN_COUNT));
 
         String query = "MATCH (p:Person) WHERE NOT p:Processed WITH p LIMIT $limit SET p:Processed RETURN count(*)";
@@ -210,7 +210,7 @@ public class PeriodicTest {
     }
 
     @Test
-    public void testTerminateIterate() throws Exception {
+    public void testTerminateIterate() {
         PeriodicTestUtils.testTerminatePeriodicQuery(db, "CALL apoc.periodic.iterate('UNWIND range(0,1000) as id RETURN id', 'WITH $id as id CREATE (:Foo {id: $id})', {batchSize:1,parallel:true})");
         PeriodicTestUtils.testTerminatePeriodicQuery(db, "CALL apoc.periodic.iterate('UNWIND range(0,1000) as id RETURN id', 'WITH $id as id CREATE (:Foo {id: $id})', {batchSize:10,iterateList:true})");
         PeriodicTestUtils.testTerminatePeriodicQuery(db, "CALL apoc.periodic.iterate('UNWIND range(0,1000) as id RETURN id', 'WITH $id as id CREATE (:Foo {id: $id})', {batchSize:10,iterateList:false})");
@@ -272,7 +272,7 @@ public class PeriodicTest {
     }
 
     @Test
-    public void testIteratePrefixGiven() throws Exception {
+    public void testIteratePrefixGiven() {
         db.executeTransactionally("UNWIND range(1,100) AS x CREATE (:Person{name:'Person_'+x})");
 
         testResult(db, "CALL apoc.periodic.iterate('match (p:Person) return p', 'WITH $p as p SET p.lastname =p.name REMOVE p.name', {batchSize:10,parallel:true})", result -> {
@@ -288,7 +288,7 @@ public class PeriodicTest {
     }
 
     @Test
-    public void testIterate() throws Exception {
+    public void testIterate() {
         db.executeTransactionally("UNWIND range(1,100) AS x CREATE (:Person{name:'Person_'+x})");
 
         testResult(db, "CALL apoc.periodic.iterate('match (p:Person) return p', 'SET p.lastname =p.name REMOVE p.name', {batchSize:10,parallel:true})", result -> {
@@ -304,7 +304,7 @@ public class PeriodicTest {
     }
 
     @Test
-    public void testIterateWithQueryPlanner() throws Exception {
+    public void testIterateWithQueryPlanner() {
         db.executeTransactionally("UNWIND range(1,100) AS x CREATE (:Person{name:'Person_'+x})");
 
         String cypherIterate = "match (p:Person) return p";
@@ -380,7 +380,7 @@ public class PeriodicTest {
     }
 
     @Test
-    public void testIteratePrefix() throws Exception {
+    public void testIteratePrefix() {
         db.executeTransactionally("UNWIND range(1,100) AS x CREATE (:Person{name:'Person_'+x})");
 
         testResult(db, "CALL apoc.periodic.iterate('match (p:Person) return p', 'SET p.lastname =p.name REMOVE p.name', {batchSize:10,parallel:true})", result -> {
@@ -396,7 +396,7 @@ public class PeriodicTest {
     }
 
     @Test
-    public void testIteratePassThroughBatch() throws Exception {
+    public void testIteratePassThroughBatch() {
         db.executeTransactionally("UNWIND range(1,100) AS x CREATE (:Person{name:'Person_'+x})");
 
         testResult(db, "CALL apoc.periodic.iterate('match (p:Person) return p', 'UNWIND $_batch AS batch WITH batch.p AS p  SET p.lastname =p.name REMOVE p.name', {batchSize:10,parallel:true, batchMode: 'BATCH_SINGLE'})", result -> {
@@ -412,7 +412,7 @@ public class PeriodicTest {
     }
 
     @Test
-    public void testIterateBatch() throws Exception {
+    public void testIterateBatch() {
         db.executeTransactionally("UNWIND range(1,100) AS x CREATE (:Person{name:'Person_'+x})");
 
         testResult(db, "CALL apoc.periodic.iterate('match (p:Person) return p', 'SET p.lastname = p.name REMOVE p.name', {batchSize:10, iterateList:true, parallel:true})", result -> {
@@ -428,7 +428,7 @@ public class PeriodicTest {
     }
 
     @Test
-    public void testIterateBatchPrefix() throws Exception {
+    public void testIterateBatchPrefix() {
         db.executeTransactionally("UNWIND range(1,100) AS x CREATE (:Person{name:'Person_'+x})");
 
         testResult(db, "CALL apoc.periodic.iterate('match (p:Person) return p', 'SET p.lastname = p.name REMOVE p.name', {batchSize:10, iterateList:true, parallel:true})", result -> {
@@ -444,7 +444,7 @@ public class PeriodicTest {
     }
 
     @Test
-    public void testIterateWithReportingFailed() throws Exception {
+    public void testIterateWithReportingFailed() {
         testResult(db, "CALL apoc.periodic.iterate('UNWIND range(-5, 5) AS x RETURN x', 'return sum(1000/x)', {batchSize:3, failedParams:9999})", result -> {
             Map<String, Object> row = Iterators.single(result);
             assertEquals(4L, row.get("batches"));
@@ -461,7 +461,7 @@ public class PeriodicTest {
     }
 
     @Test
-    public void testIterateRetries() throws Exception {
+    public void testIterateRetries() {
         testResult(db, "CALL apoc.periodic.iterate('return 1', 'CREATE (n {prop: 1/$_retry})', {retries:1})", result -> {
             Map<String, Object> row = Iterators.single(result);
             assertEquals(1L, row.get("batches"));
@@ -471,7 +471,7 @@ public class PeriodicTest {
     }
 
     @Test
-    public void testIterateFail() throws Exception {
+    public void testIterateFail() {
         db.executeTransactionally("UNWIND range(1,100) AS x CREATE (:Person{name:'Person_'+x})");
         testResult(db, "CALL apoc.periodic.iterate('match (p:Person) return p', 'WITH $p as p SET p.lastname = p.name REMOVE x.name', {batchSize:10,parallel:true})", result -> {
             Map<String, Object> row = Iterators.single(result);

--- a/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
+++ b/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
@@ -771,7 +771,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                     assertEquals(id, node.getId());
                     assertEquals(true, node.hasLabel(Label.label("Country")));
                     assertEquals("USA", node.getProperty("name"));
-                    assertEquals(new Long(1),totRel);
+                    assertEquals(Long.valueOf(1),totRel);
                     assertEquals(true, rel.isType(RelationshipType.withName("TRAVELS_TO")));
                     assertEquals("work", rel.getProperty("reason"));
                     assertEquals(2010L, rel.getProperty("year"));
@@ -793,7 +793,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                     assertEquals(id, node.getId());
                     assertEquals(true, node.hasLabel(Label.label("Country")));
                     assertEquals("USA", node.getProperty("name"));
-                    assertEquals(new Long(1),totRel);
+                    assertEquals(Long.valueOf(1),totRel);
                     assertEquals(true, rel.isType(RelationshipType.withName("TRAVELS_TO")));
                     assertEquals("work", rel.getProperty("reason"));
                     assertEquals(1995L, rel.getProperty("year"));
@@ -815,7 +815,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                     assertEquals(id, node.getId());
                     assertEquals(true, node.hasLabel(Label.label("Country")));
                     assertEquals("USA", node.getProperty("name"));
-                    assertEquals(new Long(1),totRel);
+                    assertEquals(Long.valueOf(1),totRel);
                     assertEquals(true, rel.isType(RelationshipType.withName("TRAVELS_TO")));
                     assertEquals(Arrays.asList("work", "fun").toArray(), new ArrayBackedList(rel.getProperty("reason")).toArray());
                     assertEquals(Arrays.asList(1995L, 2010L).toArray(), new ArrayBackedList(rel.getProperty("year")).toArray());
@@ -837,7 +837,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                     assertEquals(id, node.getId());
                     assertEquals(true, node.hasLabel(Label.label("Country")));
                     assertEquals("USA", node.getProperty("name"));
-                    assertEquals(new Long(1),totRel);
+                    assertEquals(Long.valueOf(1),totRel);
                     assertEquals(true, rel.isType(RelationshipType.withName("TRAVELS_TO")));
                     assertEquals(Arrays.asList("work", "fun").toArray(), new ArrayBackedList(rel.getProperty("reason")).toArray());
                     assertEquals(Arrays.asList("1995", "2010", "2015").toArray(), new ArrayBackedList(rel.getProperty("year")).toArray());
@@ -949,7 +949,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                     assertEquals(id, node.getId());
                     assertEquals(true, node.hasLabel(Label.label("Country")));
                     assertEquals("USA", node.getProperty("name"));
-                    assertEquals(new Long(1),totRel);
+                    assertEquals(Long.valueOf(1),totRel);
                     assertEquals(true, rel.isType(RelationshipType.withName("TRAVELS_TO")));
                     assertEquals("work", rel.getProperty("reason"));
                     assertEquals(2010L, rel.getProperty("year"));

--- a/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
+++ b/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
@@ -81,7 +81,7 @@ public class GraphRefactoringTest {
     }
 
     @Test
-    public void deleteAndReconnect() throws Exception {
+    public void deleteAndReconnect() {
         db.executeTransactionally("CREATE (f:One)-[:ALPHA {a:'b'}]->(b:Two)-[:BETA {c:'d', e:'f'}]->(c:Three)-[:GAMMA]->(d:Four)-[:DELTA {aa: 'bb', cc: 'dd', ee: 'ff'}]->(e:Five {foo: 'bar', baz: 'baa'})");
 
         TestUtil.testCall(db, Util.NODE_COUNT, (row) -> assertEquals(5L, row.get("result")));
@@ -115,7 +115,7 @@ public class GraphRefactoringTest {
     }
 
     @Test
-    public void deleteAndReconnectWithTerminalNodes() throws Exception {
+    public void deleteAndReconnectWithTerminalNodes() {
         db.executeTransactionally("CREATE (f:One)-[:ALPHA {a:'b'}]->(c:Two)-[:GAMMA]->(e:Three {foo: 'bar', baz: 'baa'})");
 
         // - terminal node
@@ -149,7 +149,7 @@ public class GraphRefactoringTest {
     }
 
     @Test
-    public void deleteAndReconnectConsecutiveNodes() throws Exception {
+    public void deleteAndReconnectConsecutiveNodes() {
         db.executeTransactionally("CREATE (f:Alpha)-[:REL_1 {a:'b'}]->(b:Beta)-[:REL_2 {c:'d', e:'f'}]->(c:Gamma)-[:REL_3]->(d:Delta)-[:REL_4 {aa: 'bb', cc: 'dd', ee: 'ff'}]->(e:Epsilon {foo: 'bar', baz: 'baa'})");
 
         TestUtil.testCall(db, Util.NODE_COUNT, (row) -> assertEquals(5L, row.get("result")));
@@ -182,7 +182,7 @@ public class GraphRefactoringTest {
     }
 
     @Test
-    public void deleteAndReconnectWithIncomingRelConfig() throws Exception {
+    public void deleteAndReconnectWithIncomingRelConfig() {
         db.executeTransactionally("CREATE (f:One)-[:ALPHA {a:'b'}]->(b:Two)-[:BETA {c:'d', e:'f'}]->(c:Three)-[:GAMMA]->(d:Four)-[:DELTA {aa: 'bb', cc: 'dd', ee: 'ff'}]->(e:Five {foo: 'bar', baz: 'baa'})");
 
         TestUtil.testCall(db, Util.NODE_COUNT, (row) -> assertEquals(5L, row.get("result")));
@@ -211,7 +211,7 @@ public class GraphRefactoringTest {
     }
 
     @Test
-    public void deleteAndReconnectWithOutgoingRelConfig() throws Exception {
+    public void deleteAndReconnectWithOutgoingRelConfig() {
         db.executeTransactionally("CREATE (f:One)-[:ALPHA {a:'b'}]->(b:Two)-[:BETA {c:'d', e:'f'}]->(c:Three)-[:GAMMA]->(d:Four)-[:DELTA {aa: 'bb', cc: 'dd', ee: 'ff'}]->(e:Five {foo: 'bar', baz: 'baa'})");
 
         TestUtil.testCall(db, Util.NODE_COUNT, (row) -> assertEquals(5L, row.get("result")));
@@ -244,7 +244,7 @@ public class GraphRefactoringTest {
     }
 
     @Test
-    public void deleteAndReconnectWithMergeRelConfig() throws Exception {
+    public void deleteAndReconnectWithMergeRelConfig() {
         db.executeTransactionally("CREATE (f:One)-[:ALPHA {a:'b'}]->(b:Two)-[:BETA {a:'d', e:'f', g: 'h'}]->(c:Three)-[:GAMMA {aa: 'one'}]->(d:Four)-[:DELTA {aa: 'bb', cc: 'dd', ee: 'ff'}]->(e:Five {foo: 'bar', baz: 'baa'})");
 
         TestUtil.testCall(db, Util.NODE_COUNT, (row) -> assertEquals(5L, row.get("result")));
@@ -278,7 +278,7 @@ public class GraphRefactoringTest {
     }
 
     @Test
-    public void deleteAndReconnectWithMergeRelConfigAndPropertiesCombine() throws Exception {
+    public void deleteAndReconnectWithMergeRelConfigAndPropertiesCombine() {
         db.executeTransactionally("CREATE (f:One)-[:ALPHA {a:'b'}]->(b:Two)-[:BETA {a:'d', e:'f', g: 'h'}]->(c:Three)-[:GAMMA {aa: 'one'}]->(d:Four)-[:DELTA {aa: 'bb', cc: 'dd', ee: 'ff'}]->(e:Five {foo: 'bar', baz: 'baa'})");
 
         TestUtil.testCall(db, Util.NODE_COUNT, (row) -> assertEquals(5L, row.get("result")));
@@ -312,7 +312,7 @@ public class GraphRefactoringTest {
     }
 
     @Test
-    public void deleteAndReconnectWithMergeRelConfigAndPropertiesOverride() throws Exception {
+    public void deleteAndReconnectWithMergeRelConfigAndPropertiesOverride() {
         db.executeTransactionally("CREATE (f:One)-[:ALPHA {a:'b'}]->(b:Two)-[:BETA {a:'d', e:'f', g: 'h'}]->(c:Three)-[:GAMMA {aa: 'one'}]->(d:Four)-[:DELTA {aa: 'bb', cc: 'dd', ee: 'ff'}]->(e:Five {foo: 'bar', baz: 'baa'})");
 
         TestUtil.testCall(db, Util.NODE_COUNT, (row) -> assertEquals(5L, row.get("result")));
@@ -346,7 +346,7 @@ public class GraphRefactoringTest {
     }
 
     @Test
-    public void testDeleteOneNode() throws Exception {
+    public void testDeleteOneNode() {
         long id = db.executeTransactionally("CREATE (p1:Person {ID:1}), (p2:Person {ID:2}) RETURN id(p1) as id ", emptyMap(), result -> Iterators.single(result.columnAs("id")));
         testCall(db, "MATCH (o:Person {ID:$oldID}), (n:Person {ID:$newID}) DELETE o RETURN n as node",
                       map("oldID", 1L, "newID",2L),
@@ -359,7 +359,7 @@ public class GraphRefactoringTest {
     }
 
     @Test
-    public void testEagernessMergeNodesFails() throws Exception {
+    public void testEagernessMergeNodesFails() {
         db.executeTransactionally("CREATE INDEX FOR (n:Person) ON (n.ID)");
         long id = db.executeTransactionally("CREATE (p1:Person {ID:1}), (p2:Person {ID:2}) RETURN id(p1) as id ", emptyMap(), result -> Iterators.single(result.columnAs("id")));
         testCall(db, "MATCH (o:Person {ID:$oldID}), (n:Person {ID:$newID}) CALL apoc.refactor.mergeNodes([o,n]) yield node return node",
@@ -373,7 +373,7 @@ public class GraphRefactoringTest {
     }
 
     @Test
-    public void testMergeNodesEagerAggregation() throws Exception {
+    public void testMergeNodesEagerAggregation() {
         long id = db.executeTransactionally("CREATE (p1:Person {ID:1}), (p2:Person {ID:2}) RETURN id(p1) as id ", emptyMap(), result -> Iterators.single(result.columnAs("id")));
         testCall(db, "MATCH (o:Person {ID:$oldID}), (n:Person {ID:$newID}) WITH head(collect([o,n])) as nodes CALL apoc.refactor.mergeNodes(nodes) yield node return node",
                       map("oldID", 1L, "newID",2L),
@@ -386,7 +386,7 @@ public class GraphRefactoringTest {
     }
 
     @Test
-    public void testMergeNodesEagerIndex() throws Exception {
+    public void testMergeNodesEagerIndex() {
         db.executeTransactionally("CREATE INDEX FOR (n:Person) ON (n.ID)");
         db.executeTransactionally("CALL db.awaitIndexes()");
         long id = db.executeTransactionally("CREATE (p1:Person {ID:1}), (p2:Person {ID:2}) RETURN id(p1) as id ", emptyMap(), result -> Iterators.single(result.columnAs("id")));
@@ -400,7 +400,7 @@ public class GraphRefactoringTest {
                 });
     }
     @Test
-    public void testMergeNodesIndexConflict() throws Exception {
+    public void testMergeNodesIndexConflict() {
         /*
         CREATE CONSTRAINT FOR (a:A) REQUIRE a.prop1 IS UNIQUE;
 CREATE CONSTRAINT FOR (a:B) REQUIRE a.prop2 IS UNIQUE;
@@ -506,7 +506,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
 
     @Test
-    public void testExtractNode() throws Exception {
+    public void testExtractNode() {
         Long id = db.executeTransactionally("CREATE (f:Foo)-[rel:FOOBAR {a:1}]->(b:Bar) RETURN id(rel) as id", emptyMap(), result -> Iterators.single(result.columnAs("id")));
         testCall(db, "CALL apoc.refactor.extractNode($ids,['FooBar'],'FOO','BAR')", map("ids", singletonList(id)),
                 (r) -> {
@@ -519,7 +519,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                 });
     }
     @Test
-    public void testInvertRelationship() throws Exception {
+    public void testInvertRelationship() {
         long id = db.executeTransactionally("CREATE (f:Foo)-[rel:FOOBAR {a:1}]->(b:Bar) RETURN id(rel) as id", emptyMap(), result -> Iterators.single(result.columnAs("id")));
         testCall(db, "MATCH ()-[r]->() WHERE id(r) = $id CALL apoc.refactor.invert(r) yield input, output RETURN *", map("id", id),
                 (r) -> {
@@ -548,7 +548,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
     
     @Test
-    public void testCollapseNode() throws Exception {
+    public void testCollapseNode() {
         Long id = db.executeTransactionally("CREATE (f:Foo)-[:FOO {a:1}]->(b:Bar {c:3})-[:BAR {b:2}]->(f) RETURN id(b) as id", emptyMap(), result -> Iterators.single(result.columnAs("id")));
         testCall(db, "CALL apoc.refactor.collapseNode($ids,'FOOBAR')", map("ids", singletonList(id)),
                 (r) -> {
@@ -564,7 +564,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
 
     @Test
-    public void testNormalizeAsBoolean() throws Exception {
+    public void testNormalizeAsBoolean() {
         db.executeTransactionally("CREATE ({prop: 'Y', id:1}),({prop: 'Yes', id: 2}),({prop: 'NO', id: 3}),({prop: 'X', id: 4})");
 
         testResult(
@@ -621,12 +621,12 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
 
     @Test
-    public void testCategorizeOutgoing() throws Exception {
+    public void testCategorizeOutgoing() {
         categorizeWithDirection(Direction.OUTGOING);
     }
 
     @Test
-    public void testCategorizeIncoming() throws Exception {
+    public void testCategorizeIncoming() {
         categorizeWithDirection(Direction.INCOMING);
     }
 
@@ -656,7 +656,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
 
     @Test
-    public void testCloneNodes() throws Exception {
+    public void testCloneNodes() {
         Long nodeId = db.executeTransactionally("CREATE (f:Foo {name:'foo',age:42})-[:FB]->(:Bar) RETURN id(f) AS nodeId", emptyMap(),
                 result -> Iterators.single(result.columnAs("nodeId")));
         TestUtil.testCall(db, "MATCH (n:Foo) WHERE id(n) = $nodeId CALL apoc.refactor.cloneNodes([n]) yield output as node return properties(node) as props,[(node)-[r]->() | type(r)] as types",
@@ -690,7 +690,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
 
     @Test
-    public void testMergeNodesWithConstraints() throws Exception {
+    public void testMergeNodesWithConstraints() {
         db.executeTransactionally("CREATE CONSTRAINT FOR (p:Person) REQUIRE p.name IS UNIQUE");
         long id = db.executeTransactionally("CREATE (p1:Person {name:'Foo'}), (p2:Person {surname:'Bar'}) RETURN id(p1) as id",
                 emptyMap(),
@@ -707,7 +707,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
 
     @Test
-    public void testMergeNodesWithIngoingRelationships() throws Exception {
+    public void testMergeNodesWithIngoingRelationships() {
         long lisaId = db.executeTransactionally("CREATE \n" +
                 "(alice:Person {name:'Alice'}),\n" +
                 "(bob:Person {name:'Bob'}),\n" +
@@ -734,7 +734,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
 
     @Test
-    public void testMergeNodesWithSelfRelationships() throws Exception {
+    public void testMergeNodesWithSelfRelationships() {
         Map<String, Object> result = db.executeTransactionally("CREATE \n" +
                 "(alice:Person {name:'Alice'}),\n" +
                 "(bob:Person {name:'Bob'}),\n" +
@@ -757,7 +757,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
 
     @Test
-    public void testMergeRelsOverwriteEagerAggregation() throws Exception {
+    public void testMergeRelsOverwriteEagerAggregation() {
         long id = db.executeTransactionally("Create (d:Person {name:'Daniele'})\n" + "Create (p:Country {name:'USA'})\n" + "Create (d)-[:TRAVELS_TO {year:1995, reason:\"work\"}]->(p)\n"
                 + "Create (d)-[:GOES_TO {year:2010}]->(p)\n" + "Create (d)-[:FLIGHTS_TO {company:\"Air America\"}]->(p) RETURN id(p) as id ",
                 emptyMap(),
@@ -779,7 +779,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
 
     @Test
-    public void testMergeRelsCombineEagerAggregation() throws Exception {
+    public void testMergeRelsCombineEagerAggregation() {
         long id = db.executeTransactionally("Create (d:Person {name:'Daniele'})\n" + "Create (p:Country {name:'USA'})\n" + "Create (d)-[:TRAVELS_TO {year:1995, reason:\"work\"}]->(p)\n"
                 + "Create (d)-[:GOES_TO {year:2010, reason:\"fun\"}]->(p)\n" + "Create (d)-[:FLIGHTS_TO {company:\"Air America\"}]->(p) RETURN id(p) as id ",
                 emptyMap(),
@@ -801,7 +801,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
 
     @Test
-    public void testMergeRelsEagerAggregationCombineSingleValuesProperty() throws Exception {
+    public void testMergeRelsEagerAggregationCombineSingleValuesProperty() {
         long id = db.executeTransactionally("Create (d:Person {name:'Daniele'})\n" + "Create (p:Country {name:'USA'})\n" + "Create (d)-[:TRAVELS_TO {year:1995, reason:\"work\"}]->(p)\n"
                 + "Create (d)-[:GOES_TO {year:2010, reason:\"fun\"}]->(p)\n" + "Create (d)-[:FLIGHTS_TO {company:\"Air America\"}]->(p) RETURN id(p) as id ",
                 emptyMap(),
@@ -823,7 +823,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
 
     @Test
-    public void testMergeRelsEagerAggregationCombineArrayDifferentValuesTypeProperties() throws Exception {
+    public void testMergeRelsEagerAggregationCombineArrayDifferentValuesTypeProperties() {
         long id = db.executeTransactionally("Create (d:Person {name:'Daniele'})\n" + "Create (p:Country {name:'USA'})\n" + "Create (d)-[:TRAVELS_TO {year:1995, reason:\"work\"}]->(p)\n"
                 + "Create (d)-[:GOES_TO {year:[\"2010\",\"2015\"], reason:\"fun\"}]->(p)\n" + "Create (d)-[:FLIGHTS_TO {company:\"Air America\"}]->(p) RETURN id(p) as id ",
                 emptyMap(),
@@ -935,7 +935,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
 
     @Test
-    public void testMergeRelsOverridePropertiesEagerAggregation() throws Exception {
+    public void testMergeRelsOverridePropertiesEagerAggregation() {
         long id = db.executeTransactionally("Create (d:Person {name:'Daniele'})\n" + "Create (p:Country {name:'USA'})\n" + "Create (d)-[:TRAVELS_TO {year:1995, reason:\"work\"}]->(p)\n"
                 + "Create (d)-[:GOES_TO {year:2010}]->(p)\n" + "Create (d)-[:FLIGHTS_TO {company:\"Air America\"}]->(p) RETURN id(p) as id ",
                 emptyMap(),
@@ -957,7 +957,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
 
     @Test
-    public void testMergeNodesOverridePropertiesEagerAggregation() throws Exception {
+    public void testMergeNodesOverridePropertiesEagerAggregation() {
         long id = db.executeTransactionally("CREATE (p1:Person {ID:1}), (p2:Person {ID:2}) RETURN id(p1) as id ",
                 emptyMap(),
                 result -> Iterators.single(result.columnAs("id")));
@@ -972,7 +972,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
 
     @Test
-    public void testMergeNodesOnArrayValues() throws Exception {
+    public void testMergeNodesOnArrayValues() {
         long id = db.executeTransactionally("CREATE (p1:Person {ID:1, prop: ['foo']}), (p2:Person {ID:2, prop: ['foo']}) RETURN id(p1) as id ",
                 emptyMap(),
                 result -> Iterators.single(result.columnAs("id")));
@@ -988,7 +988,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
 
     @Test
-    public void testMergeNodesOnArrayValuesPreventTypeChange() throws Exception {
+    public void testMergeNodesOnArrayValuesPreventTypeChange() {
         long id = db.executeTransactionally("CREATE (p1:Person {ID:1, prop: ['foo']}), (p2:Person {ID:2, prop: ['foo']}) RETURN id(p1) as id ",
                 emptyMap(),
                 result -> Iterators.single(result.columnAs("id")));

--- a/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
+++ b/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
@@ -71,7 +71,7 @@ public class GraphRefactoringTest {
             .withSetting(newBuilder( "internal.dbms.debug.trace_cursors", BOOL, false ).build(), false);
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         TestUtil.registerProcedure(db, GraphRefactoring.class);
     }
 

--- a/core/src/test/java/apoc/refactor/rename/RenameTest.java
+++ b/core/src/test/java/apoc/refactor/rename/RenameTest.java
@@ -44,7 +44,7 @@ public class RenameTest {
 	}
 
 	@Test
-	public void testRenameLabelForSomeNodes() throws Exception {
+	public void testRenameLabelForSomeNodes() {
 		List<Node> nodes = TestUtil.firstColumn(db, "UNWIND range(0,9) as id CREATE (f:Foo {id: id, name: 'name'+id}) RETURN f");
 		testCall(db, "CALL apoc.refactor.rename.label($oldName,$newName, $nodes)",
 				map("oldName", "Foo", "newName", "Bar", "nodes", nodes.subList(0,3)), (r) -> {});
@@ -54,7 +54,7 @@ public class RenameTest {
 	}
 
 	@Test
-	public void testRenameLabel() throws Exception {
+	public void testRenameLabel() {
 		db.executeTransactionally("UNWIND range(0,9) AS id CREATE (f:Foo {id: id})");
 		testCall(db, "CALL apoc.refactor.rename.label($oldName,$newName)",
 				map("oldName", "Foo", "newName", "Bar"), (r) -> {});
@@ -64,7 +64,7 @@ public class RenameTest {
 	}
 
 	@Test
-	public void testRenameLabelDoesntAllowCypherInjection() throws Exception {
+	public void testRenameLabelDoesntAllowCypherInjection() {
 		db.executeTransactionally("UNWIND range(0,9) AS id CREATE (f:Foo {id: id})");
 		testCall(db, "CALL apoc.refactor.rename.label(" +
 						"  'Foo', " +
@@ -88,7 +88,7 @@ public class RenameTest {
 	}
 
 	@Test
-	public void testRenameLabelDoesntAllowCypherInjectionForSomeNodes() throws Exception {
+	public void testRenameLabelDoesntAllowCypherInjectionForSomeNodes() {
 		List<Node> nodes = TestUtil.firstColumn(db, "UNWIND range(0,9) as id CREATE (f:Foo {id: id, name: 'name'+id}) RETURN f");
 		testCall(db, "CALL apoc.refactor.rename.label(" +
 						"  'Foo', " +
@@ -120,7 +120,7 @@ public class RenameTest {
 	}
 
 	@Test
-	public void testRenameRelationship() throws Exception {
+	public void testRenameRelationship() {
 		db.executeTransactionally("UNWIND range(0,9) AS id CREATE (f:Foo {id: id})-[:KNOWS {id: id}]->(l:Fii {id: id})");
 		testCall(db, "CALL apoc.refactor.rename.type($oldType,$newType)",
 				map("oldType", "KNOWS", "newType", "LOVES"), (r) -> {});
@@ -130,7 +130,7 @@ public class RenameTest {
 	}
 
 	@Test
-	public void testRenameTypeForSomeRelationships() throws Exception {
+	public void testRenameTypeForSomeRelationships() {
 		db.executeTransactionally("UNWIND range(0,9) AS id CREATE (f:Foo {id: id})-[:KNOWS {id: id}]->(l:Fii {id: id})");
 
 		List<Relationship> rels = TestUtil.firstColumn(db, "MATCH (:Foo)-[r:KNOWS]->(:Fii) RETURN r LIMIT 2");
@@ -143,7 +143,7 @@ public class RenameTest {
 	}
 
 	@Test
-	public void testRenameTypeDoesntAllowCypherInjection() throws Exception {
+	public void testRenameTypeDoesntAllowCypherInjection() {
 		db.executeTransactionally("UNWIND range(0,9) AS id CREATE (f:Foo {id: id})-[:KNOWS {id: id}]->(l:Fii {id: id})");
 		testCall(db, "CALL apoc.refactor.rename.type(" +
 						"  'KNOWS', " +
@@ -166,7 +166,7 @@ public class RenameTest {
 		assertEquals(10L, resultRelationshipsMatches( "KNOWS", null));
 	}
 	@Test
-	public void testRenameTypeDoesntAllowCypherInjectionForSomeRelationships() throws Exception {
+	public void testRenameTypeDoesntAllowCypherInjectionForSomeRelationships() {
 		db.executeTransactionally("UNWIND range(0,9) AS id CREATE (f:Foo {id: id})-[:KNOWS {id: id}]->(l:Fii {id: id})");
 
 		List<Relationship> rels = TestUtil.firstColumn(db, "MATCH (:Foo)-[r:KNOWS]->(:Fii) RETURN r LIMIT 4");
@@ -202,7 +202,7 @@ public class RenameTest {
 	}
 
 	@Test
-	public void testRenameNodesProperty() throws Exception {
+	public void testRenameNodesProperty() {
 		List<Node> nodes = TestUtil.firstColumn(db, "UNWIND range(0,9) as id CREATE (f:Foo {id: id, name: 'name'+id}) RETURN f");
 		testCall(db, "CALL apoc.refactor.rename.nodeProperty($oldName,$newName)",
 				map("oldName", "name", "newName", "surname"), (r) -> {});
@@ -212,7 +212,7 @@ public class RenameTest {
 	}
 
 	@Test
-	public void testRenamePropertyForSomeNodes() throws Exception {
+	public void testRenamePropertyForSomeNodes() {
 		List<Node> nodes = TestUtil.firstColumn(db, "UNWIND range(0,9) as id CREATE (f:Foo {id: id, name: 'name'+id}) RETURN f");
 		db.executeTransactionally("Create constraint for (n:Foo) require n.name is UNIQUE");
 		testCall(db, "CALL apoc.refactor.rename.nodeProperty($oldName,$newName,$nodes)",
@@ -223,7 +223,7 @@ public class RenameTest {
 	}
 
 	@Test
-	public void testRenamePropertyDoesntAllowCypherInjection() throws Exception {
+	public void testRenamePropertyDoesntAllowCypherInjection() {
 		db.executeTransactionally("UNWIND range(0,9) as id CREATE (f:Foo {id: id, name: 'name'+id})");
 		testCall(db, "CALL apoc.refactor.rename.nodeProperty(" +
 						"  'name', " +
@@ -246,7 +246,7 @@ public class RenameTest {
 		assertEquals(10L, resultNodesMatches(null, "name"));
 	}
 	@Test
-	public void testRenamePropertyDoesntAllowCypherInjectionForSomeNodes() throws Exception {
+	public void testRenamePropertyDoesntAllowCypherInjectionForSomeNodes() {
 		List<Node> nodes = TestUtil.firstColumn(db, "UNWIND range(0,9) as id CREATE (f:Foo {id: id, name: 'name'+id}) RETURN f");
 		testCall(db, "CALL apoc.refactor.rename.nodeProperty(" +
 						"  'name', " +
@@ -278,7 +278,7 @@ public class RenameTest {
 	}
 
 	@Test
-	public void testRenameTypeProperty() throws Exception {
+	public void testRenameTypeProperty() {
 		db.executeTransactionally("UNWIND range(0,9) as id CREATE (f:Foo {id: id})-[:KNOWS {name: 'name' +id}]->(:Fii)");
 		testCall(db, "CALL apoc.refactor.rename.typeProperty($oldName,$newName)",
 				map("oldName", "name", "newName", "surname"), (r) -> {});
@@ -288,7 +288,7 @@ public class RenameTest {
 	}
 
 	@Test
-	public void testRenameTypePropertyDoesntAllowCypherInjection() throws Exception {
+	public void testRenameTypePropertyDoesntAllowCypherInjection() {
 		db.executeTransactionally("UNWIND range(0,9) as id CREATE (f:Foo {id: id})-[:KNOWS {name: 'name' +id}]->(:Fii)");
 		testCall(db, "CALL apoc.refactor.rename.typeProperty(" +
 						"  'name', " +
@@ -312,7 +312,7 @@ public class RenameTest {
 	}
 
 	@Test
-	public void testRenameTypePropertyDoesntAllowCypherInjectionForSomeRelationships() throws Exception {
+	public void testRenameTypePropertyDoesntAllowCypherInjectionForSomeRelationships() {
 		db.executeTransactionally("UNWIND range(0,9) as id CREATE (f:Foo {id: id})-[:KNOWS {name: 'name' +id}]->(:Fii)");
 		List<Relationship> rels = TestUtil.firstColumn(db, "MATCH (:Foo)-[r:KNOWS]->(:Fii) RETURN r LIMIT 2");
 		testCall(db, "CALL apoc.refactor.rename.typeProperty(" +
@@ -372,7 +372,7 @@ public class RenameTest {
 	}
 
 	@Test
-	public void testRenamePropertyForSomeRelationship() throws Exception {
+	public void testRenamePropertyForSomeRelationship() {
 		db.executeTransactionally("UNWIND range(0,9) AS id CREATE (f:Foo {id: id})-[:KNOWS {name: 'name' + id}]->(l:Fii {id: id})");
 		List<Relationship> rels = TestUtil.firstColumn(db, "MATCH (:Foo)-[r:KNOWS]->(:Fii) RETURN r LIMIT 2");
 		testCall(db, "CALL apoc.refactor.rename.typeProperty($oldName,$newName,$rels)",

--- a/core/src/test/java/apoc/refactor/rename/RenameTest.java
+++ b/core/src/test/java/apoc/refactor/rename/RenameTest.java
@@ -39,7 +39,8 @@ public class RenameTest {
 	public DbmsRule db = new ImpermanentDbmsRule()
 			.withSetting(lock_acquisition_timeout, Duration.ofSeconds(5));
 
-	@Before public void setUp() throws Exception {
+	@Before
+	public void setUp() {
 		TestUtil.registerProcedure(db, Rename.class, Coll.class, Lock.class, Utils.class);
 	}
 

--- a/core/src/test/java/apoc/refactor/util/PropertiesManagerTest.java
+++ b/core/src/test/java/apoc/refactor/util/PropertiesManagerTest.java
@@ -34,7 +34,7 @@ public class PropertiesManagerTest {
 					+ "MATCH (d)-[l:FLIGHTS_TO]->(p) return r as rel1,h as rel2";
 
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 		TestUtil.registerProcedure(db, GraphRefactoring.class);
 	}
 

--- a/core/src/test/java/apoc/refactor/util/PropertiesManagerTest.java
+++ b/core/src/test/java/apoc/refactor/util/PropertiesManagerTest.java
@@ -160,7 +160,7 @@ public class PropertiesManagerTest {
 
 
 	@Test
-	public void testMergeProperties() throws Exception {
+	public void testMergeProperties() {
 		List<Node> nodes = TestUtil.firstColumn(db, "UNWIND [{name:'Joe',age:42,kids:'Jane'},{name:'Jane',age:32,kids:'June'}] AS data CREATE (p:Person) SET p = data RETURN p");
 		try (Transaction tx = db.beginTx()) {
 			Node target = Util.rebind(tx, nodes.get(0));

--- a/core/src/test/java/apoc/schema/SchemasTest.java
+++ b/core/src/test/java/apoc/schema/SchemasTest.java
@@ -98,7 +98,7 @@ public class SchemasTest {
     }
 
     @Test
-    public void testCreateIndex() throws Exception {
+    public void testCreateIndex() {
         testCall(db, "CALL apoc.schema.assert({Foo:['bar']},null)", (r) -> {
             assertEquals("Foo", r.get("label"));
             assertEquals("bar", r.get("key"));
@@ -114,7 +114,7 @@ public class SchemasTest {
     }
 
     @Test
-    public void testCreateSchema() throws Exception {
+    public void testCreateSchema() {
         testCall(db, "CALL apoc.schema.assert(null,{Foo:['bar']})", (r) -> {
             assertEquals("Foo", r.get("label"));
             assertEquals("bar", r.get("key"));
@@ -132,7 +132,7 @@ public class SchemasTest {
     }
 
     @Test
-    public void testDropIndexWhenUsingDropExisting() throws Exception {
+    public void testDropIndexWhenUsingDropExisting() {
         db.executeTransactionally("CREATE INDEX FOR (n:Foo) ON (n.bar)");
         db.executeTransactionally("CREATE FULLTEXT INDEX titlesAndDescriptions FOR (n:Movie|Book) ON EACH [n.title, n.description]");
         testCall(db, "CALL apoc.schema.assert(null,null)", (r) -> {
@@ -149,7 +149,7 @@ public class SchemasTest {
     }
 
     @Test
-    public void testDropIndexAndCreateIndexWhenUsingDropExisting() throws Exception {
+    public void testDropIndexAndCreateIndexWhenUsingDropExisting() {
         db.executeTransactionally("CREATE INDEX FOR (n:Foo) ON (n.bar)");
         testResult(db, "CALL apoc.schema.assert({Bar:['foo']},null)", (result) -> {
             Map<String, Object> r = result.next();
@@ -171,7 +171,7 @@ public class SchemasTest {
     }
 
     @Test
-    public void testRetainIndexWhenNotUsingDropExisting() throws Exception {
+    public void testRetainIndexWhenNotUsingDropExisting() {
         db.executeTransactionally("CREATE INDEX FOR (n:Foo) ON (n.bar)");
         testResult(db, "CALL apoc.schema.assert({Bar:['foo', 'bar']}, null, false)", (result) -> {
             Map<String, Object> r = result.next();
@@ -199,7 +199,7 @@ public class SchemasTest {
     }
 
     @Test
-    public void testDropSchemaWhenUsingDropExisting() throws Exception {
+    public void testDropSchemaWhenUsingDropExisting() {
         db.executeTransactionally("CREATE CONSTRAINT FOR (f:Foo) REQUIRE f.bar IS UNIQUE");
         testCall(db, "CALL apoc.schema.assert(null,null)", (r) -> {
             assertEquals("Foo", r.get("label"));
@@ -214,7 +214,7 @@ public class SchemasTest {
     }
 
     @Test
-    public void testDropSchemaAndCreateSchemaWhenUsingDropExisting() throws Exception {
+    public void testDropSchemaAndCreateSchemaWhenUsingDropExisting() {
         db.executeTransactionally("CREATE CONSTRAINT FOR (f:Foo) REQUIRE f.bar IS UNIQUE");
         testResult(db, "CALL apoc.schema.assert(null, {Bar:['foo']})", (result) -> {
             Map<String, Object> r = result.next();
@@ -236,7 +236,7 @@ public class SchemasTest {
     }
 
     @Test
-    public void testRetainSchemaWhenNotUsingDropExisting() throws Exception {
+    public void testRetainSchemaWhenNotUsingDropExisting() {
         db.executeTransactionally("CREATE CONSTRAINT FOR (f:Foo) REQUIRE f.bar IS UNIQUE");
         testResult(db, "CALL apoc.schema.assert(null, {Bar:['foo', 'bar']}, false)", (result) -> {
             Map<String, Object> r = result.next();
@@ -264,12 +264,12 @@ public class SchemasTest {
     }
 
     @Test
-    public void testKeepIndex() throws Exception {
+    public void testKeepIndex() {
         keepIndexCommon(false);
     }
 
     @Test
-    public void testKeepIndexWithDropExisting() throws Exception {
+    public void testKeepIndexWithDropExisting() {
         keepIndexCommon(true);
     }
 
@@ -298,7 +298,7 @@ public class SchemasTest {
     }
 
     @Test
-    public void testKeepSchema() throws Exception {
+    public void testKeepSchema() {
         db.executeTransactionally("CREATE CONSTRAINT FOR (f:Foo) REQUIRE f.bar IS UNIQUE");
         testResult(db, "CALL apoc.schema.assert(null,{Foo:['bar', 'foo']})", (result) -> {
             Map<String, Object> r = result.next();
@@ -426,7 +426,7 @@ public class SchemasTest {
     }
 
     @Test
-    public void testDropCompoundIndexWhenUsingDropExisting() throws Exception {
+    public void testDropCompoundIndexWhenUsingDropExisting() {
         db.executeTransactionally("CREATE INDEX FOR (n:Foo) ON (n.bar,n.baa)");
         awaitIndexesOnline();
         testResult(db, "CALL apoc.schema.assert(null,null,true)", (result) -> {
@@ -443,7 +443,7 @@ public class SchemasTest {
     }
 
     @Test
-    public void testDropCompoundIndexAndRecreateWithDropExisting() throws Exception {
+    public void testDropCompoundIndexAndRecreateWithDropExisting() {
         db.executeTransactionally("CREATE INDEX FOR (n:Foo) ON (n.bar,n.baa)");
         awaitIndexesOnline();
         testCall(db, "CALL apoc.schema.assert({Foo:[['bar','baa']]},null,true)", (r) -> {
@@ -459,7 +459,7 @@ public class SchemasTest {
     }
 
     @Test
-    public void testDoesntDropCompoundIndexWhenSupplyingSameCompoundIndex() throws Exception {
+    public void testDoesntDropCompoundIndexWhenSupplyingSameCompoundIndex() {
         db.executeTransactionally("CREATE INDEX FOR (n:Foo) ON (n.bar,n.baa)");
         awaitIndexesOnline();
         testResult(db, "CALL apoc.schema.assert({Foo:[['bar','baa']]},null,false)", (result) -> {
@@ -476,7 +476,7 @@ public class SchemasTest {
     }
 
     @Test
-    public void testCompoundIndexDoesntAllowCypherInjection() throws Exception {
+    public void testCompoundIndexDoesntAllowCypherInjection() {
         awaitIndexesOnline();
         testResult(db, "CALL apoc.schema.assert({Foo:[['bar`) MATCH (n) DETACH DELETE n; //','baa']]},null,false)", (result) -> {
             Map<String, Object> r = result.next();
@@ -494,12 +494,12 @@ public class SchemasTest {
         This is only for 3.2+
     */
     @Test
-    public void testKeepCompoundIndex() throws Exception {
+    public void testKeepCompoundIndex() {
         testKeepCompoundCommon(false);
     }
     
     @Test
-    public void testKeepCompoundIndexWithDropExisting() throws Exception {
+    public void testKeepCompoundIndexWithDropExisting() {
         testKeepCompoundCommon(true);
     }
 
@@ -529,7 +529,7 @@ public class SchemasTest {
     }
 
     @Test
-    public void testDropIndexAndCreateCompoundIndexWhenUsingDropExisting() throws Exception {
+    public void testDropIndexAndCreateCompoundIndexWhenUsingDropExisting() {
         db.executeTransactionally("CREATE INDEX FOR (n:Foo) ON (n.bar)");
         awaitIndexesOnline();
         testResult(db, "CALL apoc.schema.assert({Bar:[['foo','bar']]},null)", (result) -> {
@@ -589,7 +589,7 @@ public class SchemasTest {
     }
 
     @Test
-    public void testDropCompoundIndexAndCreateCompoundIndexWhenUsingDropExisting() throws Exception {
+    public void testDropCompoundIndexAndCreateCompoundIndexWhenUsingDropExisting() {
         db.executeTransactionally("CREATE INDEX FOR (n:Foo) ON (n.bar,n.baa)");
         awaitIndexesOnline();
         testCall(db, "CALL apoc.schema.assert({Foo:[['bar','baa']]},null)", (r) -> {

--- a/core/src/test/java/apoc/schema/SchemasTest.java
+++ b/core/src/test/java/apoc/schema/SchemasTest.java
@@ -92,7 +92,7 @@ public class SchemasTest {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         registerProcedure(db, Schemas.class);
         dropSchema();
     }

--- a/core/src/test/java/apoc/scoring/ScoringTest.java
+++ b/core/src/test/java/apoc/scoring/ScoringTest.java
@@ -19,7 +19,7 @@ public class ScoringTest {
     public static DbmsRule db = new ImpermanentDbmsRule();
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db,Scoring.class);
     }
 

--- a/core/src/test/java/apoc/scoring/ScoringTest.java
+++ b/core/src/test/java/apoc/scoring/ScoringTest.java
@@ -24,13 +24,13 @@ public class ScoringTest {
     }
 
     @Test
-    public void existence() throws Exception {
+    public void existence() {
         TestUtil.testCall(db, "RETURN apoc.scoring.existence(10,true) as score", (row) -> assertEquals(10D,row.get("score")));
         TestUtil.testCall(db, "RETURN apoc.scoring.existence(10,false) as score", (row) -> assertEquals(0D,row.get("score")));
     }
 
     @Test
-    public void pareto() throws Exception {
+    public void pareto() {
         TestUtil.testResult(db, "UNWIND [0,1,2,8,10,100] as value RETURN value, apoc.scoring.pareto(2,8,10,value) as score", (r) -> {
             assertEquals(0d,r.next().get("score"));
             assertEquals(0d,r.next().get("score"));

--- a/core/src/test/java/apoc/search/ParallelNodeSearchTest.java
+++ b/core/src/test/java/apoc/search/ParallelNodeSearchTest.java
@@ -16,14 +16,14 @@ public class ParallelNodeSearchTest {
 	public static DbmsRule db = new ImpermanentDbmsRule();
 
 	@BeforeClass
-    public static void initDb() throws Exception {
+    public static void initDb() {
 		TestUtil.registerProcedure(db, ParallelNodeSearch.class);
 
 		db.executeTransactionally(Util.readResourceFile("movies.cypher"));
     }
 
     @Test
-    public void testMultiSearchNode() throws Throwable {
+    public void testMultiSearchNode() {
     	String query = "call apoc.search.node('{Person: \"name\",Movie: [\"title\",\"tagline\"]}','CONTAINS','her') yield node as n return count(n) as c";
 		TestUtil.testCall(db, query, (row) -> assertEquals(6L,row.get("c")));
     	query = "call apoc.search.node('{Person: \"name\",Movie: [\"title\",\"tagline\"]}','STARTS WITH','Tom') yield node as n return count(n) as c";
@@ -33,7 +33,7 @@ public class ParallelNodeSearchTest {
     }
 
     @Test 
-    public void testMultiSearchNodeAll() throws Throwable {
+    public void testMultiSearchNodeAll() {
     	String query = "call apoc.search.nodeAll('{Person: \"name\",Movie: [\"title\",\"tagline\"]}','CONTAINS','her') yield node as n return count(n) as c";
 		TestUtil.testCall(db, query, (row) -> assertEquals(6L,row.get("c")));
     	query = "call apoc.search.nodeAll('{Person: \"name\",Movie: [\"title\",\"tagline\"]}','STARTS WITH','Tom') yield node as n return count(n) as c";
@@ -43,7 +43,7 @@ public class ParallelNodeSearchTest {
     }
     
     @Test 
-    public void testMultiSearchNodeReduced() throws Throwable {
+    public void testMultiSearchNodeReduced() {
     	String query = "call apoc.search.nodeReduced('{Person: \"name\",Movie: [\"title\",\"tagline\"]}','CONTAINS','her') yield id as n return count(n) as c";
 		TestUtil.testCall(db, query, (row) -> assertEquals(6L,row.get("c")));
     	query = "call apoc.search.nodeReduced('{Person: \"name\",Movie: [\"title\",\"tagline\"]}','STARTS WITH','Tom') yield values as n return count(n) as c";
@@ -53,7 +53,7 @@ public class ParallelNodeSearchTest {
     }
 
     @Test 
-    public void testMultiSearchNodeAllReduced() throws Throwable {
+    public void testMultiSearchNodeAllReduced() {
     	String query = "call apoc.search.nodeAllReduced('{Person: \"name\",Movie: [\"title\",\"tagline\"]}','CONTAINS','her') yield labels as n return count(n) as c";
 		TestUtil.testCall(db, query, (row) -> assertEquals(6L,row.get("c")));
     	query = "call apoc.search.nodeAllReduced('{Person: \"name\",Movie: [\"title\",\"tagline\"]}','STARTS WITH','Tom') yield values as n return count(n) as c";
@@ -62,7 +62,7 @@ public class ParallelNodeSearchTest {
 		TestUtil.testCall(db, query, (row) -> assertEquals(29L,row.get("c")));
     }
     @Test
-    public void testMultiSearchNodeAllReducedMapParam() throws Throwable {
+    public void testMultiSearchNodeAllReducedMapParam() {
     	String query = "call apoc.search.nodeAllReduced({Person: 'name', Movie: ['title','tagline']},'CONTAINS','her') yield labels as n return count(n) as c";
 		TestUtil.testCall(db, query, (row) -> assertEquals(6L,row.get("c")));
     	query = "call apoc.search.nodeAllReduced({Person: 'name', Movie: ['title','tagline']},'STARTS WITH','Tom') yield values as n return count(n) as c";
@@ -71,13 +71,13 @@ public class ParallelNodeSearchTest {
 		TestUtil.testCall(db, query, (row) -> assertEquals(29L,row.get("c")));
     }
     @Test
-    public void testMultiSearchNodeNumberComparison() throws Throwable {
+    public void testMultiSearchNodeNumberComparison() {
     	String query = "call apoc.search.nodeAllReduced({Person: 'born', Movie: ['released']},'>',2000) yield labels as n return count(n) as c";
 		TestUtil.testCall(db, query, (row) -> assertEquals(12L,row.get("c")));
     }
 
     @Test
-    public void testMultiSearchNodeNumberExactComparison() throws Throwable {
+    public void testMultiSearchNodeNumberExactComparison() {
     	String query = "call apoc.search.nodeAllReduced({Person: 'born', Movie: ['released']},'=',2000) yield labels as n return count(n) as c";
 		TestUtil.testCall(db, query, (row) -> assertEquals(3L,row.get("c")));
     	query = "call apoc.search.nodeAllReduced({Person: 'born', Movie: ['released']},'exact',2000) yield labels as n return count(n) as c";

--- a/core/src/test/java/apoc/spatial/GeocodeTest.java
+++ b/core/src/test/java/apoc/spatial/GeocodeTest.java
@@ -24,7 +24,7 @@ public class GeocodeTest {
     public DbmsRule db = new ImpermanentDbmsRule();
 
     @Before
-    public void initDb() throws Exception {
+    public void initDb() {
         TestUtil.registerProcedure(db, Geocode.class);
     }
 

--- a/core/src/test/java/apoc/spatial/SpatialTest.java
+++ b/core/src/test/java/apoc/spatial/SpatialTest.java
@@ -108,7 +108,7 @@ public class SpatialTest {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         TestUtil.registerProcedure(db, Date.class);
         TestUtil.registerProcedure(db, MockGeocode.class);
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);

--- a/core/src/test/java/apoc/spatial/SpatialTest.java
+++ b/core/src/test/java/apoc/spatial/SpatialTest.java
@@ -275,7 +275,7 @@ public class SpatialTest {
     }
 
     @Test
-    public void testAllTheThings() throws Exception {
+    public void testAllTheThings() {
         String query = "WITH apoc.date.parse('2016-06-01 00:00:00','h') as due_date,\n" +
                 "     point({latitude: 48.8582532, longitude: 2.294287}) as eiffel\n" +
                 "MATCH (e:Event)\n" +

--- a/core/src/test/java/apoc/stats/DegreeDistributionTest.java
+++ b/core/src/test/java/apoc/stats/DegreeDistributionTest.java
@@ -23,7 +23,7 @@ public class DegreeDistributionTest {
 
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, DegreeDistribution.class);
         db.executeTransactionally("UNWIND range(1,10) as rels CREATE (f:Foo) WITH * UNWIND range(1,rels) as r CREATE (f)-[:BAR]->(f)");
     }

--- a/core/src/test/java/apoc/stats/DegreeDistributionTest.java
+++ b/core/src/test/java/apoc/stats/DegreeDistributionTest.java
@@ -29,7 +29,7 @@ public class DegreeDistributionTest {
     }
 
     @Test
-    public void degrees() throws Exception {
+    public void degrees() {
         TestUtil.testCall(db, "CALL apoc.stats.degrees()", row -> {
             assertEquals(null,row.get("type"));
             assertEquals("BOTH",row.get("direction"));
@@ -52,7 +52,7 @@ public class DegreeDistributionTest {
         });
     }
     @Test
-    public void allDegrees() throws Exception {
+    public void allDegrees() {
         TestUtil.testResult(db, "CALL apoc.stats.degrees('*')", result -> {
             Map<String, Object> row = result.next();
             assertEquals("BAR",row.get("type"));

--- a/core/src/test/java/apoc/temporal/TemporalProceduresTest.java
+++ b/core/src/test/java/apoc/temporal/TemporalProceduresTest.java
@@ -21,7 +21,8 @@ public class TemporalProceduresTest
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule();
 
-    @BeforeClass public static void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() {
         TestUtil.registerProcedure(db, TemporalProcedures.class);
     }
 

--- a/core/src/test/java/apoc/temporal/TemporalProceduresTest.java
+++ b/core/src/test/java/apoc/temporal/TemporalProceduresTest.java
@@ -26,43 +26,37 @@ public class TemporalProceduresTest
     }
 
     @Test
-    public void shouldFormatDate() throws Throwable
-    {
+    public void shouldFormatDate() {
         String output = TestUtil.singleResultFirstColumn(db, "RETURN apoc.temporal.format( date( { year: 2018, month: 12, day: 10 } ), \"yyyy-MM-dd\" ) as output");
         assertEquals("2018-12-10", output);
     }
 
     @Test
-    public void shouldFormatDateTime() throws Throwable
-    {
+    public void shouldFormatDateTime() {
         String output = TestUtil.singleResultFirstColumn(db, "RETURN apoc.temporal.format( datetime( { year: 2018, month: 12, day: 10, hour: 12, minute: 34, second: 56, nanosecond: 123456789 } ), \"yyyy-MM-dd'T'HH:mm:ss.SSSS\" ) as output");
         assertEquals("2018-12-10T12:34:56.1234", output);
     }
 
     @Test
-    public void shouldFormatLocalDateTime() throws Throwable
-    {
+    public void shouldFormatLocalDateTime() {
         String output = TestUtil.singleResultFirstColumn(db, "RETURN apoc.temporal.format( localdatetime( { year: 2018, month: 12, day: 10, hour: 12, minute: 34, second: 56, nanosecond: 123456789 } ), \"yyyy-MM-dd'T'HH:mm:ss.SSSS\" ) as output");
         assertEquals("2018-12-10T12:34:56.1234", output);
     }
 
     @Test
-    public void shouldFormatTime() throws Throwable
-    {
+    public void shouldFormatTime() {
         String output = TestUtil.singleResultFirstColumn(db, "RETURN apoc.temporal.format( time( { hour: 12, minute: 34, second: 56, nanosecond: 123456789, timezone: 'GMT' } ), \"HH:mm:ss.SSSSZ\" ) as output");
         assertEquals("12:34:56.1234+0000", output);
     }
 
     @Test
-    public void shouldFormatLocalTime() throws Throwable
-    {
+    public void shouldFormatLocalTime() {
         String output = TestUtil.singleResultFirstColumn(db, "RETURN apoc.temporal.format( localtime( { hour: 12, minute: 34, second: 56, nanosecond: 123456789 } ), \"HH:mm:ss.SSSS\" ) as output");
         assertEquals("12:34:56.1234", output);
     }
 
     @Test
-    public void shouldFormatDuration() throws Throwable
-    {
+    public void shouldFormatDuration() {
         String output = TestUtil.singleResultFirstColumn(db, "RETURN apoc.temporal.format( duration('P0M0DT4820.487660000S'), \"HH:mm:ss.SSSS\" ) as output");
         assertEquals("01:20:20.4876", output);
     }
@@ -99,77 +93,68 @@ public class TemporalProceduresTest
     }
 
     @Test
-    public void shouldFormatDurationTemporal() throws Throwable
-    {
+    public void shouldFormatDurationTemporal() {
         String output = TestUtil.singleResultFirstColumn(db, "RETURN apoc.temporal.formatDuration( duration('P0M0DT4820.487660000S'), \"HH:mm:ss\" ) as output");
         assertEquals("01:20:20", output);
     }
 
     @Test
-    public void shouldFormatDurationTemporalISO() throws Throwable
-    {
+    public void shouldFormatDurationTemporalISO() {
         String output = TestUtil.singleResultFirstColumn(db, "RETURN apoc.temporal.formatDuration( duration('P0M0DT4820.487660000S'), \"ISO_DATE_TIME\" ) as output");
         assertEquals("0000-00-00T01:20:20.48766", output);
     }
 
     @Test
-    public void shouldFormatIsoDate() throws Throwable
-    {
+    public void shouldFormatIsoDate() {
         String output = TestUtil.singleResultFirstColumn(db, "RETURN apoc.temporal.format( date( { year: 2018, month: 12, day: 10 } ), 'ISO_DATE' ) as output");
         assertEquals("2018-12-10", output);
     }
 
     @Test
-    public void shouldFormatIsoLocalDateTime() throws Throwable
-    {
+    public void shouldFormatIsoLocalDateTime() {
         String output = TestUtil.singleResultFirstColumn(db, "RETURN apoc.temporal.format( localdatetime( { year: 2018, month: 12, day: 10, hour: 12, minute: 34, second: 56, nanosecond: 123456789 } ), 'ISO_LOCAL_DATE_TIME' ) as output");
         assertEquals("2018-12-10T12:34:56.123456789", output);
     }
 
     @Test
-    public void shouldReturnTheDateWithDefault() throws Throwable
-    {
+    public void shouldReturnTheDateWithDefault() {
         String output = TestUtil.singleResultFirstColumn(db, "RETURN apoc.temporal.format( localdatetime( { year: 2018, month: 12, day: 10, hour: 12, minute: 34, second: 56, nanosecond: 123456789 } )) as output");
         assertEquals("2018-12-10", output);
     }
 
     @Test
-    public void shouldReturnTheDateWithDefaultElastic() throws Throwable
-    {
+    public void shouldReturnTheDateWithDefaultElastic() {
         String output = TestUtil.singleResultFirstColumn(db, "RETURN apoc.temporal.format( localdatetime( { year: 2018, month: 12, day: 10, hour: 12, minute: 34, second: 56, nanosecond: 123456789 } ), 'DATE_HOUR_MINUTE_SECOND_FRACTION') as output");
         assertEquals("2018-12-10T12:34:56.123", output);
     }
 
     @Test
-    public void shouldFormatIsoDateWeek() throws Throwable
-    {
+    public void shouldFormatIsoDateWeek() {
         String output = TestUtil.singleResultFirstColumn(db, "RETURN apoc.temporal.format( date( { year: 2018, month: 12, day: 10 } ), 'date' ) as output");
         assertEquals("2018-12-10", output);
     }
 
     @Test
-    public void shouldFormatIsoYear() throws Throwable
-    {
+    public void shouldFormatIsoYear() {
         String output = TestUtil.singleResultFirstColumn(db, "RETURN apoc.temporal.format( date( { year: 2018, month: 12, day: 10 } ), 'date' ) as output");
         assertEquals("2018-12-10", output);
     }
 
     @Test
-    public void shouldFormatIsoOrdinalDate() throws Throwable
-    {
+    public void shouldFormatIsoOrdinalDate() {
         String output = TestUtil.singleResultFirstColumn(db, "RETURN apoc.temporal.format( date( { year: 2018, month: 12, day: 10 } ), 'ordinal_date' ) as output");
         assertEquals("2018-344", output);
     }
 
     @Test
-    public void shouldFormatIsoDateWeekError(){
+    public void shouldFormatIsoDateWeekError() {
     expected.expect(instanceOf(RuntimeException.class));
         String output = TestUtil.singleResultFirstColumn(db, "RETURN apoc.temporal.format( date( { year: 2018, month: 12, day: 10 } ), 'WRONG_FORMAT' ) as output");
         assertEquals("2018-12-10", output);
     }
 
     @Test
-    public void shouldFormatDurationIsoDateWeekError(){
+    public void shouldFormatDurationIsoDateWeekError() {
         expected.expect(instanceOf(RuntimeException.class));
         String output = TestUtil.singleResultFirstColumn(db, "RETURN apoc.temporal.formatDuration( date( { year: 2018, month: 12, day: 10 } ), 'wrongDuration' ) as output");
         assertEquals("2018-12-10", output);

--- a/core/src/test/java/apoc/text/PhoneticTest.java
+++ b/core/src/test/java/apoc/text/PhoneticTest.java
@@ -17,7 +17,7 @@ public class PhoneticTest {
     public DbmsRule db = new ImpermanentDbmsRule();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         TestUtil.registerProcedure(db, Phonetic.class);
     }
 

--- a/core/src/test/java/apoc/text/StringCleanTest.java
+++ b/core/src/test/java/apoc/text/StringCleanTest.java
@@ -28,7 +28,7 @@ public class StringCleanTest {
     public static DbmsRule db = new ImpermanentDbmsRule();
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, Strings.class);
     }
 

--- a/core/src/test/java/apoc/text/StringCleanTest.java
+++ b/core/src/test/java/apoc/text/StringCleanTest.java
@@ -48,7 +48,7 @@ public class StringCleanTest {
     public String clean;
 
     @Test
-    public void testClean() throws Exception {
+    public void testClean() {
         testCall(db,
                 "RETURN apoc.text.clean($a) AS value",
                 map("a", dirty),

--- a/core/src/test/java/apoc/text/StringsTest.java
+++ b/core/src/test/java/apoc/text/StringsTest.java
@@ -45,7 +45,7 @@ public class StringsTest {
 
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, Strings.class);
     }
 

--- a/core/src/test/java/apoc/text/StringsTest.java
+++ b/core/src/test/java/apoc/text/StringsTest.java
@@ -50,7 +50,7 @@ public class StringsTest {
     }
 
     @Test
-    public void testIndexOfSubstring() throws Exception {
+    public void testIndexOfSubstring() {
         String query = "WITH 'Hello World!' as text\n" +
                 "WITH text, size(text) as len, apoc.text.indexOf(text, 'World',3) as index\n" +
                 "RETURN substring(text, case index when -1 then len-1 else index end, len) as value;\n";
@@ -58,7 +58,7 @@ public class StringsTest {
     }
 
     @Test
-    public void testIndexOf() throws Exception {
+    public void testIndexOf() {
         String text = "The quick brown fox.";
         Object[][] data = {
                 {"Hello World!", "World", 0, 6L},
@@ -83,7 +83,7 @@ public class StringsTest {
     }
 
     @Test
-    public void testIndexesOf() throws Exception {
+    public void testIndexesOf() {
         String text = "The quick brown box.";
         Object[][] data = {
                 {"Hello World!", "o", 0, 12L, new Object[]{4L, 7L}},
@@ -119,7 +119,7 @@ public class StringsTest {
     }
 
     @Test
-    public void testReplace() throws Exception {
+    public void testReplace() {
         String text = "&N[]eo 4 #J-(3.0)  ";
         String regex = "[^a-zA-Z0-9]";
         String replacement = "";
@@ -132,7 +132,7 @@ public class StringsTest {
     }
 
     @Test
-    public void testReplaceAllWithNull() throws Exception {
+    public void testReplaceAllWithNull() {
         String text = "&N[]eo 4 #J-(3.0)  ";
         String regex = "[^a-zA-Z0-9]";
         String replacement = "";
@@ -151,7 +151,7 @@ public class StringsTest {
     }
 
     @Test
-    public void testSplit() throws Exception {
+    public void testSplit() {
         String text = "1,  2, 3,4";
         String regex = ", *";
 
@@ -167,7 +167,7 @@ public class StringsTest {
     }
 
     @Test
-    public void testSplitWithNull() throws Exception {
+    public void testSplitWithNull() {
         String text = "Hello World";
         String regex = " ";
 
@@ -193,7 +193,7 @@ public class StringsTest {
     }
 
     @Test
-    public void testJoin() throws Exception {
+    public void testJoin() {
         List<String> texts = asList("1", "2", "3", "4");
         String delimiter = ",";
         String expected = "1,2,3,4";
@@ -205,7 +205,7 @@ public class StringsTest {
     }
 
     @Test
-    public void testJoinWithNull() throws Exception {
+    public void testJoinWithNull() {
         List<String> texts = asList("Hello", null);
         String delimiter = " ";
         String expected = "Hello null";
@@ -226,28 +226,28 @@ public class StringsTest {
 
 
     @Test
-    public void testCleanWithNull() throws Exception {
+    public void testCleanWithNull() {
         testCall(db,
                 "RETURN apoc.text.clean(null) AS value",
                 row -> assertEquals(null, row.get("value")));
     }
 
     @Test
-    public void testCleanNonLatin() throws Exception {
+    public void testCleanNonLatin() {
         testCall(db,
                 "RETURN apoc.text.clean('А .::Б В=Г Д-Е Ж%Ѕ Ꙁ И І К Л М Н О П+++Р С Т ОУ Ф Х Ѡ Ц Ч,.,.Ш Щ Ъ ЪІ Ь Ѣ Ꙗ Ѥ Ю Ѫ Ѭ Ѧ Ѩ Ѯ Ѱ Ѳ Ѵ Ҁ') AS value",
                 row -> assertEquals("абвгдежѕꙁиіклмнопрстоуфхѡцчшщъъіьѣꙗѥюѫѭѧѩѯѱѳѵҁ", row.get("value")));
     }
 
     @Test
-    public void testCleanNonLatinChinese() throws Exception {
+    public void testCleanNonLatinChinese() {
         testCall(db,
                 "RETURN apoc.text.clean('桃 .::山= 區 %') AS value",
                 row -> assertEquals("桃山區", row.get("value")));
     }
 
     @Test
-    public void testCompareCleaned() throws Exception {
+    public void testCompareCleaned() {
         String string1 = "&N[]eo 4 #J-(3.0)  ";
         String string2 = " neo4j-<30";
         testCall(db,
@@ -257,7 +257,7 @@ public class StringsTest {
     }
 
     @Test
-    public void testCompareCleanedWithNull() throws Exception {
+    public void testCompareCleanedWithNull() {
         String string1 = "&N[]eo 4 #J-(3.0)  ";
         String string2 = " neo4j-<30";
         testCall(db,
@@ -271,7 +271,7 @@ public class StringsTest {
     }
 
     @Test
-    public void testCompareCleanedInQuery() throws Exception {
+    public void testCompareCleanedInQuery() {
         testCall(db,
                 "WITH apoc.text.clean($a) as clean_a, " +
                         "apoc.text.clean($b) as clean_b " +
@@ -341,21 +341,21 @@ public class StringsTest {
     // These are here to verify the claims made in string.adoc
 
     @Test
-    public void testDocReplace() throws Exception {
+    public void testDocReplace() {
         testCall(db,
                 "RETURN apoc.text.regreplace('Hello World!', '[^a-zA-Z]', '')  AS value",
                 row -> assertEquals("HelloWorld", row.get("value")));
     }
 
     @Test
-    public void testDocJoin() throws Exception {
+    public void testDocJoin() {
         testCall(db,
                 "RETURN apoc.text.join(['Hello', 'World'], ' ') AS value",
                 row -> assertEquals("Hello World", row.get("value")));
     }
 
     @Test
-    public void testDocClean() throws Exception {
+    public void testDocClean() {
         testCall(db,
                 "RETURN apoc.text.clean($text) AS value",
                 map("text", "Hello World!"),
@@ -363,7 +363,7 @@ public class StringsTest {
     }
 
     @Test
-    public void testDocCompareCleaned() throws Exception {
+    public void testDocCompareCleaned() {
         testCall(db,
                 "RETURN apoc.text.compareCleaned($text1, $text2) AS value",
                 map("text1", "Hello World!", "text2", "_hello-world_"),
@@ -737,7 +737,7 @@ public class StringsTest {
     }
 
     @Test
-    public void testToCypher() throws Exception {
+    public void testToCypher() {
         Map<String, Entity> data = TestUtil.singleResultFirstColumn(db,
                 "CREATE (f:Foo {foo:'foo',answer:42})-[fb:`F B` {fb:'fb',`an swer`:31}]->(b:`B ar` {bar:'bar',answer:41}) RETURN {f:f,fb:fb,b:b} AS data");
 

--- a/core/src/test/java/apoc/trigger/TriggerDisabledTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerDisabledTest.java
@@ -34,7 +34,7 @@ public class TriggerDisabledTest {
     public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         apocConfig().setProperty(APOC_TRIGGER_ENABLED, false);
         exceptionRule.expect(RuntimeException.class);
         exceptionRule.expectMessage(TriggerHandler.NOT_ENABLED_ERROR);

--- a/core/src/test/java/apoc/trigger/TriggerRestartTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerRestartTest.java
@@ -47,7 +47,7 @@ public class TriggerRestartTest {
     }
 
     @Test
-    public void testTriggerRunsAfterRestart() throws Exception {
+    public void testTriggerRunsAfterRestart() {
 
 //        db.execute("CALL apoc.trigger.add('myTrigger', 'unwind $createdNodes as n set n.trigger=true', {phase:'before'})");
         TestUtil.testResult(db, "CALL apoc.trigger.add('myTrigger', 'unwind $createdNodes as n set n.trigger=true', {phase:'before'})",

--- a/core/src/test/java/apoc/trigger/TriggerTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerTest.java
@@ -47,7 +47,7 @@ public class TriggerTest {
     }
 
     @Test
-    public void testListTriggers() throws Exception {
+    public void testListTriggers() {
         String query = "MATCH (c:Counter) SET c.count = c.count + size([f IN $deletedNodes WHERE id(f) > 0])";
 
         TestUtil.testCallCount(db, "CALL apoc.trigger.add('count-removals',$query,{}) YIELD name RETURN name",
@@ -61,7 +61,7 @@ public class TriggerTest {
     }
 
     @Test
-    public void testRemoveNode() throws Exception {
+    public void testRemoveNode() {
         db.executeTransactionally("CREATE (:Counter {count:0})");
         db.executeTransactionally("CREATE (f:Foo)");
         db.executeTransactionally("CALL apoc.trigger.add('count-removals','MATCH (c:Counter) SET c.count = c.count + size([f IN $deletedNodes WHERE id(f) > 0])',{})");
@@ -82,7 +82,7 @@ public class TriggerTest {
     }
 
     @Test
-    public void testRemoveRelationship() throws Exception {
+    public void testRemoveRelationship() {
         db.executeTransactionally("CREATE (:Counter {count:0})");
         db.executeTransactionally("CREATE (f:Foo)-[:X]->(f)");
         db.executeTransactionally("CALL apoc.trigger.add('count-removed-rels','MATCH (c:Counter) SET c.count = c.count + size($deletedRelationships)',{})");
@@ -93,7 +93,7 @@ public class TriggerTest {
     }
 
     @Test
-    public void testRemoveTrigger() throws Exception {
+    public void testRemoveTrigger() {
         TestUtil.testCallCount(db, "CALL apoc.trigger.add('to-be-removed','RETURN 1',{}) YIELD name RETURN name", 1);
         TestUtil.testCall(db, "CALL apoc.trigger.list()", (row) -> {
             assertEquals("to-be-removed", row.get("name"));
@@ -115,7 +115,7 @@ public class TriggerTest {
     }
 
     @Test
-    public void testRemoveAllTrigger() throws Exception {
+    public void testRemoveAllTrigger() {
         TestUtil.testCallCount(db, "CALL apoc.trigger.removeAll()", 0);
         TestUtil.testCallCount(db, "CALL apoc.trigger.add('to-be-removed-1','RETURN 1',{}) YIELD name RETURN name", 1);
         TestUtil.testCallCount(db, "CALL apoc.trigger.add('to-be-removed-2','RETURN 2',{}) YIELD name RETURN name", 1);
@@ -136,7 +136,7 @@ public class TriggerTest {
     }
 
     @Test
-    public void testTimeStampTrigger() throws Exception {
+    public void testTimeStampTrigger() {
         db.executeTransactionally("CALL apoc.trigger.add('timestamp','UNWIND $createdNodes AS n SET n.ts = timestamp()',{})");
         db.executeTransactionally("CREATE (f:Foo)");
         TestUtil.testCall(db, "MATCH (f:Foo) RETURN f", (row) -> {
@@ -145,7 +145,7 @@ public class TriggerTest {
     }
 
     @Test
-    public void testTxIdAfterAsync() throws Exception {
+    public void testTxIdAfterAsync() {
         db.executeTransactionally("CALL apoc.trigger.add('txinfo','UNWIND $createdNodes AS n SET n.txId = $transactionId, n.txTime = $commitTime',{phase:'afterAsync'})");
         db.executeTransactionally("CREATE (f:Bar)");
         org.neo4j.test.assertion.Assert.assertEventually(() ->
@@ -201,7 +201,7 @@ public class TriggerTest {
     }
 
     @Test
-    public void testPauseResult() throws Exception {
+    public void testPauseResult() {
         db.executeTransactionally("CALL apoc.trigger.add('pausedTest', 'UNWIND $createdNodes AS n SET n.txId = $transactionId, n.txTime = $commitTime', {phase: 'after'})");
         TestUtil.testCall(db, "CALL apoc.trigger.pause('pausedTest')", (row) -> {
             assertEquals("pausedTest", row.get("name"));
@@ -211,7 +211,7 @@ public class TriggerTest {
     }
 
     @Test
-    public void testPauseOnCallList() throws Exception {
+    public void testPauseOnCallList() {
         db.executeTransactionally("CALL apoc.trigger.add('test', 'UNWIND $createdNodes AS n SET n.txId = $transactionId, n.txTime = $commitTime', {phase: 'after'})");
         db.executeTransactionally("CALL apoc.trigger.pause('test')");
         TestUtil.testCall(db, "CALL apoc.trigger.list()", (row) -> {
@@ -222,7 +222,7 @@ public class TriggerTest {
     }
 
     @Test
-    public void testResumeResult() throws Exception {
+    public void testResumeResult() {
         db.executeTransactionally("CALL apoc.trigger.add('test', 'UNWIND $createdNodes AS n SET n.txId = $transactionId, n.txTime = $commitTime', {phase: 'after'})");
         db.executeTransactionally("CALL apoc.trigger.pause('test')");
         TestUtil.testCall(db, "CALL apoc.trigger.resume('test')", (row) -> {
@@ -233,7 +233,7 @@ public class TriggerTest {
     }
 
     @Test
-    public void testTriggerPause() throws Exception {
+    public void testTriggerPause() {
         db.executeTransactionally("CALL apoc.trigger.add('test','UNWIND $createdNodes AS n SET n.txId = $transactionId, n.txTime = $commitTime',{})");
         db.executeTransactionally("CALL apoc.trigger.pause('test')");
         db.executeTransactionally("CREATE (f:Foo {name:'Michael'})");
@@ -245,7 +245,7 @@ public class TriggerTest {
     }
 
     @Test
-    public void testTriggerResume() throws Exception {
+    public void testTriggerResume() {
         db.executeTransactionally("CALL apoc.trigger.add('test','UNWIND $createdNodes AS n SET n.txId = $transactionId, n.txTime = $commitTime',{})");
         db.executeTransactionally("CALL apoc.trigger.pause('test')");
         db.executeTransactionally("CALL apoc.trigger.resume('test')");
@@ -258,12 +258,12 @@ public class TriggerTest {
     }
 
     @Test(expected = QueryExecutionException.class)
-    public void showThrowAnException() throws Exception {
+    public void showThrowAnException() {
         db.executeTransactionally("CALL apoc.trigger.add('test','UNWIND $createdNodes AS n SET n.txId = , n.txTime = $commitTime',{})");
     }
 
     @Test
-    public void testCreatedRelationshipsAsync() throws Exception {
+    public void testCreatedRelationshipsAsync() {
         db.executeTransactionally("CREATE (:A {name: \"A\"})-[:R1]->(:Z {name: \"Z\"})");
         db.executeTransactionally("CALL apoc.trigger.add('trigger-after-async', 'UNWIND $createdRelationships AS r\n" +
                 "MATCH (a:A)-[r]->(z:Z)\n" +
@@ -353,7 +353,7 @@ public class TriggerTest {
     }
 
     @Test
-    public void testDeleteRelationships() throws Exception {
+    public void testDeleteRelationships() {
         db.executeTransactionally("CREATE (a:A {name: \"A\"})-[:R1]->(z:Z {name: \"Z\"}), (a)-[:R2]->(z)");
         db.executeTransactionally("CALL apoc.trigger.add('trigger-after', 'UNWIND $deletedRelationships AS r\n" +
                 "MERGE (a:AA{name: \"AA\"})\n" +

--- a/core/src/test/java/apoc/trigger/TriggerTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerTest.java
@@ -40,7 +40,7 @@ public class TriggerTest {
     private long start;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         start = System.currentTimeMillis();
         TestUtil.registerProcedure(db, Trigger.class, Nodes.class);
         apocConfig().setProperty(APOC_TRIGGER_ENABLED, true);

--- a/core/src/test/java/apoc/util/UtilTest.java
+++ b/core/src/test/java/apoc/util/UtilTest.java
@@ -44,14 +44,14 @@ public class UtilTest {
     }
 
     @Test
-    public void testSubMap() throws Exception {
+    public void testSubMap() {
         assertEquals(map("b","c"),Util.subMap(map("a.b","c"),"a"));
         assertEquals(map("b","c"),Util.subMap(map("a.b","c"),"a."));
         assertEquals(map(),Util.subMap(map("a.b","c"),"x"));
     }
 
     @Test
-    public void testPartitionList() throws Exception {
+    public void testPartitionList() {
         List list = asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
         assertEquals(1,Util.partitionSubList(list,0).count());
         assertEquals(1,Util.partitionSubList(list,1).count());
@@ -69,7 +69,7 @@ public class UtilTest {
     }
 
     @Test
-    public void cleanPassword() throws Exception {
+    public void cleanPassword() {
         String url = "http://%slocalhost:7474/path?query#ref";
         assertEquals(format(url,""), Util.cleanUrl(format(url, "user:pass@")));
     }

--- a/core/src/test/java/apoc/util/UtilTest.java
+++ b/core/src/test/java/apoc/util/UtilTest.java
@@ -34,7 +34,7 @@ public class UtilTest {
     private static Node node;
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, Utils.class);
         try (Transaction tx = db.beginTx()) {
             node = tx.createNode(Label.label("User"));

--- a/core/src/test/java/apoc/util/UtilsTest.java
+++ b/core/src/test/java/apoc/util/UtilsTest.java
@@ -36,7 +36,7 @@ public class UtilsTest {
     public static DbmsRule db = new ImpermanentDbmsRule();
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void setUp() {
         TestUtil.registerProcedure(db, Utils.class);
     }
 

--- a/core/src/test/java/apoc/util/UtilsTest.java
+++ b/core/src/test/java/apoc/util/UtilsTest.java
@@ -41,7 +41,7 @@ public class UtilsTest {
     }
 
     @Test
-    public void testMultipleCharsetsCompressionWithDifferentResults() throws Exception {
+    public void testMultipleCharsetsCompressionWithDifferentResults() {
 
         List<String> listCompressed = new ArrayList<>();
 
@@ -93,7 +93,7 @@ public class UtilsTest {
     }
 
     @Test
-    public void testValueMainCompressorAlgoOnSimpleString() throws Exception {
+    public void testValueMainCompressorAlgoOnSimpleString() {
 
         String TEST_TO_GZIP = "H4sIAAAAAAAA/wtJLS4BADLRTXgEAAAA";
         String TEST_TO_DEFLATE = "eJwLSS0uAQAD3QGh";
@@ -125,7 +125,7 @@ public class UtilsTest {
     }
 
     @Test(expected = RuntimeException.class)
-    public void testWrongDecompressionFromPreviousDifferentCompressionAlgo() throws Exception {
+    public void testWrongDecompressionFromPreviousDifferentCompressionAlgo() {
         try {
             TestUtil.testCall(db, "WITH apoc.util.compress('test', {compression: 'GZIP'}) AS compressed RETURN apoc.util.decompress(compressed, {compression: 'DEFLATE'}) AS value", r -> {
             });
@@ -137,7 +137,7 @@ public class UtilsTest {
     }
 
     @Test
-    public void testWrongDecompressionFromPreviousDifferentCharset() throws Exception {
+    public void testWrongDecompressionFromPreviousDifferentCharset() {
 
         TestUtil.testCall(db,
                 "WITH apoc.util.compress($text, {charset: 'UTF-8'}) AS compressed RETURN apoc.util.decompress(compressed, {charset: 'UTF-8'}) AS value",
@@ -159,7 +159,7 @@ public class UtilsTest {
     }
 
     @Test
-    public void testCompressAndDecompressWithMultipleCompressionCharsetsReturningStartString() throws Exception {
+    public void testCompressAndDecompressWithMultipleCompressionCharsetsReturningStartString() {
 
         TestUtil.testCall(db,
                 "WITH apoc.util.compress($text) AS compressed RETURN apoc.util.decompress(compressed) AS value",
@@ -211,7 +211,7 @@ public class UtilsTest {
     }
 
     @Test
-    public void testCompressAndDecompressWithMultipleCompressionAlgosReturningStartString() throws Exception {
+    public void testCompressAndDecompressWithMultipleCompressionAlgosReturningStartString() {
 
         TestUtil.testCall(db,
                 "WITH apoc.util.compress($text) AS compressed RETURN apoc.util.decompress(compressed) AS value",
@@ -251,22 +251,22 @@ public class UtilsTest {
     }
 
     @Test
-    public void testSha1() throws Exception {
+    public void testSha1() {
         TestUtil.testCall(db, "RETURN apoc.util.sha1(['ABC']) AS value", r -> assertEquals("3c01bdbb26f358bab27f267924aa2c9a03fcfdb8", r.get("value")));
     }
 
     @Test
-    public void testMd5() throws Exception {
+    public void testMd5() {
         TestUtil.testCall(db, "RETURN apoc.util.md5(['ABC']) AS value", r -> assertEquals("902fbdd2b1df0c4f70b4a5d23525e932", r.get("value")));
     }
 
     @Test
-    public void testValidateFalse() throws Exception {
+    public void testValidateFalse() {
         TestUtil.testResult(db, "CALL apoc.util.validate(false,'message',null)", r -> assertEquals(false,r.hasNext()));
     }
 
     @Test
-    public void testValidateTrue() throws Exception {
+    public void testValidateTrue() {
         try {
             db.executeTransactionally("CALL apoc.util.validate(true,'message %d',[42])");
             fail("should have failed");
@@ -276,12 +276,12 @@ public class UtilsTest {
     }
 
     @Test
-    public void testValidatePredicateReturn() throws Exception {
+    public void testValidatePredicateReturn() {
         TestUtil.testCall(db, "RETURN apoc.util.validatePredicate(false,'message',null) AS value", r -> assertEquals(true, r.get("value")));
     }
 
     @Test
-    public void testValidatePredicateTrue() throws Exception {
+    public void testValidatePredicateTrue() {
         db.executeTransactionally("CREATE (:Person {predicate: true})");
         TestUtil.testFail(db, "MATCH (n:Person) RETURN apoc.util.validatePredicate(n.predicate,'message %d',[42]) AS n", QueryExecutionException.class);
     }

--- a/core/src/test/java/apoc/warmup/WarmupTest.java
+++ b/core/src/test/java/apoc/warmup/WarmupTest.java
@@ -25,7 +25,7 @@ public class WarmupTest {
     public DbmsRule db = new ImpermanentDbmsRule();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         TestUtil.registerProcedure(db, Warmup.class);
         // Create enough nodes and relationships to span 2 pages
         db.executeTransactionally("CREATE CONSTRAINT FOR (f:Foo) REQUIRE f.foo IS UNIQUE");

--- a/core/src/test/java/apoc/warmup/WarmupTest.java
+++ b/core/src/test/java/apoc/warmup/WarmupTest.java
@@ -40,7 +40,7 @@ public class WarmupTest {
     }
 
     @Test
-    public void testWarmup() throws Exception {
+    public void testWarmup() {
         TestUtil.testCall(db, "CALL apoc.warmup.run()", r -> {
             assertEquals(4L, r.get("nodesTotal"));
             assertNotEquals(0L, r.get("nodePages"));
@@ -50,7 +50,7 @@ public class WarmupTest {
     }
 
     @Test
-    public void testWarmupProperties() throws Exception {
+    public void testWarmupProperties() {
         TestUtil.testCall(db, "CALL apoc.warmup.run(true)", r -> {
             assertEquals(true, r.get("propertiesLoaded"));
             assertNotEquals(0L, r.get("propPages"));
@@ -58,7 +58,7 @@ public class WarmupTest {
     }
 
     @Test
-    public void testWarmupDynamicProperties() throws Exception {
+    public void testWarmupDynamicProperties() {
         TestUtil.testCall(db, "CALL apoc.warmup.run(true,true)", r -> {
             assertEquals(true, r.get("propertiesLoaded"));
             assertEquals(true, r.get("dynamicPropertiesLoaded"));
@@ -67,7 +67,7 @@ public class WarmupTest {
     }
 
     @Test
-    public void testWarmupIndexes() throws Exception {
+    public void testWarmupIndexes() {
         TestUtil.testCall(db, "CALL apoc.warmup.run(true,true,true)", r -> {
             assertEquals(true, r.get("indexesLoaded"));
             assertNotEquals( 0L, r.get("indexPages") );
@@ -75,7 +75,7 @@ public class WarmupTest {
     }
 
     @Test
-    public void testWarmupOnDifferentStorageEngines() throws Exception {
+    public void testWarmupOnDifferentStorageEngines() {
         final List<String> supportedTypes = Arrays.asList("standard", "aligned");
         for (String storageType : supportedTypes) {
             db.restartDatabase(Map.of(GraphDatabaseSettings.db_format, storageType));

--- a/test-utils/src/main/java/apoc/util/MySQLContainerExtension.java
+++ b/test-utils/src/main/java/apoc/util/MySQLContainerExtension.java
@@ -19,5 +19,5 @@ public class MySQLContainerExtension extends MySQLContainer<MySQLContainerExtens
                 .withStartupTimeout(Duration.ofMinutes(2)));
 
         addExposedPort(3306);
-    };
+    }
 }

--- a/test-utils/src/main/java/org/neo4j/test/rule/DbmsRule.java
+++ b/test-utils/src/main/java/org/neo4j/test/rule/DbmsRule.java
@@ -298,8 +298,7 @@ public abstract class DbmsRule extends ExternalResource implements GraphDatabase
         return restartDatabase( Map.of() );
     }
 
-    public GraphDatabaseAPI restartDatabase( Map<Setting<?>,Object> configChanges ) throws IOException
-    {
+    public GraphDatabaseAPI restartDatabase( Map<Setting<?>,Object> configChanges ) {
         managementService.shutdown();
         database = null;
         // This DatabaseBuilder has already been configured with the global settings as well as any test-specific settings,

--- a/test-utils/src/main/java/org/neo4j/test/rule/DbmsRule.java
+++ b/test-utils/src/main/java/org/neo4j/test/rule/DbmsRule.java
@@ -293,7 +293,7 @@ public abstract class DbmsRule extends ExternalResource implements GraphDatabase
         return this;
     }
 
-    public GraphDatabaseAPI restartDatabase() throws IOException
+    public GraphDatabaseAPI restartDatabase()
     {
         return restartDatabase( Map.of() );
     }

--- a/test-utils/src/main/java/org/neo4j/test/rule/ExternalResource.java
+++ b/test-utils/src/main/java/org/neo4j/test/rule/ExternalResource.java
@@ -60,7 +60,7 @@ public abstract class ExternalResource implements TestRule
      *
      * @throws Throwable if setup fails (which will disable {@code after}
      */
-    protected void before() throws Throwable
+    protected void before()
     {
         // do nothing
     }
@@ -68,7 +68,7 @@ public abstract class ExternalResource implements TestRule
     /**
      * Override to tear down your specific external resource.
      */
-    protected void after( boolean successful ) throws Throwable
+    protected void after( boolean successful )
     {
         // do nothing
     }


### PR DESCRIPTION
Cleanup some dead code and unused imports to reduce the crazy number of warnings.

There was also some deprecated usages of new Integer, new Long etc that I converted (first commit), these were considered errors and they are marked for removal.

This PR reduces our warnings by about 1000! (out of nearly 4000 though) 