### PR TITLE
[vFQk1rX0] vuln-fix: Fix path traversal vulnerability (CVE-2022-23532)

### DIFF
--- a/common/src/main/java/apoc/util/FileUtils.java
+++ b/common/src/main/java/apoc/util/FileUtils.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -179,7 +178,7 @@ public class FileUtils {
         Path urlPath;
         URL toURL = null;
         try {
-            final URI uri = URI.create(url.trim());
+            final URI uri = URI.create(url.trim()).normalize();
             toURL = uri.toURL();
             urlPath = Paths.get(uri);
         } catch (Exception e) {
@@ -194,11 +193,8 @@ public class FileUtils {
 
     private static boolean pathStartsWithOther(Path resolvedPath, Path basePath) {
         try {
-            return resolvedPath.toRealPath().startsWith(basePath.toRealPath());
+            return resolvedPath.toFile().getCanonicalFile().toPath().startsWith(basePath.toRealPath());
         } catch (Exception e) {
-            if (e instanceof NoSuchFileException) { // If we're about to creating a file this exception has been thrown
-                return resolvedPath.normalize().startsWith(basePath);
-            }
             return false;
         }
     }

--- a/common/src/main/java/apoc/util/FileUtils.java
+++ b/common/src/main/java/apoc/util/FileUtils.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -191,10 +192,13 @@ public class FileUtils {
         return urlPath;
     }
 
-    private static boolean pathStartsWithOther(Path resolvedPath, Path basePath) {
+    private static boolean pathStartsWithOther(Path resolvedPath, Path basePath) throws IOException {
         try {
             return resolvedPath.toFile().getCanonicalFile().toPath().startsWith(basePath.toRealPath());
         } catch (Exception e) {
+            if (e instanceof NoSuchFileException) { // If we're about to create a file this exception has been thrown
+                return resolvedPath.toFile().getCanonicalFile().toPath().startsWith(basePath);
+            }
             return false;
         }
     }

--- a/core/src/main/java/apoc/export/csv/ExportCSV.java
+++ b/core/src/main/java/apoc/export/csv/ExportCSV.java
@@ -117,8 +117,8 @@ public class ExportCSV {
 
     private void dump(Object data, ExportConfig c, ProgressReporter reporter, ExportFileManager printWriter, CsvFormat exporter) {
         if (data instanceof SubGraph)
-            exporter.dump((SubGraph)data,printWriter,reporter,c);
+            exporter.dump((SubGraph) data, printWriter, reporter, c);
         if (data instanceof Result)
-            exporter.dump((Result)data,printWriter,reporter,c);
+            exporter.dump((Result) data, printWriter, reporter, c);
     }
 }

--- a/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
+++ b/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
@@ -7,7 +7,9 @@ import apoc.export.graphml.ExportGraphML;
 import apoc.export.json.ExportJson;
 import apoc.util.FileUtils;
 import apoc.util.TestUtil;
+import junit.framework.TestCase;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -15,6 +17,7 @@ import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
@@ -35,10 +38,14 @@ import static org.junit.Assert.fail;
 public class ExportCoreSecurityTest {
 
     private static final File directory = new File("target/import");
+    private static final File subDirectory = new File("target/import/tests");
     private static final List<String> APOC_EXPORT_PROCEDURE_NAME = Arrays.asList("csv", "json", "graphml", "cypher");
 
     static {
+        //noinspection ResultOfMethodCallIgnored
         directory.mkdirs();
+        //noinspection ResultOfMethodCallIgnored
+        subDirectory.mkdirs();
     }
 
     @ClassRule
@@ -48,7 +55,11 @@ public class ExportCoreSecurityTest {
     @BeforeClass
     public static void setUp() {
         TestUtil.registerProcedure(db, ExportCSV.class, ExportJson.class, ExportGraphML.class, ExportCypher.class);
-        ApocConfig.apocConfig().setProperty(ApocConfig.APOC_EXPORT_FILE_ENABLED, false);
+        setFileExport(false);
+    }
+
+    private static void setFileExport(boolean allowed) {
+        ApocConfig.apocConfig().setProperty(ApocConfig.APOC_EXPORT_FILE_ENABLED, allowed);
     }
 
     private static Collection<String[]> data(Map<String, List<String>> apocProcedureArguments) {
@@ -101,16 +112,12 @@ public class ExportCoreSecurityTest {
 
         @Test
         public void testIllegalFSAccessExport() {
-            final String message = apocProcedure + " should throw an exception";
-            try {
-                db.executeTransactionally("CALL " + apocProcedure, Map.of(),
-                        Result::resultAsString);
-                fail(message);
-            } catch (Exception e) {
-                assertError(e, ApocConfig.EXPORT_TO_FILE_ERROR, RuntimeException.class, apocProcedure);
-            }
-        }
+            QueryExecutionException e = Assert.assertThrows(QueryExecutionException.class,
+                    () -> TestUtil.testCall(db, "CALL " + apocProcedure, (r) -> {})
+            );
 
+            assertError(e, ApocConfig.EXPORT_TO_FILE_ERROR, RuntimeException.class, apocProcedure);
+        }
     }
 
     @RunWith(Parameterized.class)
@@ -149,45 +156,256 @@ public class ExportCoreSecurityTest {
         public void testIllegalExternalFSAccessExport() {
             final String message = apocProcedure + " should throw an exception";
             try {
-                ApocConfig.apocConfig().setProperty(ApocConfig.APOC_EXPORT_FILE_ENABLED, true);
+                setFileExport(true);
                 db.executeTransactionally("CALL " + apocProcedure, Map.of(),
                         Result::resultAsString);
                 fail(message);
             } catch (Exception e) {
                 assertError(e, FileUtils.ACCESS_OUTSIDE_DIR_ERROR, IOException.class, apocProcedure);
             } finally {
-                ApocConfig.apocConfig().setProperty(ApocConfig.APOC_EXPORT_FILE_ENABLED, false);
+                setFileExport(false);
             }
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class TestPathTraversalAccess {
+        private final String apocProcedure;
+
+        public TestPathTraversalAccess(String exportMethod, String exportMethodType, String exportMethodArguments) {
+            this.apocProcedure = "apoc.export." + exportMethod + "." + exportMethodType + "(" + exportMethodArguments + ")";
+        }
+
+        private static final String case1 = "'file:///%2e%2e%2f%2f%2e%2e%2f%2f%2e%2e%2f%2f%2e%2e%2f%2fapoc/test.txt'";
+        private static final String case2 = "'file:///%2e%2e%2f%2ftest.txt'";
+        private static final String case3 = "'../test.txt'";
+        private static final String case4 = "'tests/../../test.txt'";
+        private static final String case5 = "'tests/..//..//test.txt'";
+
+        private static final List<String> cases = Arrays.asList(case1, case2, case3, case4, case5);
+
+        private static final Map<String, List<String>> METHOD_ARGUMENTS = Map.of(
+                "query",  cases.stream().map(
+                        filePath -> "\"RETURN 1\", " + filePath + ", {}"
+                ).toList(),
+                "all", cases.stream().map(
+                        filePath -> filePath + ", {}"
+                ).toList(),
+                "data", cases.stream().map(
+                        filePath -> "[], [], " + filePath + ", {}"
+                ).toList(),
+                "graph", cases.stream().map(
+                        filePath -> "{nodes: [], relationships: []}, " + filePath + ", {}"
+                ).toList()
+        );
+
+        @Parameterized.Parameters
+        public static Collection<String[]> data() {
+            return ExportCoreSecurityTest.data(METHOD_ARGUMENTS);
+        }
+
+        @Test
+        public void testPathTraversal() {
+            setFileExport(true);
+
+            QueryExecutionException e = Assert.assertThrows(QueryExecutionException.class,
+                    () -> TestUtil.testCall(db, "CALL " + apocProcedure, (r) -> {})
+            );
+
+            assertError(e, FileUtils.ACCESS_OUTSIDE_DIR_ERROR, IOException.class, apocProcedure);
+            setFileExport(false);
+        }
+    }
+
+    /**
+     * All of these will resolve to a local path after normalization which will point to
+     * a non-existing directory in our import folder: /apoc. Causing them to error that is
+     * not found. They all attempt to exit the import folder back to the apoc folder:
+     * Directory Layout: .../apoc/core/target/import
+     */
+    @RunWith(Parameterized.class)
+    public static class TestPathTraversalIsNormalised {
+        private final String apocProcedure;
+
+        public TestPathTraversalIsNormalised(String exportMethod, String exportMethodType, String exportMethodArguments) {
+            this.apocProcedure = "apoc.export." + exportMethod + "." + exportMethodType + "(" + exportMethodArguments + ")";
+        }
+
+        private static final String case1 = "'file://%2e%2e%2f%2e%2e%2f%2e%2e%2f%2e%2e%2f/apoc/test.txt'";
+        private static final String case2 = "'file://../../../../apoc/test.txt'";
+        private static final String case3 = "'file:///..//..//..//..//apoc//core//..//test.txt'";
+        private static final String case4 = "'file:///..//..//..//..//apoc/test.txt'";
+        private static final String case5 = "'file://" + directory.getAbsolutePath() + "//..//..//..//..//apoc/test.txt'";
+        private static final String case6 = "'file:///%252e%252e%252f%252e%252e%252f%252e%252e%252f%252e%252e%252f/apoc/test.txt'";
+
+        private static final List<String> cases = Arrays.asList(case1, case2, case3, case4, case5, case6);
+
+        private static final Map<String, List<String>> METHOD_ARGUMENTS = Map.of(
+                "query", cases.stream().map(
+                        filePath -> "\"RETURN 1\", " + filePath + ", {}"
+                ).toList(),
+                "all", cases.stream().map(
+                        filePath -> filePath + ", {}"
+                ).toList(),
+                "data", cases.stream().map(
+                        filePath -> "[], [], " + filePath + ", {}"
+                ).toList(),
+                "graph", cases.stream().map(
+                        filePath -> "{nodes: [], relationships: []}, " + filePath + ", {}"
+                ).toList()
+        );
+
+        @Parameterized.Parameters
+        public static Collection<String[]> data() {
+            return ExportCoreSecurityTest.data(METHOD_ARGUMENTS);
+        }
+
+        @Test
+        public void testPathTraversal() {
+            setFileExport(true);
+
+            QueryExecutionException e = Assert.assertThrows(QueryExecutionException.class,
+                    () -> TestUtil.testCall(db, "CALL " + apocProcedure, (r) -> {})
+            );
+
+            TestCase.assertTrue(e.getMessage().contains("apoc/test.txt (No such file or directory)"));
+            setFileExport(false);
+        }
+    }
+
+    /**
+     * These tests normalize the path to be within the import directory and make the file there.
+     * Some attempt to exit the directory.
+     * They result in a file name test.txt being created (and deleted after).
+     */
+    @RunWith(Parameterized.class)
+    public static class TestPathTraversalIsNormalisedWithinDirectory {
+        private final String apocProcedure;
+
+        public TestPathTraversalIsNormalisedWithinDirectory(String exportMethod, String exportMethodType, String exportMethodArguments) {
+            this.apocProcedure = "apoc.export." + exportMethod + "." + exportMethodType + "(" + exportMethodArguments + ")";
+        }
+
+        private static final String case1 = "'file:///..//..//..//..//apoc//..//..//..//..//test.txt'";
+        private static final String case2 = "'file:///..//..//..//..//apoc//..//test.txt'";
+        private static final String case3 = "'file:///../import/../import//..//test.txt'";
+        private static final String case4 = "'file://test.txt'";
+        private static final String case5 = "'file://tests/../test.txt'";
+        private static final String case6 = "'file:///tests//..//test.txt'";
+        private static final String case7 = "'test.txt'";
+
+        private static final List<String> cases = Arrays.asList(case1, case2, case3, case4, case5, case6, case7);
+
+        private static final Map<String, List<String>> METHOD_ARGUMENTS = Map.of(
+                "query", cases.stream().map(
+                        filePath -> "\"RETURN 1\", " + filePath + ", {}"
+                ).toList(),
+                "all", cases.stream().map(
+                        filePath -> filePath + ", {}"
+                ).toList(),
+                "data", cases.stream().map(
+                        filePath -> "[], [], " + filePath + ", {}"
+                ).toList(),
+                "graph", cases.stream().map(
+                        filePath -> "{nodes: [], relationships: []}, " + filePath + ", {}"
+                ).toList()
+        );
+
+        @Parameterized.Parameters
+        public static Collection<String[]> data() {
+            return ExportCoreSecurityTest.data(METHOD_ARGUMENTS);
+        }
+
+        @Test
+        public void testPathTraversal() {
+            setFileExport(true);
+
+            TestUtil.testCall(db, "CALL " + apocProcedure,
+                    (r) -> assertTrue(((String) r.get("file")).contains("test.txt"))
+            );
+
+            File f = new File(directory.getAbsolutePath() + "/test.txt");
+            TestCase.assertTrue(f.exists());
+            TestCase.assertTrue(f.delete());
+        }
+    }
+
+
+    /**
+     * These tests normalize the path to be within the import directory and step into a subdirectory
+     * to make the file there.
+     * Some attempt to exit the directory.
+     * They result in a file name test.txt in the directory /tests being created (and deleted after).
+     */
+    @RunWith(Parameterized.class)
+    public static class TestPathTraversAllowedWithinDirectory {
+        private final String apocProcedure;
+
+        public TestPathTraversAllowedWithinDirectory(String exportMethod, String exportMethodType, String exportMethodArguments) {
+            this.apocProcedure = "apoc.export." + exportMethod + "." + exportMethodType + "(" + exportMethodArguments + ")";
+        }
+
+        private static final String case1 = "'file:///../import/../import//..//tests/test.txt'";
+        private static final String case2 = "'file:///..//..//..//..//apoc//..//tests/test.txt'";
+        private static final String case3 = "'file:///../import/../import//..//tests/../tests/test.txt'";
+        private static final String case4 = "'file:///tests/test.txt'";
+        private static final String case5 = "'tests/test.txt'";
+
+        private static final List<String> cases = Arrays.asList(case1, case2, case3, case4, case5);
+
+        private static final Map<String, List<String>> METHOD_ARGUMENTS = Map.of(
+                "query", cases.stream().map(
+                        filePath -> "\"RETURN 1\", " + filePath + ", {}"
+                ).toList(),
+                "all", cases.stream().map(
+                        filePath -> filePath + ", {}"
+                ).toList(),
+                "data", cases.stream().map(
+                        filePath -> "[], [], " + filePath + ", {}"
+                ).toList(),
+                "graph", cases.stream().map(
+                        filePath -> "{nodes: [], relationships: []}, " + filePath + ", {}"
+                ).toList()
+        );
+
+        @Parameterized.Parameters
+        public static Collection<String[]> data() {
+            return ExportCoreSecurityTest.data(METHOD_ARGUMENTS);
+        }
+
+        @Test
+        public void testPathTraversal() {
+            setFileExport(true);
+
+            TestUtil.testCall(db, "CALL " + apocProcedure,
+                    (r) -> assertTrue(((String) r.get("file")).contains("tests/test.txt"))
+            );
+
+            File f = new File(subDirectory.getAbsolutePath() + "/test.txt");
+            TestCase.assertTrue(f.exists());
+            TestCase.assertTrue(f.delete());
         }
     }
 
     public static class TestCypherSchema {
         private final String apocProcedure = "apoc.export.cypher.schema(%s)";
-        private final String message = apocProcedure + " should throw an exception";
 
         @Test
         public void testIllegalFSAccessExportCypherSchema() {
-            try {
-                db.executeTransactionally(String.format("CALL " + apocProcedure, "'./hello', {}"), Map.of(),
-                        Result::resultAsString);
-                fail(message);
-            } catch (Exception e) {
-                assertError(e, ApocConfig.EXPORT_TO_FILE_ERROR, RuntimeException.class, apocProcedure);
-            }
+            QueryExecutionException e = Assert.assertThrows(QueryExecutionException.class,
+                    () -> TestUtil.testCall(db, String.format("CALL " + apocProcedure, "'./hello', {}"), (r) -> {})
+            );
+            assertError(e, ApocConfig.EXPORT_TO_FILE_ERROR, RuntimeException.class, apocProcedure);
         }
 
         @Test
         public void testIllegalExternalFSAccessExportCypherSchema() {
-            try {
-                ApocConfig.apocConfig().setProperty(ApocConfig.APOC_EXPORT_FILE_ENABLED, true);
-                db.executeTransactionally(String.format("CALL " + apocProcedure, "'../hello', {}"), Map.of(),
-                        Result::resultAsString);
-                fail(message);
-            } catch (Exception e) {
-                assertError(e, FileUtils.ACCESS_OUTSIDE_DIR_ERROR, IOException.class, apocProcedure);
-            } finally {
-                ApocConfig.apocConfig().setProperty(ApocConfig.APOC_EXPORT_FILE_ENABLED, false);
-            }
+            setFileExport(true);
+            QueryExecutionException e = Assert.assertThrows(QueryExecutionException.class,
+                    () -> TestUtil.testCall(db, String.format("CALL " + apocProcedure, "'../hello', {}"), (r) -> {})
+            );
+            assertError(e, FileUtils.ACCESS_OUTSIDE_DIR_ERROR, IOException.class, apocProcedure);
+            setFileExport(false);
         }
     }
 

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -116,8 +116,9 @@ public class ExportCsvTest {
             ",,,,,,,,0,1,KNOWS%n" +
             ",,,,,,,,3,4,NEXT_DELIVERY%n");
 
-    private static File directory = new File("target/import");
-    static { //noinspection ResultOfMethodCallIgnored
+    private static final File directory = new File("target/import");
+    static {
+        //noinspection ResultOfMethodCallIgnored
         directory.mkdirs();
     }
 

--- a/core/src/test/java/apoc/export/json/ExportJsonTest.java
+++ b/core/src/test/java/apoc/export/json/ExportJsonTest.java
@@ -40,8 +40,8 @@ import static apoc.export.json.JsonFormat.Format;
 public class ExportJsonTest {
 
     private static final String DEFLATE_EXT = ".zz";
-    private static File directory = new File("target/import");
-    private static File directoryExpected = new File("src/test/resources/exportJSON");
+    private static final File directory = new File("target/import");
+    private static final File directoryExpected = new File("src/test/resources/exportJSON");
 
     static { //noinspection ResultOfMethodCallIgnored
         directory.mkdirs();


### PR DESCRIPTION
vuln-fix: Fixes path traversal vulnerability (CVE-2022-23532)

Impact: APOC export procedures were vulnerable to path traversal which could result in files being written to outside of the control directory.