### PR TITLE
[yHvDctRN] Add tests and docs about $transactionId

### DIFF
--- a/core/src/test/java/apoc/trigger/TriggerNewProceduresTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerNewProceduresTest.java
@@ -241,6 +241,71 @@ public class TriggerNewProceduresTest {
     }
 
     @Test
+    public void testTxIdWithRelationshipsAndAfter() {
+        db.executeTransactionally("CREATE (:RelationshipCounter {count:0})");
+        String name = UUID.randomUUID().toString();
+        
+        // We need to filter $createdRelationships, i.e. `size(..) > 0`, not to cause a deadlock
+        String query = """
+                 WITH size($createdRelationships) AS sizeRels
+                 WHERE sizeRels > 0
+                 MATCH (c:RelationshipCounter)
+                 SET c.txId = $transactionId  SET c.count = c.count + sizeRels""";
+        
+        sysDb.executeTransactionally("CALL apoc.trigger.install('neo4j', $name, $query, {phase: 'after'})",
+                Map.of("name", name, "query", query));
+        awaitTriggerDiscovered(db, name, query);
+        
+        db.executeTransactionally("CREATE (a:A)<-[r:C]-(b:B)");
+        
+        testCall(db, "MATCH (n:RelationshipCounter) RETURN n",
+                this::testTxIdWithRelsAssertionsCommon);
+    }
+
+    @Test
+    public void testTxIdWithRelationshipsAndAfterAsync(){
+        testTxIdWithRelationshipsCommon("afterAsync");
+
+        testCallEventually(db, "MATCH (n:RelationshipCounter) RETURN n", 
+                this::testTxIdWithRelsAssertionsCommon, 
+                10);
+    }
+
+    private void testTxIdWithRelsAssertionsCommon(Map<String, Object> r) {
+        final Node n = (Node) r.get("n");
+        assertEquals(1L, n.getProperty("count"));
+        final long txId = (long) n.getProperty("txId");
+        assertTrue("Current txId is: " + txId, txId > -1L);
+    }
+
+    @Test
+    public void testTxIdWithRelationshipsAndBefore(){
+        testTxIdWithRelationshipsCommon("before");
+
+        testCall(db, "MATCH (n:RelationshipCounter) RETURN n", r -> {
+            final Node n = (Node) r.get("n");
+            assertEquals(-1L, n.getProperty("txId"));
+            assertEquals(1L, n.getProperty("count"));
+        });
+    }
+
+    private static void testTxIdWithRelationshipsCommon(String phase) {
+        String query = """
+                MATCH (c:RelationshipCounter)
+                  SET c.count = c.count + size($createdRelationships)
+                  SET c.txId = $transactionId""";
+
+        db.executeTransactionally("CREATE (:RelationshipCounter {count:0})");
+        String name = UUID.randomUUID().toString();
+
+        sysDb.executeTransactionally("CALL apoc.trigger.install( 'neo4j', $name, $query, {phase: $phase})",
+                Map.of("name", name, "query", query, "phase", phase));
+        awaitTriggerDiscovered(db, name, query);
+
+        db.executeTransactionally("CREATE (a:A)<-[r:C]-(b:B)");
+    }
+
+    @Test
     public void testMetaDataBefore() {
         String triggerQuery = "UNWIND $createdNodes AS n SET n.label = labels(n)[0], n += $metaData";
         String matchQuery = "MATCH (n:Bar) RETURN n";


### PR DESCRIPTION
Related to https://github.com/neo4j/docs-apoc/pull/90

With `before` the `$transactionId` always returns `-1` because the [txData.getTransactionId()](https://github.com/neo4j/apoc/blob/dev/core/src/main/java/apoc/trigger/TriggerMetadata.java#L69) throws an `java.lang.IllegalStateException: Transaction id is not assigned yet. It will be assigned during transaction commit.`.


The example with 'after', is slightly different than the one on the related Trello card because in that way would causes a deadlock.
I created a card to track of this behavior `[H5vz3qhy]`.