### PR TITLE
[gcL5e77c] Fix edge cases in trigger methods

### DIFF
--- a/core/src/main/java/apoc/trigger/TriggerHandlerNewProcedures.java
+++ b/core/src/main/java/apoc/trigger/TriggerHandlerNewProcedures.java
@@ -34,25 +34,25 @@ public class TriggerHandlerNewProcedures {
     }
 
     public static TriggerInfo install(String databaseName, String triggerName, String statement, Map<String,Object> selector, Map<String,Object> params) {
-        final TriggerInfo[] previous = new TriggerInfo[1];
+        final TriggerInfo[] result = new TriggerInfo[1];
 
         withSystemDb(tx -> {
             Node node = Util.mergeNode(tx, SystemLabels.ApocTrigger, null,
                     Pair.of(SystemPropertyKeys.database.name(), databaseName),
                     Pair.of(SystemPropertyKeys.name.name(), triggerName));
             
-            // we'll return previous trigger info
-            previous[0] = fromNode(node, true);
-            
             node.setProperty(SystemPropertyKeys.statement.name(), statement);
             node.setProperty(SystemPropertyKeys.selector.name(), Util.toJson(selector));
             node.setProperty(SystemPropertyKeys.params.name(), Util.toJson(params));
             node.setProperty(SystemPropertyKeys.paused.name(), false);
+            
+            // we'll the return current trigger info
+            result[0] = fromNode(node, true);
 
             setLastUpdate(databaseName, tx);
         });
 
-        return previous[0];
+        return result[0];
     }
 
     public static TriggerInfo drop(String databaseName, String triggerName) {

--- a/core/src/main/java/apoc/trigger/TriggerNewProcedures.java
+++ b/core/src/main/java/apoc/trigger/TriggerNewProcedures.java
@@ -65,11 +65,8 @@ public class TriggerNewProcedures {
         checkInSystemWriter();
         checkTargetDatabase(databaseName);
         Map<String,Object> params = (Map)config.getOrDefault("params", Collections.emptyMap());
-        TriggerInfo removed = TriggerHandlerNewProcedures.install(databaseName, name, statement, selector, params);
-        final TriggerInfo triggerInfo = new TriggerInfo(name, statement, selector, params, true, false);
-        if (removed.query != null) {
-            return Stream.of( removed, triggerInfo);
-        }
+        
+        TriggerInfo triggerInfo = TriggerHandlerNewProcedures.install(databaseName, name, statement, selector, params);
         return Stream.of(triggerInfo);
     }
 
@@ -82,10 +79,7 @@ public class TriggerNewProcedures {
     public Stream<TriggerInfo> drop(@Name("databaseName") String databaseName, @Name("name")String name) {
         checkInSystemWriter();
         final TriggerInfo removed = TriggerHandlerNewProcedures.drop(databaseName, name);
-        if (removed == null) {
-            return Stream.of(new TriggerInfo(name, null, null, false, false));
-        }
-        return Stream.of(removed);
+        return Stream.ofNullable(removed);
     }
     
     
@@ -108,8 +102,8 @@ public class TriggerNewProcedures {
     public Stream<TriggerInfo> stop(@Name("databaseName") String databaseName, @Name("name")String name) {
         checkInSystemWriter();
 
-        return Stream.of(
-                TriggerHandlerNewProcedures.updatePaused(databaseName, name, true));
+        final TriggerInfo triggerInfo = TriggerHandlerNewProcedures.updatePaused(databaseName, name, true);
+        return Stream.ofNullable(triggerInfo);
     }
 
     // TODO - change with @SystemOnlyProcedure
@@ -119,9 +113,9 @@ public class TriggerNewProcedures {
     @Description("Eventually restarts the given paused trigger.")
     public Stream<TriggerInfo> start(@Name("databaseName") String databaseName, @Name("name")String name) {
         checkInSystemWriter();
+        
         final TriggerInfo triggerInfo = TriggerHandlerNewProcedures.updatePaused(databaseName, name, false);
-
-        return Stream.of(triggerInfo);
+        return Stream.ofNullable(triggerInfo);
     }
 
     // TODO - change with @SystemOnlyProcedure

--- a/core/src/test/java/apoc/trigger/TriggerNewProceduresTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerNewProceduresTest.java
@@ -6,6 +6,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.neo4j.configuration.GraphDatabaseSettings;
@@ -127,6 +128,42 @@ public class TriggerNewProceduresTest {
     }
 
     @Test
+    public void testDropStopAndStartNotExistentTrigger() {
+        testCallEmpty( sysDb, "CALL apoc.trigger.stop('neo4j', $name)",
+                map("name", UUID.randomUUID().toString()) );
+
+        testCallEmpty( sysDb, "CALL apoc.trigger.start('neo4j', $name)",
+                map("name", UUID.randomUUID().toString()) );
+
+
+        testCallEmpty( sysDb, "CALL apoc.trigger.drop('neo4j', $name)",
+                map( "name", UUID.randomUUID().toString()) );
+    }
+    
+    @Test
+    public void testOverwriteTrigger() {
+        final String name = UUID.randomUUID().toString();
+        
+        String queryOne = "RETURN 111";
+        testCall(sysDb, "CALL apoc.trigger.install('neo4j', $name, $query, {})",
+                map("name", name, "query", queryOne),
+                r -> {
+                    assertEquals(name, r.get("name"));
+                    assertEquals(queryOne, r.get("query"));
+                }
+        );
+
+        String queryTwo = "RETURN 999";
+        testCall(sysDb, "CALL apoc.trigger.install('neo4j', $name, $query, {})",
+                map("name", name, "query", queryTwo),
+                r -> {
+                    assertEquals(name, r.get("name"));
+                    assertEquals(queryTwo, r.get("query"));
+                }
+        );
+    }
+
+    @Test
     public void testIssue2247() {
         db.executeTransactionally("CREATE (n:ToBeDeleted)");
         final String name = "myTrig";
@@ -173,11 +210,7 @@ public class TriggerNewProceduresTest {
         });
         testCallCountEventually(db, "CALL apoc.trigger.list()", 0, TIMEOUT);
 
-        testCall(sysDb, "CALL apoc.trigger.drop('neo4j', 'to-be-removed')", (row) -> {
-            assertEquals("to-be-removed", row.get("name"));
-            assertNull(row.get("query"));
-            assertEquals(false, row.get("installed"));
-        });
+        testCallEmpty(sysDb, "CALL apoc.trigger.drop('neo4j', 'to-be-removed')", Collections.emptyMap());
     }
 
     @Test

--- a/core/src/test/java/apoc/trigger/TriggerNewProceduresTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerNewProceduresTest.java
@@ -6,7 +6,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.neo4j.configuration.GraphDatabaseSettings;


### PR DESCRIPTION
- The `apoc.trogger.drop`, `apoc.trogger.stop` and `apoc.trogger.start` return an empty result if the trigger doesn't exist
- The `apoc.trigger.install` returns the current trigger instead of the previous one