### PR TITLE
[i19tvtq1] Add Trello Traceability GHA to the CI

### DIFF
--- a/.github/workflows/traceability.yml
+++ b/.github/workflows/traceability.yml
@@ -1,0 +1,23 @@
+name: traceability
+
+on:
+  pull_request:
+    branches:
+      - dev
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  validate-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: AzuObs/github-action-traceability@v1
+        with:
+          global_verification_strategy: commits_and_pr_title
+          short_link_verification_strategy: trello_or_noid
+          trello_api_key: ${{ secrets.TRELLO_API_KEY }}
+          trello_api_token: ${{ secrets.TRELLO_API_TOKEN }}
+          github_api_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/traceability.yml
+++ b/.github/workflows/traceability.yml
@@ -14,7 +14,7 @@ jobs:
   validate-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: AzuObs/github-action-traceability@v1
+      - uses: neo4j/github-action-traceability@v1
         with:
           global_verification_strategy: commits_and_pr_title
           short_link_verification_strategy: trello_or_noid

--- a/readme.adoc
+++ b/readme.adoc
@@ -8,7 +8,6 @@
 https://community.neo4j.com[image:https://img.shields.io/discourse/users?logo=discourse&server=https%3A%2F%2Fcommunity.neo4j.com[Discourse users]]
 https://discord.gg/neo4j[image:https://img.shields.io/discord/787399249741479977?logo=discord&logoColor=white[Discord]]
 
-
 = Awesome Procedures for Neo4j {branch}.x
 
 // tag::readme[]


### PR DESCRIPTION
Adds https://github.com/neo4j/github-action-traceability to the APOC CI. You may wish to review the code in my custom Github Action since nobody has reviewed that code.