### PR TITLE
[480BDuYi] Try de-flake some trigger tests with embedded db

### DIFF
--- a/test-utils/src/main/java/apoc/trigger/TriggerTestUtil.java
+++ b/test-utils/src/main/java/apoc/trigger/TriggerTestUtil.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertEquals;
 
 public class TriggerTestUtil {
     public static final long TIMEOUT = 10L;
-    public static final long TRIGGER_DEFAULT_REFRESH = 250;
+    public static final long TRIGGER_DEFAULT_REFRESH = 3000;
 
     public static void awaitTriggerDiscovered(GraphDatabaseService db, String name, String query) {
         awaitTriggerDiscovered(db, name, query, false);


### PR DESCRIPTION
In 4.4 [I increased this value](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3355), and in this way the problem seems to be resolved.

In 5.x [I tried to put a lower value](https://github.com/neo4j/apoc/pull/250#discussion_r1060649214), 
but apparently some tests are flaky.

As with 4.4, I couldn't figure out exactly why this stabilize the tests (hoping it's for the same reason as 4.4), 
also because the problem seems to occur only with the embedded instance 
(i.e. `org.neo4j.test.TestDatabaseManagementServiceBuilder` )