### PR TITLE
Remove use of getID

### DIFF
--- a/common/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/common/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -156,7 +156,7 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 		AtomicInteger nodeCount = new AtomicInteger(0);
 		Function<Node, Map.Entry<Set<String>, Set<String>>> keyMapper = (node) -> {
 			try (Transaction tx = db.beginTx()) {
-				node = tx.getNodeById(node.getId());
+				node = tx.getNodeByElementId(node.getElementId());
 				Set<String> idProperties = CypherFormatterUtils.getNodeIdProperties(node, uniqueConstraints).keySet();
 				Set<String> labels = getLabels(node);
 				tx.commit();
@@ -266,7 +266,7 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 
 		Function<Relationship, Map<String, Object>> keyMapper = (rel) -> {
 			try (Transaction tx = db.beginTx()) {
-				rel = tx.getRelationshipById(rel.getId());
+				rel = tx.getRelationshipByElementId(rel.getElementId());
 				Node start = rel.getStartNode();
 				Set<String> startLabels = getLabels(start);
 

--- a/common/src/main/java/apoc/result/VirtualNode.java
+++ b/common/src/main/java/apoc/result/VirtualNode.java
@@ -261,8 +261,7 @@ public class VirtualNode implements Node {
 
     @Override
     public boolean equals(Object o) {
-        return this == o || o instanceof Node && Objects.equals(elementId, ((Node) o).getElementId());
-
+        return this == o || o instanceof Node && Objects.equals(getElementId(), ((Node) o).getElementId());
     }
 
     @Override

--- a/common/src/main/java/apoc/result/VirtualNode.java
+++ b/common/src/main/java/apoc/result/VirtualNode.java
@@ -261,7 +261,7 @@ public class VirtualNode implements Node {
 
     @Override
     public boolean equals(Object o) {
-        return this == o || o instanceof Node && id == ((Node) o).getId();
+        return this == o || o instanceof Node && Objects.equals(elementId, ((Node) o).getElementId());
 
     }
 

--- a/common/src/main/java/apoc/result/VirtualRelationship.java
+++ b/common/src/main/java/apoc/result/VirtualRelationship.java
@@ -153,8 +153,8 @@ public class VirtualRelationship implements Relationship {
 
     @Override
     public boolean equals(Object o) {
-        return this == o || o instanceof Relationship && id == ((Relationship) o).getId();
-
+        return this == o || o instanceof Relationship &&
+                Objects.equals(getElementId(), ((Relationship) o).getElementId());
     }
 
     @Override

--- a/common/src/main/java/apoc/result/WrappedNode.java
+++ b/common/src/main/java/apoc/result/WrappedNode.java
@@ -214,7 +214,7 @@ public class WrappedNode implements Node {
 
     @Override
     public boolean equals(Object o) {
-        return this == o || o instanceof Node && id == ((Node) o).getId();
+        return this == o || o instanceof Node && Objects.equals(getElementId(), ((Node) o).getElementId());
 
     }
 

--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -942,11 +942,11 @@ public class Util {
     }
 
     public static Node rebind(Transaction tx, Node node) {
-         return node instanceof VirtualNode ? node : tx.getNodeById(node.getId());
+         return node instanceof VirtualNode ? node : tx.getNodeByElementId(node.getElementId());
     }
 
     public static Relationship rebind(Transaction tx, Relationship rel) {
-         return rel instanceof VirtualRelationship ? rel : tx.getRelationshipById(rel.getId());
+         return rel instanceof VirtualRelationship ? rel : tx.getRelationshipByElementId(rel.getElementId());
     }
 
     public static <T extends Entity> T rebind(Transaction tx, T e) {

--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.collections.api.iterator.LongIterator;
 import org.neo4j.graphdb.ExecutionPlanDescription;
 import org.neo4j.graphdb.Result;
+import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.logging.NullLog;
 import org.neo4j.procedure.Mode;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
@@ -1089,7 +1090,7 @@ public class Util {
     }
 
     public static boolean isSelfRel(Relationship rel) {
-        return rel.getStartNodeId() == rel.getEndNodeId();
+        return Objects.equals(rel.getStartNode().getElementId(), rel.getEndNode().getElementId());
     }
 
     public static String toCypherMap(Map<String, Object> map) {
@@ -1145,5 +1146,12 @@ public class Util {
     public static <T extends Entity> T withTransactionAndRebind(GraphDatabaseService db, Transaction transaction, Function<Transaction, T> action) {
         T result = retryInTx(NullLog.getInstance(), db, action, 0, 0, r -> {});
         return rebind(transaction, result);
+    }
+
+    public static long getNodeId(InternalTransaction tx, String elementId) {
+        return tx.elementIdMapper().nodeId(elementId);
+    }
+    public static  String getNodeElementId(InternalTransaction tx, long id) {
+        return tx.elementIdMapper().nodeElementId(id);
     }
 }

--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -1151,7 +1151,14 @@ public class Util {
     public static long getNodeId(InternalTransaction tx, String elementId) {
         return tx.elementIdMapper().nodeId(elementId);
     }
+
+    public static long getRelationshipId(InternalTransaction tx, String elementId) {
+        return tx.elementIdMapper().relationshipId(elementId);
+    }
     public static  String getNodeElementId(InternalTransaction tx, long id) {
         return tx.elementIdMapper().nodeElementId(id);
+    }
+    public static  String getRelationshipElementId(InternalTransaction tx, long id) {
+        return tx.elementIdMapper().relationshipElementId(id);
     }
 }

--- a/common/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
+++ b/common/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
@@ -10,194 +10,151 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-public class CypherResultSubGraph implements SubGraph
-{
+public class CypherResultSubGraph implements SubGraph {
 
-    private final SortedMap<Long, Node> nodes = new TreeMap<>();
-    private final SortedMap<Long, Relationship> relationships = new TreeMap<>();
+    private final SortedMap<String, Node> nodes = new TreeMap<>();
+    private final SortedMap<String, Relationship> relationships = new TreeMap<>();
     private final Collection<Label> labels = new HashSet<>();
     private final Collection<RelationshipType> types = new HashSet<>();
     private final Collection<IndexDefinition> indexes = new HashSet<>();
     private final Collection<ConstraintDefinition> constraints = new HashSet<>();
 
-    public void add( Node node )
-    {
-        final long id = node.getId();
-        if ( !nodes.containsKey( id ) )
-        {
-            addNode( id, node );
+    public void add(Node node) {
+        final String id = node.getElementId();
+        if (!nodes.containsKey(id)) {
+            addNode(id, node);
         }
     }
 
-    void addNode( long id, Node data )
-    {
-        nodes.put( id, data );
-        labels.addAll( Iterables.asList( data.getLabels() ) );
+    void addNode(String id, Node data) {
+        nodes.put(id, data);
+        labels.addAll(Iterables.asList(data.getLabels()));
     }
 
-    public void add( Relationship rel )
-    {
-        final long id = rel.getId();
-        if ( !relationships.containsKey( id ) )
-        {
-            addRel( id, rel );
-            add( rel.getStartNode() );
-            add( rel.getEndNode() );
+    public void add(Relationship rel) {
+        final String id = rel.getElementId();
+        if (!relationships.containsKey(id)) {
+            addRel(id, rel);
+            add(rel.getStartNode());
+            add(rel.getEndNode());
         }
     }
 
-    public static SubGraph from(Transaction tx, Result result, boolean addBetween)
-    {
+    public static SubGraph from(Transaction tx, Result result, boolean addBetween) {
         final CypherResultSubGraph graph = new CypherResultSubGraph();
         final List<String> columns = result.columns();
-        result.forEachRemaining( row ->
-        {
-            for ( String column : columns )
-            {
-                final Object value = row.get( column );
-                graph.addToGraph( value );
+        result.forEachRemaining(row -> {
+            for (String column : columns) {
+                final Object value = row.get(column);
+                graph.addToGraph(value);
             }
-        } );
-        for ( IndexDefinition def : tx.schema().getIndexes() )
-        {
-            if ( def.getIndexType() != IndexType.LOOKUP )
-            {
-                if ( def.isNodeIndex() )
-                {
-                    for ( Label label : def.getLabels() )
-                    {
-                        if ( graph.getLabels().contains( label ) )
-                        {
-                            graph.addIndex( def );
+        });
+        for (IndexDefinition def : tx.schema().getIndexes()) {
+            if (def.getIndexType() != IndexType.LOOKUP) {
+                if (def.isNodeIndex()) {
+                    for (Label label : def.getLabels()) {
+                        if (graph.getLabels().contains(label)) {
+                            graph.addIndex(def);
                             break;
                         }
                     }
-                }
-                else
-                {
-                    for ( RelationshipType type : def.getRelationshipTypes() )
-                    {
-                        if ( graph.getTypes().contains( type ) )
-                        {
-                            graph.addIndex( def );
+                } else {
+                    for (RelationshipType type : def.getRelationshipTypes()) {
+                        if (graph.getTypes().contains(type)) {
+                            graph.addIndex(def);
                             break;
                         }
                     }
                 }
             }
         }
-        for ( ConstraintDefinition def : tx.schema().getConstraints() )
-        {
-            if ( graph.getLabels().contains( def.getLabel() ) )
-            {
-                graph.addConstraint( def );
+        for (ConstraintDefinition def : tx.schema().getConstraints()) {
+            if (graph.getLabels().contains(def.getLabel())) {
+                graph.addConstraint(def);
             }
-        }
-        if ( addBetween )
-        {
+        } if (addBetween) {
             graph.addRelationshipsBetweenNodes();
         }
         return graph;
     }
 
-    private void addIndex( IndexDefinition def )
-    {
-        indexes.add( def );
+    private void addIndex(IndexDefinition def) {
+        indexes.add(def);
     }
 
-    private void addConstraint( ConstraintDefinition def )
-    {
-        constraints.add( def );
+    private void addConstraint(ConstraintDefinition def) {
+        constraints.add(def);
     }
 
-    private void addRelationshipsBetweenNodes()
-    {
+    private void addRelationshipsBetweenNodes() {
         Set<Node> newNodes = new HashSet<>();
-        for ( Node node : nodes.values() )
-        {
-            for ( Relationship relationship : node.getRelationships() )
-            {
-                if ( !relationships.containsKey( relationship.getId() ) )
-                {
+        for (Node node : nodes.values()) {
+            for (Relationship relationship : node.getRelationships()) {
+                if (!relationships.containsKey(relationship.getElementId())) {
                     continue;
                 }
 
-                final Node other = relationship.getOtherNode( node );
-                if ( nodes.containsKey( other.getId() ) || newNodes.contains( other ) )
-                {
+                final Node other = relationship.getOtherNode(node);
+                if (nodes.containsKey(other.getElementId()) || newNodes.contains(other)) {
                     continue;
                 }
-                newNodes.add( other );
+                newNodes.add(other);
             }
         }
-        for ( Node node : newNodes )
-        {
-            add( node );
+        for (Node node : newNodes) {
+            add(node);
         }
     }
 
-    private void addToGraph( Object value )
-    {
-        if ( value instanceof Node )
-        {
-            add( (Node) value );
+    private void addToGraph(Object value) {
+        if (value instanceof Node) {
+            add((Node) value);
         }
-        if ( value instanceof Relationship )
-        {
-            add( (Relationship) value );
+        if (value instanceof Relationship) {
+            add((Relationship) value);
         }
-        if ( value instanceof Iterable )
-        {
-            for ( Object inner : (Iterable) value )
-            {
-                addToGraph( inner );
+        if (value instanceof Iterable) {
+            for (Object inner : (Iterable) value) {
+                addToGraph(inner);
             }
         }
     }
 
     @Override
-    public Iterable<Node> getNodes()
-    {
+    public Iterable<Node> getNodes() {
         return nodes.values();
     }
 
     @Override
-    public Iterable<Relationship> getRelationships()
-    {
+    public Iterable<Relationship> getRelationships() {
         return relationships.values();
     }
 
-    public Collection<Label> getLabels()
-    {
+    public Collection<Label> getLabels() {
         return labels;
     }
 
-    public Collection<RelationshipType> getTypes()
-    {
+    public Collection<RelationshipType> getTypes() {
         return types;
     }
 
-    void addRel( Long id, Relationship rel )
-    {
-        relationships.put( id, rel );
+    void addRel(String id, Relationship rel) {
+        relationships.put(id, rel);
         types.add(rel.getType());
     }
 
     @Override
-    public boolean contains( Relationship relationship )
-    {
-        return relationships.containsKey( relationship.getId() );
+    public boolean contains(Relationship relationship) {
+        return relationships.containsKey(relationship.getElementId());
     }
 
     @Override
-    public Iterable<IndexDefinition> getIndexes()
-    {
+    public Iterable<IndexDefinition> getIndexes() {
         return indexes;
     }
 
     @Override
-    public Iterable<ConstraintDefinition> getConstraints()
-    {
+    public Iterable<ConstraintDefinition> getConstraints() {
         return constraints;
     }
 
@@ -245,8 +202,8 @@ public class CypherResultSubGraph implements SubGraph
         return relationships.values().stream()
                 .filter(r -> {
                     boolean matchType = r.getType().equals(type);
-                    boolean matchStart = start != null ? r.getStartNode().hasLabel(start) : true;
-                    boolean matchEnd = end != null ? r.getEndNode().hasLabel(end) : true;
+                    boolean matchStart = start == null || r.getStartNode().hasLabel(start);
+                    boolean matchEnd = end == null || r.getEndNode().hasLabel(end);
                     return matchType && matchStart && matchEnd;
                 })
                 .count();

--- a/common/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
+++ b/common/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
@@ -42,7 +42,7 @@ public class DatabaseSubGraph implements SubGraph
     @Override
     public boolean contains( Relationship relationship )
     {
-        return transaction.getRelationshipById( relationship.getId() ) != null;
+        return transaction.getRelationshipByElementId( relationship.getElementId() ) != null;
     }
 
     @Override

--- a/common/src/test/java/apoc/result/VirtualNodeTest.java
+++ b/common/src/test/java/apoc/result/VirtualNodeTest.java
@@ -109,4 +109,14 @@ public class VirtualNodeTest {
         assertEquals(start, end.getRelationships().iterator().next().getOtherNode(end));
     }
 
+    @Test
+    public void testVirtualNodesEqualEachother() {
+        VirtualNode node1 = new VirtualNode(1L);
+        VirtualNode node2 = new VirtualNode(2L);
+
+        assertEquals(node1, node1);
+        assertEquals(node2, node2);
+        assertNotEquals(node1, node2);
+    }
+
 }

--- a/common/src/test/java/apoc/result/VirtualNodeTest.java
+++ b/common/src/test/java/apoc/result/VirtualNodeTest.java
@@ -55,7 +55,8 @@ public class VirtualNodeTest {
 
         RelationshipType relationshipType = RelationshipType.withName("TYPE");
         Relationship rel = start.createRelationshipTo(end, relationshipType);
-        assertTrue("the rel id should be < 0", rel.getId() < 0);
+        // Virtual Nodes/Relationships element ids are just String versions of ints.
+        assertTrue("the rel id should be < 0", rel.getElementId().startsWith("-"));
 
         assertEquals(1, Iterables.count(start.getRelationships()));
         assertEquals(0, Iterables.count(start.getRelationships(Direction.INCOMING)));
@@ -92,7 +93,8 @@ public class VirtualNodeTest {
 
         RelationshipType relationshipType = RelationshipType.withName("TYPE");
         Relationship rel = end.createRelationshipFrom(start, relationshipType);
-        assertTrue("the rel id should be < 0", rel.getId() < 0);
+        // Virtual Nodes/Relationships element ids are just String versions of ints.
+        assertTrue("the rel id should be < 0", rel.getElementId().startsWith("-"));
 
         assertEquals(1, Iterables.count(start.getRelationships()));
         assertEquals(0, Iterables.count(start.getRelationships(Direction.INCOMING)));

--- a/core/src/main/java/apoc/export/arrow/ExportResultStrategy.java
+++ b/core/src/main/java/apoc/export/arrow/ExportResultStrategy.java
@@ -1,28 +1,14 @@
 package apoc.export.arrow;
 
 import apoc.meta.Types;
-import apoc.util.Util;
-import apoc.util.collection.Iterables;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.neo4j.cypher.export.SubGraph;
-import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.Label;
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.Relationship;
-import org.neo4j.graphdb.RelationshipType;
 import java.util.AbstractMap;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static apoc.export.arrow.ArrowUtils.FIELD_ID;
-import static apoc.export.arrow.ArrowUtils.FIELD_LABELS;
-import static apoc.export.arrow.ArrowUtils.FIELD_SOURCE_ID;
-import static apoc.export.arrow.ArrowUtils.FIELD_TARGET_ID;
-import static apoc.export.arrow.ArrowUtils.FIELD_TYPE;
 import static apoc.export.arrow.ExportArrowStrategy.fromMetaType;
 import static apoc.export.arrow.ExportArrowStrategy.toField;
 
@@ -38,36 +24,5 @@ public interface ExportResultStrategy {
                 .map(e -> toField(e.getKey(), e.getValue()))
                 .collect(Collectors.toList());
         return new Schema(fields);
-    }
-
-    default Map<String, Object> entityToMap(Entity entity) {
-        Map<String, Object> flattened = new HashMap<>();
-        flattened.put(FIELD_ID.getName(), entity.getId());
-        if (entity instanceof Node) {
-            flattened.put(FIELD_LABELS.getName(), Util.labelStrings((Node) entity));
-        } else {
-            Relationship rel = (Relationship) entity;
-            flattened.put(FIELD_TYPE.getName(), rel.getType().name());
-            flattened.put(FIELD_SOURCE_ID.getName(), rel.getStartNodeId());
-            flattened.put(FIELD_TARGET_ID.getName(), rel.getEndNodeId());
-        }
-        flattened.putAll(entity.getAllProperties());
-        return flattened;
-    }
-
-    default Map<String, Object> createConfigMap(SubGraph subGraph, ArrowConfig config) {
-        final List<String> allLabelsInUse = Iterables.stream(subGraph.getAllLabelsInUse())
-                .map(Label::name)
-                .collect(Collectors.toList());
-        final List<String> allRelationshipTypesInUse = Iterables.stream(subGraph.getAllRelationshipTypesInUse())
-                .map(RelationshipType::name)
-                .collect(Collectors.toList());
-        Map<String, Object> configMap = new HashMap<>();
-        configMap.put("includeLabels", allLabelsInUse);
-        if (!allRelationshipTypesInUse.isEmpty()) {
-            configMap.put("includeRels", allRelationshipTypesInUse);
-        }
-        configMap.putAll(config.getConfig());
-        return configMap;
     }
 }

--- a/core/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/core/src/main/java/apoc/export/csv/CsvFormat.java
@@ -41,6 +41,7 @@ import static apoc.export.util.MetaInformation.collectPropTypesForRelationships;
 import static apoc.export.util.MetaInformation.getLabelsString;
 import static apoc.export.util.MetaInformation.updateKeyTypes;
 import static apoc.util.Util.getNodeId;
+import static apoc.util.Util.getRelationshipId;
 import static apoc.util.Util.joinLabels;
 
 /**
@@ -211,7 +212,7 @@ public class CsvFormat implements Format {
                                     return entrySet.getKey().name();
                                 default:
                                     String prop = s.split(":")[0];
-                                    return "".equals(prop) ? String.valueOf(getNodeId(tx, r.getElementId())) : cleanPoint(FormatUtils.toString(r.getProperty(prop, "")));
+                                    return "".equals(prop) ? String.valueOf(getRelationshipId(tx, r.getElementId())) : cleanPoint(FormatUtils.toString(r.getProperty(prop, "")));
                             }
                         }).collect(Collectors.toList());
                     })

--- a/core/src/main/java/apoc/export/csv/ExportCSV.java
+++ b/core/src/main/java/apoc/export/csv/ExportCSV.java
@@ -17,6 +17,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
@@ -100,7 +101,7 @@ public class ExportCSV {
         ProgressInfo progressInfo = new ProgressInfo(fileName, source, format);
         progressInfo.batchSize = exportConfig.getBatchSize();
         ProgressReporter reporter = new ProgressReporter(null, null, progressInfo);
-        CsvFormat exporter = new CsvFormat(db);
+        CsvFormat exporter = new CsvFormat(db, (InternalTransaction) tx);
 
         ExportFileManager cypherFileManager = FileManagerFactory
                 .createFileManager(fileName, exportConfig.isBulkImport(), exportConfig);

--- a/core/src/main/java/apoc/export/csv/ImportCsv.java
+++ b/core/src/main/java/apoc/export/csv/ImportCsv.java
@@ -50,7 +50,7 @@ public class ImportCsv {
                     final ProgressReporter reporter = new ProgressReporter(null, null, new ProgressInfo(file, source, "csv"));
                     final CsvEntityLoader loader = new CsvEntityLoader(clc, reporter, log);
 
-                    final Map<String, Map<String, Long>> idMapping = new HashMap<>();
+                    final Map<String, Map<String, String>> idMapping = new HashMap<>();
                     for (Map<String, Object> node : nodes) {
                         final Object data = node.getOrDefault("fileName", node.get("data"));
                         final List<String> labels = (List<String>) node.get("labels");

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
@@ -202,7 +202,7 @@ public class XmlGraphMLReader {
     }
 
     public long parseXML(Reader input) throws XMLStreamException {
-        Map<String, Long> cache = new HashMap<>(1024*32);
+        Map<String, String> cache = new HashMap<>(1024*32);
         XMLInputFactory inputFactory = XMLInputFactory.newInstance();
         inputFactory.setProperty("javax.xml.stream.isCoalescing", true);
         inputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
@@ -276,7 +276,7 @@ public class XmlGraphMLReader {
                         if (storeNodeIds) node.setProperty("id", id);
                         setDefaults(nodeKeys, node);
                         last = node;
-                        cache.put(id, node.getId());
+                        cache.put(id, node.getElementId());
                         if (reporter != null) reporter.update(1, 0, 0);
                         count++;
                         continue;
@@ -328,16 +328,16 @@ public class XmlGraphMLReader {
         }
     }
 
-    private Node getByNodeId(Map<String, Long> cache, Transaction tx, StartElement element, XmlNodeExport.NodeType nodeType) {
+    private Node getByNodeId(Map<String, String> cache, Transaction tx, StartElement element, XmlNodeExport.NodeType nodeType) {
         final XmlNodeExport.ExportNode xmlNodeInterface = nodeType.get();
         final ExportConfig.NodeConfig nodeConfig = xmlNodeInterface.getNodeConfigReader(this);
         
         final String sourceTargetValue = getAttribute(element, QName.valueOf(nodeType.getName()));
         
-        final Long id = cache.get(sourceTargetValue);
+        final String id = cache.get(sourceTargetValue);
         // without source/target config, we look for the internal id
         if (StringUtils.isBlank(nodeConfig.label)) {
-            return tx.getNodeById(id);
+            return tx.getNodeByElementId(id);
         }
         // with source/target configured, we search a node with a specified label 
         // and with a type specified in sourceType, if present, or string by default

--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -236,7 +236,7 @@ public class Meta {
                 : nodes.stream().filter(Objects::nonNull).map(String::trim).map(Label::label);
 
         final boolean isIncludeRels = CollectionUtils.isEmpty(conf.getIncludesRels());
-        Set<Long> visitedNodes = new HashSet<>();
+        Set<String> visitedNodes = new HashSet<>();
         return labels
                 .flatMap(label -> isIncludeRels ? Stream.of(subGraph.countsForNode(label)) : conf.getIncludesRels()
                         .stream()
@@ -261,8 +261,8 @@ public class Meta {
                         })
                         .flatMap(pair -> transaction.findNodes(label)
                                 .map(node -> {
-                                    if (!visitedNodes.contains(node.getId()) && node.hasRelationship(pair.getLeft(), RelationshipType.withName(pair.getRight()))) {
-                                        visitedNodes.add(node.getId());
+                                    if (!visitedNodes.contains(node.getElementId()) && node.hasRelationship(pair.getLeft(), RelationshipType.withName(pair.getRight()))) {
+                                        visitedNodes.add(node.getElementId());
                                         return 1L;
                                     } else {
                                         return 0L;

--- a/core/src/main/java/apoc/path/PathExplorer.java
+++ b/core/src/main/java/apoc/path/PathExplorer.java
@@ -11,6 +11,7 @@ import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.traversal.*;
+import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
@@ -23,6 +24,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static apoc.path.PathExplorer.NodeFilter.*;
+import static apoc.util.Util.getNodeElementId;
 
 public class PathExplorer {
 	public static final Uniqueness UNIQUENESS = Uniqueness.RELATIONSHIP_PATH;
@@ -114,7 +116,7 @@ public class PathExplorer {
 			return Collections.singletonList((Node) start);
 		}
 		if (start instanceof Number) {
-			return Collections.singletonList(tx.getNodeById(((Number) start).longValue()));
+			return Collections.singletonList(tx.getNodeByElementId(getNodeElementId((InternalTransaction) tx, ((Number) start).longValue())));
 		}
 		if (start instanceof List) {
 			List list = (List) start;
@@ -124,7 +126,7 @@ public class PathExplorer {
 			if (first instanceof Node) return (List<Node>)list;
 			if (first instanceof Number) {
                 List<Node> nodes = new ArrayList<>();
-                for (Number n : ((List<Number>)list)) nodes.add(tx.getNodeById(n.longValue()));
+                for (Number n : ((List<Number>)list)) nodes.add(tx.getNodeByElementId(getNodeElementId((InternalTransaction) tx, n.longValue())));
                 return nodes;
             }
 		}

--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -281,9 +281,9 @@ public class GraphRefactoring {
         nodesSet.stream().sorted(Comparator.comparingLong(Node::getId)).forEach(tx::acquireWriteLock);
 
         final Node first = nodes.get(0);
-        final List<Long> existingSelfRelIds = conf.isPreservingExistingSelfRels()
+        final List<String> existingSelfRelIds = conf.isPreservingExistingSelfRels()
                 ? StreamSupport.stream(first.getRelationships().spliterator(), false).filter(Util::isSelfRel)
-                    .map(Entity::getId)
+                    .map(Entity::getElementId)
                     .collect(Collectors.toList())
                 : Collections.emptyList();
 
@@ -586,14 +586,14 @@ public class GraphRefactoring {
         });
     }
 
-    private void mergeNodes(Node source, Node target, RefactorConfig conf, List<Long> excludeRelIds) {
+    private void mergeNodes(Node source, Node target, RefactorConfig conf, List<String> excludeRelIds) {
         try {
             Map<String, Object> properties = source.getAllProperties();
 
             copyRelationships(source, copyLabels(source, target), true, conf.isCreatingNewSelfRel());
             if (conf.getMergeRelsAllowed()) {
-                mergeRelsWithSameTypeAndDirectionInMergeNodes(target, conf, Direction.OUTGOING, excludeRelIds);
-                mergeRelsWithSameTypeAndDirectionInMergeNodes(target, conf, Direction.INCOMING, excludeRelIds);
+                mergeRelationshipsWithSameTypeAndDirection(target, conf, Direction.OUTGOING, excludeRelIds);
+                mergeRelationshipsWithSameTypeAndDirection(target, conf, Direction.INCOMING, excludeRelIds);
             }
             source.delete();
             PropertiesManager.mergeProperties(properties, target, conf);

--- a/core/src/main/java/apoc/refactor/util/RefactorUtil.java
+++ b/core/src/main/java/apoc/refactor/util/RefactorUtil.java
@@ -12,10 +12,10 @@ import static apoc.util.Util.isSelfRel;
 
 public class RefactorUtil {
 
-    public static void mergeRelsWithSameTypeAndDirectionInMergeNodes(Node node, RefactorConfig config, Direction dir, List<Long> excludeRelIds) {
+    public static void mergeRelationshipsWithSameTypeAndDirection(Node node, RefactorConfig config, Direction dir, List<String> excludeRelIds) {
         for (RelationshipType type : node.getRelationshipTypes()) {
             StreamSupport.stream(node.getRelationships(dir,type).spliterator(), false)
-                    .filter(rel -> !excludeRelIds.contains(rel.getId()))
+                    .filter(rel -> !excludeRelIds.contains(rel.getElementId()))
                     .collect(Collectors.groupingBy(rel -> Pair.of(rel.getStartNode(), rel.getEndNode())))
                     .values().stream()
                     .filter(list -> !list.isEmpty())

--- a/core/src/main/java/apoc/spatial/Distance.java
+++ b/core/src/main/java/apoc/spatial/Distance.java
@@ -78,7 +78,7 @@ public class Distance {
 
     private void checkNodeHasGeo(Node node) {
         if (!node.hasProperty(LATITUDE) || !node.hasProperty(LONGITUDE)) {
-            throw new IllegalArgumentException(String.format("Node with id %s has invalid geo properties", node.getId()));
+            throw new IllegalArgumentException(String.format("Node with id %s has invalid geo properties", node.getElementId()));
         }
     }
 

--- a/core/src/test/java/apoc/number/exact/ExactTest.java
+++ b/core/src/test/java/apoc/number/exact/ExactTest.java
@@ -11,6 +11,7 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import static apoc.util.TestUtil.testCall;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author AgileLARUS
@@ -31,61 +32,62 @@ public class ExactTest {
 
 	@Test
 	public void testAdd(){
-		testCall(db,"return apoc.number.exact.add('1213669989','1238126387') as value", row -> assertEquals(new String("2451796376"), row.get("value")));
+		testCall(db,"return apoc.number.exact.add('1213669989','1238126387') as value", row -> assertEquals("2451796376", row.get("value")));
 	}
 
+	@Test
 	public void testAddNull(){
-		testCall(db,"return apoc.number.exact.add(null,'1238126387') as value", row -> assertEquals(null, row.get("value")));
+		testCall(db,"return apoc.number.exact.add(null,'1238126387') as value", row -> assertNull(row.get("value")));
 	}
 
 	@Test
 	public void testSub(){
-		testCall(db,"return apoc.number.exact.sub('1238126387','1213669989') as value", row -> assertEquals(new String("24456398"), row.get("value")));
+		testCall(db,"return apoc.number.exact.sub('1238126387','1213669989') as value", row -> assertEquals("24456398", row.get("value")));
 	}
 
 	@Test
 	public void testMul(){
-		testCall(db,"return apoc.number.exact.mul('550058444','662557', 15, 'HALF_DOWN') as value", row -> assertEquals(new String("364445072481308"), row.get("value")));
+		testCall(db,"return apoc.number.exact.mul('550058444','662557', 15, 'HALF_DOWN') as value", row -> assertEquals("364445072481308", row.get("value")));
 	}
 
 	@Test
 	public void testDiv(){
-		testCall(db,"return apoc.number.exact.div('550058444','662557', 18, 'HALF_DOWN') as value", row -> assertEquals(new String("830.205467605051339"), row.get("value")));
+		testCall(db,"return apoc.number.exact.div('550058444','662557', 18, 'HALF_DOWN') as value", row -> assertEquals("830.205467605051339", row.get("value")));
 	}
 
 	@Test
 	public void testToInteger(){
-		testCall(db,"return apoc.number.exact.toInteger('504238974', 5, 'HALF_DOWN') as value", row -> assertEquals(new Long(504238974), row.get("value")));
+		testCall(db,"return apoc.number.exact.toInteger('504238974', 5, 'HALF_DOWN') as value", row -> assertEquals(504238974L, row.get("value")));
 	}
 
 	@Test
 	public void testToFloat(){
-		testCall(db,"return apoc.number.exact.toFloat('50423.1656', 10, null) as value", row -> assertEquals(new Double(50423.1656), row.get("value")));
+		testCall(db,"return apoc.number.exact.toFloat('50423.1656', 10, null) as value", row -> assertEquals(50423.1656, row.get("value")));
 	}
 
 	@Test
 	public void testToExact(){
-		testCall(db,"return apoc.number.exact.toExact(521468545698447) as value", row -> assertEquals(new Long("521468545698447"), row.get("value")));
+		testCall(db,"return apoc.number.exact.toExact(521468545698447) as value", row -> assertEquals(Long.valueOf("521468545698447"), row.get("value")));
 	}
 
 	@Test
 	public void testPrec(){
-		testCall(db,"return apoc.number.exact.mul('550058444','662557', 5, 'HALF_DOWN') as value", row -> assertEquals(new String("364450000000000"), row.get("value")));
+		testCall(db,"return apoc.number.exact.mul('550058444','662557', 5, 'HALF_DOWN') as value", row -> assertEquals("364450000000000", row.get("value")));
 	}
 
 	@Test
 	public void testRound(){
-		testCall(db,"return apoc.number.exact.mul('550058444','662557', 10, 'DOWN') as value", row -> assertEquals(new String("364445072400000"), row.get("value")));
+		testCall(db,"return apoc.number.exact.mul('550058444','662557', 10, 'DOWN') as value", row -> assertEquals("364445072400000", row.get("value")));
 	}
 
 	@Test
 	public void testMulWithoutOptionalParams(){
-		testCall(db,"return apoc.number.exact.mul('550058444','662557') as value", row -> assertEquals(new String("364445072481308"), row.get("value")));
+		testCall(db,"return apoc.number.exact.mul('550058444','662557') as value", row -> assertEquals("364445072481308", row.get("value")));
 	}
 
 	@Test
 	public void testAddScientificNotation(){
-		testCall(db,"return apoc.number.exact.add('1E6','1E6') as value", row -> assertEquals(new String("2000000"), row.get("value")));
+		testCall(db,"return apoc.number.exact.add('1E6','1E6') as value", row -> assertEquals("2000000", row.get("value")));
 	}
 
 }

--- a/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
+++ b/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
@@ -45,7 +45,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNull;

--- a/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
+++ b/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
@@ -346,41 +346,28 @@ public class GraphRefactoringTest {
     }
 
     @Test
-    public void testDeleteOneNode() {
-        long id = db.executeTransactionally("CREATE (p1:Person {ID:1}), (p2:Person {ID:2}) RETURN id(p1) as id ", emptyMap(), result -> Iterators.single(result.columnAs("id")));
-        testCall(db, "MATCH (o:Person {ID:$oldID}), (n:Person {ID:$newID}) DELETE o RETURN n as node",
-                      map("oldID", 1L, "newID",2L),
-                (r) -> {
-                    Node node = (Node) r.get("node");
-                    assertNotEquals(id, node.getId());
-                    assertEquals(true, node.hasLabel(Label.label("Person")));
-                    assertEquals(2L, node.getProperty("ID"));
-                });
-    }
-
-    @Test
     public void testEagernessMergeNodesFails() {
         db.executeTransactionally("CREATE INDEX FOR (n:Person) ON (n.ID)");
-        long id = db.executeTransactionally("CREATE (p1:Person {ID:1}), (p2:Person {ID:2}) RETURN id(p1) as id ", emptyMap(), result -> Iterators.single(result.columnAs("id")));
+        String id = db.executeTransactionally("CREATE (p1:Person {ID:1}), (p2:Person {ID:2}) RETURN elementId(p1) as id", emptyMap(), result -> Iterators.single(result.columnAs("id")));
         testCall(db, "MATCH (o:Person {ID:$oldID}), (n:Person {ID:$newID}) CALL apoc.refactor.mergeNodes([o,n]) yield node return node",
                       map("oldID", 1L, "newID",2L),
                 (r) -> {
                     Node node = (Node) r.get("node");
-                    assertEquals(id, node.getId());
-                    assertEquals(true, node.hasLabel(Label.label("Person")));
+                    assertEquals(id, node.getElementId());
+                    assertTrue(node.hasLabel(label("Person")));
                     assertEquals(2L, node.getProperty("ID"));
                 });
     }
 
     @Test
     public void testMergeNodesEagerAggregation() {
-        long id = db.executeTransactionally("CREATE (p1:Person {ID:1}), (p2:Person {ID:2}) RETURN id(p1) as id ", emptyMap(), result -> Iterators.single(result.columnAs("id")));
+        String id = db.executeTransactionally("CREATE (p1:Person {ID:1}), (p2:Person {ID:2}) RETURN elementId(p1) as id ", emptyMap(), result -> Iterators.single(result.columnAs("id")));
         testCall(db, "MATCH (o:Person {ID:$oldID}), (n:Person {ID:$newID}) WITH head(collect([o,n])) as nodes CALL apoc.refactor.mergeNodes(nodes) yield node return node",
                       map("oldID", 1L, "newID",2L),
                 (r) -> {
                     Node node = (Node) r.get("node");
-                    assertEquals(id, node.getId());
-                    assertEquals(true, node.hasLabel(Label.label("Person")));
+                    assertEquals(id, node.getElementId());
+                    assertTrue(node.hasLabel(label("Person")));
                     assertEquals(2L, node.getProperty("ID"));
                 });
     }
@@ -389,35 +376,27 @@ public class GraphRefactoringTest {
     public void testMergeNodesEagerIndex() {
         db.executeTransactionally("CREATE INDEX FOR (n:Person) ON (n.ID)");
         db.executeTransactionally("CALL db.awaitIndexes()");
-        long id = db.executeTransactionally("CREATE (p1:Person {ID:1}), (p2:Person {ID:2}) RETURN id(p1) as id ", emptyMap(), result -> Iterators.single(result.columnAs("id")));
+        String id = db.executeTransactionally("CREATE (p1:Person {ID:1}), (p2:Person {ID:2}) RETURN elementId(p1) as id ", emptyMap(), result -> Iterators.single(result.columnAs("id")));
         testCall(db, "MATCH (o:Person {ID:$oldID}), (n:Person {ID:$newID}) USING INDEX o:Person(ID) USING INDEX n:Person(ID) CALL apoc.refactor.mergeNodes([o,n]) yield node return node",
                       map("oldID", 1L, "newID",2L),
                 (r) -> {
                     Node node = (Node) r.get("node");
-                    assertEquals(id, node.getId());
-                    assertEquals(true, node.hasLabel(Label.label("Person")));
+                    assertEquals(id, node.getElementId());
+                    assertTrue(node.hasLabel(label("Person")));
                     assertEquals(2L, node.getProperty("ID"));
                 });
     }
     @Test
     public void testMergeNodesIndexConflict() {
-        /*
-        CREATE CONSTRAINT FOR (a:A) REQUIRE a.prop1 IS UNIQUE;
-CREATE CONSTRAINT FOR (a:B) REQUIRE a.prop2 IS UNIQUE;
-CREATE (a:A) SET a.prop1 = 1;
-CREATE (b:B) SET b.prop2 = 99;
-
-MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b]) YIELD node RETURN node;
-         */
         db.executeTransactionally("CREATE CONSTRAINT FOR (a:A) REQUIRE a.prop1 IS UNIQUE;");
         db.executeTransactionally("CREATE CONSTRAINT FOR (b:B) REQUIRE b.prop2 IS UNIQUE;");
         db.executeTransactionally("CALL db.awaitIndexes()");
-        long id = db.executeTransactionally("CREATE (a:A) SET a.prop1 = 1 CREATE (b:B) SET b.prop2 = 99 RETURN id(a) as id ", emptyMap(), result -> Iterators.single(result.columnAs("id")));
+        String id = db.executeTransactionally("CREATE (a:A) SET a.prop1 = 1 CREATE (b:B) SET b.prop2 = 99 RETURN elementId(a) as id ", emptyMap(), result -> Iterators.single(result.columnAs("id")));
         testCall(db, "MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b]) YIELD node RETURN node",
                       map("oldID", 1L, "newID",2L),
                 (r) -> {
                     Node node = (Node) r.get("node");
-                    assertEquals(id, node.getId());
+                    assertEquals(id, node.getElementId());
                     assertTrue(node.hasLabel(Label.label("A")));
                     assertTrue(node.hasLabel(Label.label("B")));
                     assertEquals(1L, node.getProperty("prop1"));
@@ -438,11 +417,11 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
         testCall(db, "MATCH (b1:BLabel {name:'b1'}), (b2:BLabel {name:'b2'}), (b3:BLabel {name:'b3'}), (b4:BLabel {name:'b4'}) " +
                 "     WITH head(collect([b1,b2,b3,b4])) as nodes CALL apoc.refactor.mergeNodes(nodes) yield node return node",
                 row -> {
-                    assertTrue(row.get("node") != null);
+                    assertNotNull(row.get("node"));
                     assertTrue(row.get("node") instanceof Node);
                     Node resultingNode = (Node)(row.get("node"));
-                    assertTrue(resultingNode.getDegree(Direction.OUTGOING) == 0);
-                    assertTrue(resultingNode.getDegree(Direction.INCOMING) == 4);
+                    assertEquals(0, resultingNode.getDegree(Direction.OUTGOING));
+                    assertEquals(4, resultingNode.getDegree(Direction.INCOMING));
                 }
         );
     }
@@ -461,14 +440,15 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                 row -> {
                     Node node = (Node) row.get("node");
                     assertNotNull(node);
-                    assertTrue(node.getDegree(Direction.OUTGOING) == 3);
-                    assertTrue(node.getDegree(Direction.INCOMING) == 0);
+                    assertEquals(3, node.getDegree(Direction.OUTGOING));
+                    assertEquals(0, node.getDegree(Direction.INCOMING));
                 }
         );
 
-        testResult(db, "MATCH (a:ALabel) return count(*) as count", result -> {
-            assertEquals( "other ALabel nodes have been deleted", 1, (long)Iterators.single(result.columnAs("count")));
-        });
+        testResult(
+                db, "MATCH (a:ALabel) return count(*) as count",
+                result -> assertEquals( "other ALabel nodes have been deleted", 1, (long)Iterators.single(result.columnAs("count")))
+        );
     }
 
     @Test
@@ -480,8 +460,8 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                 row -> {
                     Node node = (Node) row.get("node");
                     assertNotNull(node);
-                    assertTrue(node.getDegree(Direction.OUTGOING) == 1);
-                    assertTrue(node.getDegree(Direction.INCOMING) == 0);
+                    assertEquals(1, node.getDegree(Direction.OUTGOING));
+                    assertEquals(0, node.getDegree(Direction.INCOMING));
                 }
         );
     }
@@ -499,8 +479,8 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                 row -> {
                     Node node = (Node) row.get("node");
                     assertNotNull(node);
-                    assertTrue(node.getDegree(Direction.OUTGOING) == 2);
-                    assertTrue(node.getDegree(Direction.INCOMING) == 0);
+                    assertEquals(2, node.getDegree(Direction.OUTGOING));
+                    assertEquals(0, node.getDegree(Direction.INCOMING));
                 }
         );
     }
@@ -512,7 +492,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                 (r) -> {
                     assertEquals(id, r.get("input"));
                     Node node = (Node) r.get("output");
-                    assertEquals(true, node.hasLabel(Label.label("FooBar")));
+                    assertTrue(node.hasLabel(label("FooBar")));
                     assertEquals(1L, node.getProperty("a"));
                     assertNotNull(node.getSingleRelationship(RelationshipType.withName("FOO"), Direction.OUTGOING));
                     assertNotNull(node.getSingleRelationship(RelationshipType.withName("BAR"), Direction.INCOMING));
@@ -525,8 +505,8 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                 (r) -> {
                     assertEquals(id, r.get("input"));
                     Relationship rel = (Relationship) r.get("output");
-                    assertEquals(true, rel.getStartNode().hasLabel(Label.label("Bar")));
-                    assertEquals(true, rel.getEndNode().hasLabel(Label.label("Foo")));
+                    assertTrue(rel.getStartNode().hasLabel(label("Bar")));
+                    assertTrue(rel.getEndNode().hasLabel(label("Foo")));
                     assertEquals(1L, rel.getProperty("a"));
                 });
     }
@@ -554,7 +534,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                 (r) -> {
                     assertEquals(id, r.get("input"));
                     Relationship rel = (Relationship) r.get("output");
-                    assertEquals(true, rel.isType(RelationshipType.withName("FOOBAR")));
+                    assertTrue(rel.isType(RelationshipType.withName("FOOBAR")));
                     assertEquals(1L, rel.getProperty("a"));
                     assertEquals(2L, rel.getProperty("b"));
                     assertEquals(3L, rel.getProperty("c"));
@@ -589,7 +569,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                         "CREATE ({prop: 'C', k: 'c', id: 6})");
 
 
-        final boolean outgoing = direction == Direction.OUTGOING ? true : false;
+        final boolean outgoing = direction == Direction.OUTGOING;
         final String label = "Letter";
         final String targetKey = "name";
         db.executeTransactionally("CREATE CONSTRAINT constraint FOR (n:`" + label + "`) REQUIRE n.`" + targetKey + "` IS UNIQUE");
@@ -692,15 +672,15 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     @Test
     public void testMergeNodesWithConstraints() {
         db.executeTransactionally("CREATE CONSTRAINT FOR (p:Person) REQUIRE p.name IS UNIQUE");
-        long id = db.executeTransactionally("CREATE (p1:Person {name:'Foo'}), (p2:Person {surname:'Bar'}) RETURN id(p1) as id",
+        String id = db.executeTransactionally("CREATE (p1:Person {name:'Foo'}), (p2:Person {surname:'Bar'}) RETURN elementId(p1) as id",
                 emptyMap(),
                 result -> Iterators.single(result.columnAs("id"))
         );
         testCall(db, "MATCH (o:Person {name:'Foo'}), (n:Person {surname:'Bar'}) CALL apoc.refactor.mergeNodes([o,n]) yield node return node",
                 (r) -> {
                     Node node = (Node) r.get("node");
-                    assertEquals(id, node.getId());
-                    assertEquals(true, node.hasLabel(Label.label("Person")));
+                    assertEquals(id, node.getElementId());
+                    assertTrue(node.hasLabel(label("Person")));
                     assertEquals("Foo", node.getProperty("name"));
                     assertEquals("Bar", node.getProperty("surname"));
                 });
@@ -708,23 +688,24 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
 
     @Test
     public void testMergeNodesWithIngoingRelationships() {
-        long lisaId = db.executeTransactionally("CREATE \n" +
-                "(alice:Person {name:'Alice'}),\n" +
-                "(bob:Person {name:'Bob'}),\n" +
-                "(john:Person {name:'John'}),\n" +
-                "(lisa:Person {name:'Lisa'}),\n" +
-                "(alice)-[:knows]->(bob),\n" +
-                "(lisa)-[:knows]->(alice),\n" +
-                "(bob)-[:knows]->(john) return id(lisa) as lisaId", emptyMap(),
+        String lisaId = db.executeTransactionally("""
+                        CREATE
+                        (alice:Person {name:'Alice'}),
+                        (bob:Person {name:'Bob'}),
+                        (john:Person {name:'John'}),
+                        (lisa:Person {name:'Lisa'}),
+                        (alice)-[:knows]->(bob),
+                        (lisa)-[:knows]->(alice),
+                        (bob)-[:knows]->(john) return elementId(lisa) as lisaId""", emptyMap(),
                 result -> Iterators.single(result.columnAs("lisaId")));
 
-        //Merge (Bob) into (Lisa).
+        // Merge (Bob) into (Lisa).
         // The updated node should have one ingoing edge from (Alice), and two outgoing edges to (John) and (Alice).
         testCall(db,
                 "MATCH (bob:Person {name:'Bob'}), (lisa:Person {name:'Lisa'}) CALL apoc.refactor.mergeNodes([lisa, bob]) yield node return node, bob",
                 (r)-> {
                     Node node = (Node) r.get("node");
-                    assertEquals(lisaId, node.getId());
+                    assertEquals(lisaId, node.getElementId());
                     assertEquals("Bob", node.getProperty("name"));
                     assertEquals(1, node.getDegree(Direction.INCOMING));
                     assertEquals(2, node.getDegree(Direction.OUTGOING));
@@ -735,11 +716,12 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
 
     @Test
     public void testMergeNodesWithSelfRelationships() {
-        Map<String, Object> result = db.executeTransactionally("CREATE \n" +
-                "(alice:Person {name:'Alice'}),\n" +
-                "(bob:Person {name:'Bob'}),\n" +
-                "(bob)-[:likes]->(bob) RETURN id(alice) AS aliceId, id(bob) AS bobId", emptyMap(),
-                innerResult -> Iterators.single(innerResult));
+        Map<String, Object> result = db.executeTransactionally("""
+                        CREATE
+                        (alice:Person {name:'Alice'}),
+                        (bob:Person {name:'Bob'}),
+                        (bob)-[:likes]->(bob) RETURN elementId(alice) AS aliceId, id(bob) AS bobId""", emptyMap(),
+                Iterators::single);
 
         // Merge (bob) into (alice).
         // The updated node should have one self relationship.
@@ -748,31 +730,41 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                 "MATCH (alice:Person {name:'Alice'}), (bob:Person {name:'Bob'}) WITH * LIMIT 1 CALL apoc.refactor.mergeNodes([alice, bob]) yield node return node",
                 (r)-> {
                     Node node = (Node) r.get("node");
-                    assertEquals(result.get("aliceId"), node.getId());
+                    assertEquals(result.get("aliceId"), node.getElementId());
                     assertEquals("Bob", node.getProperty("name"));
                     assertEquals(1, node.getDegree(Direction.INCOMING));
                     assertEquals(1, node.getDegree(Direction.OUTGOING));
-                    assertTrue(node.getSingleRelationship(RelationshipType.withName("likes"), Direction.OUTGOING).getEndNode().equals(node));
+                    assertEquals(node.getSingleRelationship(RelationshipType.withName("likes"), Direction.OUTGOING).getEndNode(), node);
                 });
     }
 
     @Test
     public void testMergeRelsOverwriteEagerAggregation() {
-        long id = db.executeTransactionally("Create (d:Person {name:'Daniele'})\n" + "Create (p:Country {name:'USA'})\n" + "Create (d)-[:TRAVELS_TO {year:1995, reason:\"work\"}]->(p)\n"
-                + "Create (d)-[:GOES_TO {year:2010}]->(p)\n" + "Create (d)-[:FLIGHTS_TO {company:\"Air America\"}]->(p) RETURN id(p) as id ",
+        String id = db.executeTransactionally("""
+                        Create (d:Person {name:'Daniele'})
+                        Create (p:Country {name:'USA'})
+                        Create (d)-[:TRAVELS_TO {year:1995, reason:"work"}]->(p)
+                        Create (d)-[:GOES_TO {year:2010}]->(p)
+                        Create (d)-[:FLIGHTS_TO {company:"Air America"}]->(p) RETURN elementId(p) as id""",
                 emptyMap(),
                 result -> Iterators.single(result.columnAs("id")));
-        testCall(db, "MATCH (d:Person {name:'Daniele'})\n" + "MATCH (p:Country {name:'USA'})\n" + "MATCH (d)-[r:TRAVELS_TO]->(p)\n" + "MATCH (d)-[h:GOES_TO]->(p)\n"
-                        + "MATCH (d)-[l:FLIGHTS_TO]->(p)\n" + "call apoc.refactor.mergeRelationships([r,h,l],{properties:\"overwrite\"}) yield rel\n MATCH (d)-[u]->(p) " + "return p,d,u,u.to as to, count(u) as totRel",
+        testCall(db, """
+                        MATCH (d:Person {name:'Daniele'})
+                        MATCH (p:Country {name:'USA'})
+                        MATCH (d)-[r:TRAVELS_TO]->(p)
+                        MATCH (d)-[h:GOES_TO]->(p)
+                        MATCH (d)-[l:FLIGHTS_TO]->(p)
+                        CALL apoc.refactor.mergeRelationships([r,h,l],{properties:"overwrite"}) YIELD rel
+                         MATCH (d)-[u]->(p) return p, d, u, u.to as to, count(u) as totRel""",
                 (r) -> {
                     Node node = (Node) r.get("p");
                     Long totRel = (Long) r.get("totRel");
                     Relationship rel = (Relationship) r.get("u");
-                    assertEquals(id, node.getId());
-                    assertEquals(true, node.hasLabel(Label.label("Country")));
+                    assertEquals(id, node.getElementId());
+                    assertTrue(node.hasLabel(label("Country")));
                     assertEquals("USA", node.getProperty("name"));
                     assertEquals(Long.valueOf(1),totRel);
-                    assertEquals(true, rel.isType(RelationshipType.withName("TRAVELS_TO")));
+                    assertTrue(rel.isType(RelationshipType.withName("TRAVELS_TO")));
                     assertEquals("work", rel.getProperty("reason"));
                     assertEquals(2010L, rel.getProperty("year"));
                 });
@@ -780,21 +772,31 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
 
     @Test
     public void testMergeRelsCombineEagerAggregation() {
-        long id = db.executeTransactionally("Create (d:Person {name:'Daniele'})\n" + "Create (p:Country {name:'USA'})\n" + "Create (d)-[:TRAVELS_TO {year:1995, reason:\"work\"}]->(p)\n"
-                + "Create (d)-[:GOES_TO {year:2010, reason:\"fun\"}]->(p)\n" + "Create (d)-[:FLIGHTS_TO {company:\"Air America\"}]->(p) RETURN id(p) as id ",
+        String id = db.executeTransactionally("""
+                        Create (d:Person {name:'Daniele'})
+                        Create (p:Country {name:'USA'})
+                        Create (d)-[:TRAVELS_TO {year:1995, reason:"work"}]->(p)
+                        Create (d)-[:GOES_TO {year:2010, reason:"fun"}]->(p)
+                        Create (d)-[:FLIGHTS_TO {company:"Air America"}]->(p) RETURN elementId(p) as id\s""",
                 emptyMap(),
                 result -> Iterators.single(result.columnAs("id")));
-        testCall(db, "MATCH (d:Person {name:'Daniele'})\n" + "MATCH (p:Country {name:'USA'})\n" + "MATCH (d)-[r:TRAVELS_TO]->(p)\n" + "MATCH (d)-[h:GOES_TO]->(p)\n"
-                        + "MATCH (d)-[l:FLIGHTS_TO]->(p)\n" + "call apoc.refactor.mergeRelationships([r,h,l],{properties:\"discard\"}) yield rel\n MATCH (d)-[u]->(p) " + "return p,d,u,u.to as to, count(u) as totRel",
+        testCall(db, """
+                        MATCH (d:Person {name:'Daniele'})
+                        MATCH (p:Country {name:'USA'})
+                        MATCH (d)-[r:TRAVELS_TO]->(p)
+                        MATCH (d)-[h:GOES_TO]->(p)
+                        MATCH (d)-[l:FLIGHTS_TO]->(p)
+                        call apoc.refactor.mergeRelationships([r,h,l],{properties:"discard"}) yield rel
+                         MATCH (d)-[u]->(p) return p,d,u,u.to as to, count(u) as totRel""",
                 (r) -> {
                     Node node = (Node) r.get("p");
                     Long totRel = (Long) r.get("totRel");
                     Relationship rel = (Relationship) r.get("u");
-                    assertEquals(id, node.getId());
-                    assertEquals(true, node.hasLabel(Label.label("Country")));
+                    assertEquals(id, node.getElementId());
+                    assertTrue(node.hasLabel(label("Country")));
                     assertEquals("USA", node.getProperty("name"));
                     assertEquals(Long.valueOf(1),totRel);
-                    assertEquals(true, rel.isType(RelationshipType.withName("TRAVELS_TO")));
+                    assertTrue(rel.isType(RelationshipType.withName("TRAVELS_TO")));
                     assertEquals("work", rel.getProperty("reason"));
                     assertEquals(1995L, rel.getProperty("year"));
                 });
@@ -802,21 +804,31 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
 
     @Test
     public void testMergeRelsEagerAggregationCombineSingleValuesProperty() {
-        long id = db.executeTransactionally("Create (d:Person {name:'Daniele'})\n" + "Create (p:Country {name:'USA'})\n" + "Create (d)-[:TRAVELS_TO {year:1995, reason:\"work\"}]->(p)\n"
-                + "Create (d)-[:GOES_TO {year:2010, reason:\"fun\"}]->(p)\n" + "Create (d)-[:FLIGHTS_TO {company:\"Air America\"}]->(p) RETURN id(p) as id ",
+        String id = db.executeTransactionally("""
+                        Create (d:Person {name:'Daniele'})
+                        Create (p:Country {name:'USA'})
+                        Create (d)-[:TRAVELS_TO {year:1995, reason:"work"}]->(p)
+                        Create (d)-[:GOES_TO {year:2010, reason:"fun"}]->(p)
+                        Create (d)-[:FLIGHTS_TO {company:"Air America"}]->(p) RETURN elementId(p) as id""",
                 emptyMap(),
                 result -> Iterators.single(result.columnAs("id")));
-        testCall(db, "MATCH (d:Person {name:'Daniele'})\n" + "MATCH (p:Country {name:'USA'})\n" + "MATCH (d)-[r:TRAVELS_TO]->(p)\n" + "MATCH (d)-[h:GOES_TO]->(p)\n"
-                        + "MATCH (d)-[l:FLIGHTS_TO]->(p)\n" + "call apoc.refactor.mergeRelationships([r,h,l],{properties:\"combine\"}) yield rel\n MATCH (d)-[u]->(p) " + "return p,d,u,u.to as to, count(u) as totRel",
+        testCall(db, """
+                        MATCH (d:Person {name:'Daniele'})
+                        MATCH (p:Country {name:'USA'})
+                        MATCH (d)-[r:TRAVELS_TO]->(p)
+                        MATCH (d)-[h:GOES_TO]->(p)
+                        MATCH (d)-[l:FLIGHTS_TO]->(p)
+                        call apoc.refactor.mergeRelationships([r,h,l],{properties:"combine"}) yield rel
+                         MATCH (d)-[u]->(p) return p,d,u,u.to as to, count(u) as totRel""",
                 (r) -> {
                     Node node = (Node) r.get("p");
                     Long totRel = (Long) r.get("totRel");
                     Relationship rel = (Relationship) r.get("u");
-                    assertEquals(id, node.getId());
-                    assertEquals(true, node.hasLabel(Label.label("Country")));
+                    assertEquals(id, node.getElementId());
+                    assertTrue(node.hasLabel(label("Country")));
                     assertEquals("USA", node.getProperty("name"));
                     assertEquals(Long.valueOf(1),totRel);
-                    assertEquals(true, rel.isType(RelationshipType.withName("TRAVELS_TO")));
+                    assertTrue(rel.isType(RelationshipType.withName("TRAVELS_TO")));
                     assertEquals(Arrays.asList("work", "fun").toArray(), new ArrayBackedList(rel.getProperty("reason")).toArray());
                     assertEquals(Arrays.asList(1995L, 2010L).toArray(), new ArrayBackedList(rel.getProperty("year")).toArray());
                 });
@@ -824,21 +836,31 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
 
     @Test
     public void testMergeRelsEagerAggregationCombineArrayDifferentValuesTypeProperties() {
-        long id = db.executeTransactionally("Create (d:Person {name:'Daniele'})\n" + "Create (p:Country {name:'USA'})\n" + "Create (d)-[:TRAVELS_TO {year:1995, reason:\"work\"}]->(p)\n"
-                + "Create (d)-[:GOES_TO {year:[\"2010\",\"2015\"], reason:\"fun\"}]->(p)\n" + "Create (d)-[:FLIGHTS_TO {company:\"Air America\"}]->(p) RETURN id(p) as id ",
+        String id = db.executeTransactionally("""
+                        Create (d:Person {name:'Daniele'})
+                        Create (p:Country {name:'USA'})
+                        Create (d)-[:TRAVELS_TO {year:1995, reason:"work"}]->(p)
+                        Create (d)-[:GOES_TO {year:["2010","2015"], reason:"fun"}]->(p)
+                        Create (d)-[:FLIGHTS_TO {company:"Air America"}]->(p) RETURN elementId(p) as id""",
                 emptyMap(),
                 result -> Iterators.single(result.columnAs("id")));
-        testCall(db, "MATCH (d:Person {name:'Daniele'})\n" + "MATCH (p:Country {name:'USA'})\n" + "MATCH (d)-[r:TRAVELS_TO]->(p)\n" + "MATCH (d)-[h:GOES_TO]->(p)\n"
-                        + "MATCH (d)-[l:FLIGHTS_TO]->(p)\n" + "call apoc.refactor.mergeRelationships([r,h,l],{properties:\"combine\"}) yield rel\n MATCH (d)-[u]->(p) " + "return p,d,u,u.to as to, count(u) as totRel",
+        testCall(db, """
+                        MATCH (d:Person {name:'Daniele'})
+                        MATCH (p:Country {name:'USA'})
+                        MATCH (d)-[r:TRAVELS_TO]->(p)
+                        MATCH (d)-[h:GOES_TO]->(p)
+                        MATCH (d)-[l:FLIGHTS_TO]->(p)
+                        CALL apoc.refactor.mergeRelationships([r,h,l],{properties:"combine"}) YIELD rel
+                         MATCH (d)-[u]->(p) RETURN p,d,u,u.to as to, count(u) AS totRel""",
                 (r) -> {
                     Node node = (Node) r.get("p");
                     Long totRel = (Long) r.get("totRel");
                     Relationship rel = (Relationship) r.get("u");
-                    assertEquals(id, node.getId());
-                    assertEquals(true, node.hasLabel(Label.label("Country")));
+                    assertEquals(id, node.getElementId());
+                    assertTrue(node.hasLabel(label("Country")));
                     assertEquals("USA", node.getProperty("name"));
                     assertEquals(Long.valueOf(1),totRel);
-                    assertEquals(true, rel.isType(RelationshipType.withName("TRAVELS_TO")));
+                    assertTrue(rel.isType(RelationshipType.withName("TRAVELS_TO")));
                     assertEquals(Arrays.asList("work", "fun").toArray(), new ArrayBackedList(rel.getProperty("reason")).toArray());
                     assertEquals(Arrays.asList("1995", "2010", "2015").toArray(), new ArrayBackedList(rel.getProperty("year")).toArray());
                 });
@@ -935,22 +957,32 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
 
     @Test
-    public void testMergeRelsOverridePropertiesEagerAggregation() {
-        long id = db.executeTransactionally("Create (d:Person {name:'Daniele'})\n" + "Create (p:Country {name:'USA'})\n" + "Create (d)-[:TRAVELS_TO {year:1995, reason:\"work\"}]->(p)\n"
-                + "Create (d)-[:GOES_TO {year:2010}]->(p)\n" + "Create (d)-[:FLIGHTS_TO {company:\"Air America\"}]->(p) RETURN id(p) as id ",
+    public void testMergeRelsOverridePropertiesEagerAggregation() throws Exception {
+        String id = db.executeTransactionally("""
+                        Create (d:Person {name:'Daniele'})
+                        Create (p:Country {name:'USA'})
+                        Create (d)-[:TRAVELS_TO {year:1995, reason:"work"}]->(p)
+                        Create (d)-[:GOES_TO {year:2010}]->(p)
+                        Create (d)-[:FLIGHTS_TO {company:"Air America"}]->(p) RETURN elementId(p) as id""",
                 emptyMap(),
                 result -> Iterators.single(result.columnAs("id")));
-        testCall(db, "MATCH (d:Person {name:'Daniele'})\n" + "MATCH (p:Country {name:'USA'})\n" + "MATCH (d)-[r:TRAVELS_TO]->(p)\n" + "MATCH (d)-[h:GOES_TO]->(p)\n"
-                        + "MATCH (d)-[l:FLIGHTS_TO]->(p)\n" + "call apoc.refactor.mergeRelationships([r,h,l],{properties:\"override\"}) yield rel\n MATCH (d)-[u]->(p) " + "return p,d,u,u.to as to, count(u) as totRel",
+        testCall(db, """
+                        MATCH (d:Person {name:'Daniele'})
+                        MATCH (p:Country {name:'USA'})
+                        MATCH (d)-[r:TRAVELS_TO]->(p)
+                        MATCH (d)-[h:GOES_TO]->(p)
+                        MATCH (d)-[l:FLIGHTS_TO]->(p)
+                        CALL apoc.refactor.mergeRelationships([r,h,l],{properties:"override"}) YIELD rel
+                         MATCH (d)-[u]->(p) RETURN p, d, u, u.to AS to, count(u) AS totRel""",
                 (r) -> {
                     Node node = (Node) r.get("p");
                     Long totRel = (Long) r.get("totRel");
                     Relationship rel = (Relationship) r.get("u");
-                    assertEquals(id, node.getId());
-                    assertEquals(true, node.hasLabel(Label.label("Country")));
+                    assertEquals(id, node.getElementId());
+                    assertTrue(node.hasLabel(label("Country")));
                     assertEquals("USA", node.getProperty("name"));
                     assertEquals(Long.valueOf(1),totRel);
-                    assertEquals(true, rel.isType(RelationshipType.withName("TRAVELS_TO")));
+                    assertTrue(rel.isType(RelationshipType.withName("TRAVELS_TO")));
                     assertEquals("work", rel.getProperty("reason"));
                     assertEquals(2010L, rel.getProperty("year"));
                 });
@@ -958,30 +990,30 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
 
     @Test
     public void testMergeNodesOverridePropertiesEagerAggregation() {
-        long id = db.executeTransactionally("CREATE (p1:Person {ID:1}), (p2:Person {ID:2}) RETURN id(p1) as id ",
+        String id = db.executeTransactionally("CREATE (p1:Person {ID:1}), (p2:Person {ID:2}) RETURN elementId(p1) as id ",
                 emptyMap(),
                 result -> Iterators.single(result.columnAs("id")));
         testCall(db, "MATCH (o:Person {ID:$oldID}), (n:Person {ID:$newID}) WITH head(collect([o,n])) as nodes CALL apoc.refactor.mergeNodes(nodes, {properties:\"override\"}) yield node return node",
                 map("oldID", 1L, "newID",2L),
                 (r) -> {
                     Node node = (Node) r.get("node");
-                    assertEquals(id, node.getId());
-                    assertEquals(true, node.hasLabel(Label.label("Person")));
+                    assertEquals(id, node.getElementId());
+                    assertTrue(node.hasLabel(label("Person")));
                     assertEquals(2L, node.getProperty("ID"));
                 });
     }
 
     @Test
     public void testMergeNodesOnArrayValues() {
-        long id = db.executeTransactionally("CREATE (p1:Person {ID:1, prop: ['foo']}), (p2:Person {ID:2, prop: ['foo']}) RETURN id(p1) as id ",
+        String id = db.executeTransactionally("CREATE (p1:Person {ID:1, prop: ['foo']}), (p2:Person {ID:2, prop: ['foo']}) RETURN elementId(p1) as id ",
                 emptyMap(),
                 result -> Iterators.single(result.columnAs("id")));
         testCall(db, "MATCH (o:Person {ID:$oldID}), (n:Person {ID:$newID}) WITH head(collect([o,n])) as nodes CALL apoc.refactor.mergeNodes(nodes, {properties:'combine'}) yield node return node",
                 map("oldID", 1L, "newID",2L),
                 (r) -> {
                     Node node = (Node) r.get("node");
-                    assertEquals(id, node.getId());
-                    assertEquals(true, node.hasLabel(Label.label("Person")));
+                    assertEquals(id, node.getElementId());
+                    assertTrue(node.hasLabel(label("Person")));
                     assertArrayEquals(new long[] {1L, 2L}, (long[]) node.getProperty("ID"));
                     assertEquals("foo", node.getProperty("prop"));
                 });
@@ -989,15 +1021,15 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
 
     @Test
     public void testMergeNodesOnArrayValuesPreventTypeChange() {
-        long id = db.executeTransactionally("CREATE (p1:Person {ID:1, prop: ['foo']}), (p2:Person {ID:2, prop: ['foo']}) RETURN id(p1) as id ",
+        String id = db.executeTransactionally("CREATE (p1:Person {ID:1, prop: ['foo']}), (p2:Person {ID:2, prop: ['foo']}) RETURN elementId(p1) as id ",
                 emptyMap(),
                 result -> Iterators.single(result.columnAs("id")));
         testCall(db, "MATCH (o:Person {ID:$oldID}), (n:Person {ID:$newID}) WITH head(collect([o,n])) as nodes CALL apoc.refactor.mergeNodes(nodes, {properties:'combine', singleElementAsArray: true}) yield node return node",
                 map("oldID", 1L, "newID",2L),
                 (r) -> {
                     Node node = (Node) r.get("node");
-                    assertEquals(id, node.getId());
-                    assertEquals(true, node.hasLabel(Label.label("Person")));
+                    assertEquals(id, node.getElementId());
+                    assertTrue(node.hasLabel(label("Person")));
                     assertArrayEquals(new long[] {1L, 2L}, (long[]) node.getProperty("ID"));
                     assertArrayEquals(new String[] {"foo"}, (String[]) node.getProperty("prop"));
                 });
@@ -1008,11 +1040,12 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
         // given
         final String label = "Country";
         final String targetKey = "name";
-        db.executeTransactionally("with [\"IT\", \"DE\"] as countries\n" +
-                "unwind countries as country\n" +
-                "foreach (no in RANGE(1, 4) |\n" +
-                "  create (n:Company {name: country + no, country: country})\n" +
-                ")");
+        db.executeTransactionally("""
+                WITH ["IT", "DE"] AS countries
+                UNWIND countries AS country
+                foreach (no in RANGE(1, 4) |
+                  CREATE (n:Company {name: country + no, country: country})
+                )""");
 
         // when
         try {
@@ -1033,11 +1066,12 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
         final String label = "Country";
         final String targetKey = "name";
         db.executeTransactionally("CREATE CONSTRAINT constraint FOR (n:`" + label + "`) REQUIRE n.`" + targetKey + "` IS UNIQUE");
-        db.executeTransactionally("with [\"IT\", \"DE\"] as countries\n" +
-                "unwind countries as country\n" +
-                "foreach (no in RANGE(1, 4) |\n" +
-                "  create (n:Company {name: country + no, country: country})\n" +
-                ")");
+        db.executeTransactionally("""
+                WITH ["IT", "DE"] AS countries
+                UNWIND countries AS country
+                foreach (no in RANGE(1, 4) |
+                  CREATE (n:Company {name: country + no, country: country})
+                )""");
 
         // when
         db.executeTransactionally("CALL apoc.refactor.categorize('country', 'OPERATES_IN', true, $label, $targetKey, [], 1)",
@@ -1059,11 +1093,12 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
         final String label = "Country";
         final String targetKey = "name";
         db.executeTransactionally("CREATE CONSTRAINT constraint FOR (n:`" + label + "`) REQUIRE n.`" + targetKey + "` IS UNIQUE");
-        db.executeTransactionally("with [\"IT\", \"DE\"] as countries\n" +
-                "unwind countries as country\n" +
-                "foreach (no in RANGE(1, 4) |\n" +
-                "  create (n:Company {name: country + no, country: country})\n" +
-                ")");
+        db.executeTransactionally("""
+                WITH ["IT", "DE"] as countries
+                UNWIND countries as country
+                foreach (no in RANGE(1, 4) |
+                  CREATE (n:Company {name: country + no, country: country})
+                )""");
 
         // when
         db.executeTransactionally("CALL apoc.refactor.categorize('country', 'FOO`]->() WITH n SET n = {} RETURN n//', true, $label, $targetKey, [], 1)",
@@ -1187,8 +1222,10 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                     List<Relationship> relationships = IteratorUtils.toList(node.getRelationships().iterator());
 
                     assertEquals(4, relationships.size());
-                    relationships.sort(Comparator.comparingLong(Relationship::getStartNodeId)
-                            .thenComparingLong(Relationship::getEndNodeId));
+                    relationships.sort(
+                            Comparator.comparing(rel -> ((Relationship) rel).getStartNode().getElementId())
+                                    .thenComparing(rel -> ((Relationship) rel).getEndNode().getElementId())
+                    );
 
                     // two A-A rels: the existing one and the new one after merge
                     Relationship firstSelfRel = relationships.get(0);
@@ -1228,8 +1265,10 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                     List<Relationship> relationships = IteratorUtils.toList(node.getRelationships().iterator());
 
                     assertEquals(3, relationships.size());
-                    relationships.sort(Comparator.comparingLong(Relationship::getStartNodeId)
-                            .thenComparingLong(Relationship::getEndNodeId));
+                    relationships.sort(
+                            Comparator.comparing(rel -> ((Relationship) rel).getStartNode().getElementId())
+                                    .thenComparing(rel -> ((Relationship) rel).getEndNode().getElementId())
+                    );
 
                     Relationship firstRel = relationships.get(0);
                     assertEquals("A", firstRel.getStartNode().getLabels().iterator().next().name());


### PR DESCRIPTION
Replace most instances of getId, getNodeByID or getRelById etc as they are deprecated for removal.


This isn't all cases, there are about 20 left still, but this was all I had time for on cleanup (plus the last ones are hard :P )