### PR TITLE
[126ZorO2] Document that apoc.util.sha1 and apoc.text.random are not suitable for cryptographic use.

### DIFF
--- a/core/src/main/java/apoc/text/Strings.java
+++ b/core/src/main/java/apoc/text/Strings.java
@@ -333,7 +333,8 @@ public class Strings {
     private static final String numeric = "0123456789";
 
     @UserFunction("apoc.text.random")
-    @Description("Generates a random string to the given length using a length parameter and an optional string of valid characters.")
+    @Description("Generates a random string to the given length using a length parameter and an optional string of valid characters.\n" +
+            "Unsuitable for cryptographic use-cases.")
     public String random(final @Name("length") long length, @Name(value = "valid", defaultValue = "A-Za-z0-9") String valid) {
         valid = valid.replaceAll("A-Z", upper).replaceAll("a-z", lower).replaceAll("0-9", numeric);
 

--- a/core/src/main/java/apoc/util/Utils.java
+++ b/core/src/main/java/apoc/util/Utils.java
@@ -18,7 +18,8 @@ public class Utils {
     public TerminationGuard terminationGuard;
 
     @UserFunction("apoc.util.sha1")
-    @Description("Returns the SHA1 of the concatenation of all string values in the given list.")
+    @Description("Returns the SHA1 of the concatenation of all string values in the given list.\n" +
+            "SHA1 is a weak hashing algorithm which is unsuitable for cryptographic use-cases.")
     public String sha1(@Name("values") List<Object> values) {
         String value = values.stream().map(v -> v == null ? "" : v.toString()).collect(Collectors.joining());
         return DigestUtils.sha1Hex(value);


### PR DESCRIPTION
During the Threat Modelling it was decided that apoc.util.sha1 and apoc.text.random should be documented as unsafe for cryptographic use to discourage users from thinking they are secure.