### PR TITLE
Fix the missing constraint error message for apoc.import.json()

### DIFF
--- a/core/src/main/java/apoc/export/json/JsonImporter.java
+++ b/core/src/main/java/apoc/export/json/JsonImporter.java
@@ -40,7 +40,7 @@ public class JsonImporter implements Closeable {
             "MATCH (e%s {%2$s: row.end.id}) " +
             "CREATE (s)-[r:%s]->(e) SET r += row.properties";
     public static final String MISSING_CONSTRAINT_ERROR_MSG = "Missing constraint required for import. Execute this query: \n" +
-            "CREATE CONSTRAINT ON (n:%s) assert n.%s IS UNIQUE;";
+            "CREATE CONSTRAINT FOR (n:%s) REQUIRE n.%s IS UNIQUE;";
 
     private final List<Map<String, Object>> paramList;
     private final int unwindBatchSize;


### PR DESCRIPTION
Fixes #290

Signed-off-by: John Lin <johnlinp@gmail.com>

## Proposed Changes (Mandatory)

Use `FOR` instead of `ON` and use `REQUIRE` instead of `ASSERT`.