### PR TITLE
[MiVboeTJ] Fixes slf4j apoc logger

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -54,6 +54,8 @@ dependencies {
     api group: 'com.jayway.jsonpath', name: 'json-path', version: '2.7.0'
     api group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
     api group: 'org.apache.commons', name: 'commons-collections4', version: '4.2'
+    // We need this to avoid seeing SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder" on startup
+    api group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.36'
 
     // We need to force this dependency's verion due to a vulnerability https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/3048
     api group: 'org.apache.commons', name: 'commons-lang3', {

--- a/test-startup/src/test/java/StartupTest.java
+++ b/test-startup/src/test/java/StartupTest.java
@@ -12,7 +12,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static apoc.util.TestContainerUtil.createDB;
+import static apoc.util.TestContainerUtil.dockerImageForNeo4j;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -35,17 +37,21 @@ public class StartupTest {
                 int procedureCount = session.run("SHOW PROCEDURES YIELD name WHERE name STARTS WITH 'apoc' RETURN count(*) AS count").peek().get("count").asInt();
                 int functionCount = session.run("SHOW FUNCTIONS YIELD name WHERE name STARTS WITH 'apoc' RETURN count(*) AS count").peek().get("count").asInt();
                 int coreCount = session.run("CALL apoc.help('') YIELD core WHERE core = true RETURN count(*) AS count").peek().get("count").asInt();
+                String startupLog = neo4jContainer.getLogs();
 
                 assertTrue(procedureCount > 0);
                 assertTrue(functionCount > 0);
                 assertTrue(coreCount > 0);
+                // Check there's one and only one logger for apoc inside the container
+                assertFalse(startupLog.contains("SLF4J: Failed to load class \"org.slf4j.impl.StaticLoggerBinder\""));
+                assertFalse(startupLog.contains("SLF4J: Class path contains multiple SLF4J providers"));
             } catch (Exception ex) {
                 // if Testcontainers wasn't able to retrieve the docker image we ignore the test
                 if (TestContainerUtil.isDockerImageAvailable(ex)) {
                     ex.printStackTrace();
                     fail("Should not have thrown exception when trying to start Neo4j: " + ex);
                 } else if (!TestUtil.isRunningInCI()) {
-                    fail( "The docker image " + TestContainerUtil.neo4jEnterpriseDockerImageVersion + " should be available in the CI. Exception:" + ex);
+                    fail( "The docker image " + dockerImageForNeo4j(version) + " could not be loaded. Check whether it's available locally / in the CI. Exception:" + ex);
                 }
             }
         }
@@ -74,7 +80,7 @@ public class StartupTest {
                     ex.printStackTrace();
                     fail("Should not have thrown exception when trying to start Neo4j: " + ex);
                 } else {
-                    fail( "The docker image " + TestContainerUtil.neo4jEnterpriseDockerImageVersion + " should be available in the CI. Exception:" + ex);
+                    fail( "The docker image " + dockerImageForNeo4j(version) + " could not be loaded. Check whether it's available locally / in the CI. Exception:" + ex);
                 }
             }
         }

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -18,15 +18,21 @@ dependencies {
         exclude group: 'org.apache.hive', module: 'hive-service'
     }
 
+    // The logger will come from the :common project via slf4j-simple
+    def withoutLoggers = {
+        exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+        exclude group: 'org.slf4j', module: 'slf4j-reload4j'
+    }
+
     api group: 'junit', name: 'junit', version: '4.13.2'
     api group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
     api group: 'org.hamcrest', name: 'hamcrest-library', version: '2.2'
     api group: 'org.neo4j.community', name: 'it-test-support', version: neo4jVersionEffective // , classifier: "tests"
     api group: 'org.neo4j', name: 'log-test-utils', version: neo4jVersionEffective // , classifier: "tests"
     api group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.0.0'
-    api group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.4', withoutServers
-    api group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.4', withoutServers
-    api group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '3.3.4', withoutServers
+    api group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.4', withoutServers.andThen(withoutLoggers)
+    api group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.4', withoutServers.andThen(withoutLoggers)
+    api group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '3.3.4', withoutServers.andThen(withoutLoggers)
     api group: 'org.testcontainers', name: 'testcontainers', version: testContainersVersion
     api group: 'org.testcontainers', name: 'neo4j', version: testContainersVersion
     api group: 'org.testcontainers', name: 'elasticsearch', version: testContainersVersion

--- a/test-utils/src/main/java/apoc/util/TestContainerUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestContainerUtil.java
@@ -50,6 +50,13 @@ public class TestContainerUtil {
     private static File coreDir = new File(baseDir, System.getProperty("coreDir"));
     private static File extendedDir = new File(baseDir, "extended");
 
+    public static String dockerImageForNeo4j(Neo4jVersion version) {
+        if (version == Neo4jVersion.COMMUNITY)
+            return neo4jCommunityDockerImageVersion;
+        else
+            return neo4jEnterpriseDockerImageVersion;
+    }
+
     public static TestcontainersCausalCluster createEnterpriseCluster(List<ApocPackage> apocPackages, int numOfCoreInstances, int numberOfReadReplica, Map<String, Object> neo4jConfig, Map<String, String> envSettings) {
         return TestcontainersCausalCluster.create(apocPackages, numOfCoreInstances, numberOfReadReplica, Duration.ofMinutes(4), neo4jConfig, envSettings);
     }


### PR DESCRIPTION
## Why
Because we were seeing messages like this one on startup:

```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```