### PR TITLE
[KrJWRWJD] Fix flaky testTerminatePeriodicQuery

### DIFF
--- a/test-utils/src/main/java/apoc/periodic/PeriodicTestUtils.java
+++ b/test-utils/src/main/java/apoc/periodic/PeriodicTestUtils.java
@@ -48,9 +48,9 @@ public class PeriodicTestUtils {
                 db.executeTransactionally(periodicQuery, Map.of(),
                     result -> {
                         Map<String, Object> row = Iterators.single(result);
-                        return row.get("wasTerminated");
+                        return (boolean) row.get("wasTerminated");
                     }),
-                (value) -> true, 10L, TimeUnit.SECONDS);
+                (value) -> value, 15L, TimeUnit.SECONDS);
         } catch(Exception tfe) {
             assertEquals(tfe.getMessage(),true, tfe.getMessage().contains("terminated"));
         }


### PR DESCRIPTION
I don't know if it can be really related, but the `(value) -> true` makes the assertion always green 
even if the `killPeriodicQueryAsync(db);` just before is deleted. 