### PR TITLE
[ROQ0fkdz] Reduce the number of transactions we use in triggers

### DIFF
--- a/core/src/main/java/apoc/trigger/TriggerHandlerNewProcedures.java
+++ b/core/src/main/java/apoc/trigger/TriggerHandlerNewProcedures.java
@@ -11,7 +11,6 @@ import org.neo4j.graphdb.Transaction;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import static apoc.ApocConfig.APOC_TRIGGER_ENABLED;
@@ -33,76 +32,66 @@ public class TriggerHandlerNewProcedures {
         }
     }
 
-    public static TriggerInfo install(String databaseName, String triggerName, String statement, Map<String,Object> selector, Map<String,Object> params) {
-        final TriggerInfo[] result = new TriggerInfo[1];
+    public static TriggerInfo install(String databaseName, String triggerName, String statement, Map<String,Object> selector, Map<String,Object> params, Transaction tx) {
+        final TriggerInfo result;
 
-        withSystemDb(tx -> {
-            Node node = Util.mergeNode(tx, SystemLabels.ApocTrigger, null,
-                    Pair.of(SystemPropertyKeys.database.name(), databaseName),
-                    Pair.of(SystemPropertyKeys.name.name(), triggerName));
-            
-            node.setProperty(SystemPropertyKeys.statement.name(), statement);
-            node.setProperty(SystemPropertyKeys.selector.name(), Util.toJson(selector));
-            node.setProperty(SystemPropertyKeys.params.name(), Util.toJson(params));
-            node.setProperty(SystemPropertyKeys.paused.name(), false);
-            
-            // we'll the return current trigger info
-            result[0] = fromNode(node, true);
+        Node node = Util.mergeNode(tx, SystemLabels.ApocTrigger, null,
+                Pair.of(SystemPropertyKeys.database.name(), databaseName),
+                Pair.of(SystemPropertyKeys.name.name(), triggerName));
 
-            setLastUpdate(databaseName, tx);
-        });
+        node.setProperty(SystemPropertyKeys.statement.name(), statement);
+        node.setProperty(SystemPropertyKeys.selector.name(), Util.toJson(selector));
+        node.setProperty(SystemPropertyKeys.params.name(), Util.toJson(params));
+        node.setProperty(SystemPropertyKeys.paused.name(), false);
+        
+        // we'll return current trigger info
+        result = fromNode(node, true);
 
-        return result[0];
+        setLastUpdate(databaseName, tx);
+
+        return result;
     }
 
-    public static TriggerInfo drop(String databaseName, String triggerName) {
+    public static TriggerInfo drop(String databaseName, String triggerName, Transaction tx) {
         final TriggerInfo[] previous = new TriggerInfo[1];
 
-        withSystemDb(tx -> {
-            getTriggerNodes(databaseName, tx, triggerName)
-                    .forEachRemaining(node -> {
-                                previous[0] = fromNode(node, false);
-                                node.delete();
-                            });
-            
-            setLastUpdate(databaseName, tx);
-        });
+        getTriggerNodes(databaseName, tx, triggerName)
+                .forEachRemaining(node -> {
+                            previous[0] = fromNode(node, false);
+                            node.delete();
+                        });
+        
+        setLastUpdate(databaseName, tx);
 
         return previous[0];
     }
 
-    public static TriggerInfo updatePaused(String databaseName, String name, boolean paused) {
+    public static TriggerInfo updatePaused(String databaseName, String name, boolean paused, Transaction tx) {
         final TriggerInfo[] result = new TriggerInfo[1];
 
-        withSystemDb(tx -> {
-            getTriggerNodes(databaseName, tx, name)
-                    .forEachRemaining(node -> {
-                        node.setProperty( SystemPropertyKeys.paused.name(), paused );
+        getTriggerNodes(databaseName, tx, name)
+                .forEachRemaining(node -> {
+                    node.setProperty( SystemPropertyKeys.paused.name(), paused );
 
-                        // we'll return previous trigger info
-                        result[0] = fromNode(node, true);
-                    });
+                    // we'll return previous trigger info
+                    result[0] = fromNode(node, true);
+                });
 
-            setLastUpdate(databaseName, tx);
-        });
+        setLastUpdate(databaseName, tx);
 
         return result[0];
     }
 
-    public static List<TriggerInfo> dropAll(String databaseName) {
+    public static List<TriggerInfo> dropAll(String databaseName, Transaction tx) {
         final List<TriggerInfo> previous = new ArrayList<>();
 
-        withSystemDb(tx -> {
-            getTriggerNodes(databaseName, tx)
-                    .forEachRemaining(node -> {
-                        String triggerName = (String) node.getProperty(SystemPropertyKeys.name.name());
-
-                        // we'll return previous trigger info
-                        previous.add( fromNode(node, false) );
-                        node.delete();
-                    });
-            setLastUpdate(databaseName, tx);
-        });
+        getTriggerNodes(databaseName, tx)
+                .forEachRemaining(node -> {
+                    // we'll return previous trigger info
+                    previous.add( fromNode(node, false) );
+                    node.delete();
+                });
+        setLastUpdate(databaseName, tx);
 
         return previous;
     }
@@ -125,13 +114,6 @@ public class TriggerHandlerNewProcedures {
         }
         return tx.findNodes(label, dbNameKey, databaseName,
                 SystemPropertyKeys.name.name(), name);
-    }
-
-    public static void withSystemDb(Consumer<Transaction> consumer) {
-        try (Transaction tx = apocConfig().getSystemDb().beginTx()) {
-            consumer.accept(tx);
-            tx.commit();
-        }
     }
 
     private static void setLastUpdate(String databaseName, Transaction tx) {

--- a/core/src/main/java/apoc/trigger/TriggerNewProcedures.java
+++ b/core/src/main/java/apoc/trigger/TriggerNewProcedures.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -32,10 +33,10 @@ public class TriggerNewProcedures {
     
     @Context public Transaction tx;
 
-    private void checkInSystemWriter() {
+    private void checkInSystemWriter(Transaction tx) {
         TriggerHandlerNewProcedures.checkEnabled();
         
-        if (!db.databaseName().equals(SYSTEM_DATABASE_NAME) || !Util.isWriteableInstance(db)) {
+        if (!db.databaseName().equals(SYSTEM_DATABASE_NAME) || !Util.isWriteableInstance(db, tx)) {
             throw new RuntimeException(TRIGGER_NOT_ROUTED_ERROR);
         }
     }
@@ -48,7 +49,7 @@ public class TriggerNewProcedures {
         }
     }
 
-    private void checkTargetDatabase(String databaseName) {
+    private void checkTargetDatabase(String databaseName, Transaction tx) {
         final Set<String> databases = tx.execute("SHOW DATABASES", Collections.emptyMap())
                 .<String>columnAs("name")
                 .stream()
@@ -68,12 +69,15 @@ public class TriggerNewProcedures {
     @Procedure(name = "apoc.trigger.install", mode = Mode.WRITE)
     @Description("Eventually adds a trigger for a given database which is invoked when a successful transaction occurs.")
     public Stream<TriggerInfo> install(@Name("databaseName") String databaseName, @Name("name") String name, @Name("statement") String statement, @Name(value = "selector")  Map<String,Object> selector, @Name(value = "config", defaultValue = "{}") Map<String,Object> config) {
-        checkInSystemWriter();
-        checkTargetDatabase(databaseName);
-        Map<String,Object> params = (Map)config.getOrDefault("params", Collections.emptyMap());
-        
-        TriggerInfo triggerInfo = TriggerHandlerNewProcedures.install(databaseName, name, statement, selector, params);
-        return Stream.of(triggerInfo);
+
+        return withTransaction(tx -> {
+            checkInSystemWriter(tx);
+            checkTargetDatabase(databaseName, tx);
+            Map<String,Object> params = (Map)config.getOrDefault("params", Collections.emptyMap());
+
+            TriggerInfo triggerInfo = TriggerHandlerNewProcedures.install(databaseName, name, statement, selector, params, tx);
+            return Stream.of(triggerInfo);
+        });
     }
 
 
@@ -83,9 +87,11 @@ public class TriggerNewProcedures {
     @Procedure(name = "apoc.trigger.drop", mode = Mode.WRITE)
     @Description("Eventually removes the given trigger.")
     public Stream<TriggerInfo> drop(@Name("databaseName") String databaseName, @Name("name")String name) {
-        checkInSystemWriter();
-        final TriggerInfo removed = TriggerHandlerNewProcedures.drop(databaseName, name);
-        return Stream.ofNullable(removed);
+        return withTransaction(tx -> {
+            checkInSystemWriter(tx);
+            final TriggerInfo removed = TriggerHandlerNewProcedures.drop(databaseName, name, tx);
+            return Stream.ofNullable(removed);
+        });
     }
     
     
@@ -95,9 +101,11 @@ public class TriggerNewProcedures {
     @Procedure(name = "apoc.trigger.dropAll", mode = Mode.WRITE)
     @Description("Eventually removes all triggers from the given database.")
     public Stream<TriggerInfo> dropAll(@Name("databaseName") String databaseName) {
-        checkInSystemWriter();
-        return TriggerHandlerNewProcedures.dropAll(databaseName)
-                .stream().sorted(Comparator.comparing(i -> i.name));
+        return withTransaction(tx -> {
+            checkInSystemWriter(tx);
+            return TriggerHandlerNewProcedures.dropAll(databaseName, tx)
+                    .stream().sorted(Comparator.comparing(i -> i.name));
+        });
     }
 
     // TODO - change with @SystemOnlyProcedure
@@ -106,10 +114,12 @@ public class TriggerNewProcedures {
     @Procedure(name = "apoc.trigger.stop", mode = Mode.WRITE)
     @Description("Eventually stops the given trigger.")
     public Stream<TriggerInfo> stop(@Name("databaseName") String databaseName, @Name("name")String name) {
-        checkInSystemWriter();
+        return withTransaction(tx -> {
+            checkInSystemWriter(tx);
 
-        final TriggerInfo triggerInfo = TriggerHandlerNewProcedures.updatePaused(databaseName, name, true);
-        return Stream.ofNullable(triggerInfo);
+            final TriggerInfo triggerInfo = TriggerHandlerNewProcedures.updatePaused(databaseName, name, true, tx);
+            return Stream.ofNullable(triggerInfo);
+        });
     }
 
     // TODO - change with @SystemOnlyProcedure
@@ -118,10 +128,12 @@ public class TriggerNewProcedures {
     @Procedure(name = "apoc.trigger.start", mode = Mode.WRITE)
     @Description("Eventually restarts the given paused trigger.")
     public Stream<TriggerInfo> start(@Name("databaseName") String databaseName, @Name("name")String name) {
-        checkInSystemWriter();
-        
-        final TriggerInfo triggerInfo = TriggerHandlerNewProcedures.updatePaused(databaseName, name, false);
-        return Stream.ofNullable(triggerInfo);
+        return withTransaction(tx -> {
+            checkInSystemWriter(tx);
+
+            final TriggerInfo triggerInfo = TriggerHandlerNewProcedures.updatePaused(databaseName, name, false, tx);
+            return Stream.ofNullable(triggerInfo);
+        });
     }
 
     // TODO - change with @SystemOnlyProcedure
@@ -133,5 +145,14 @@ public class TriggerNewProcedures {
         checkInSystem();
 
         return TriggerHandlerNewProcedures.getTriggerNodesList(databaseName, tx);
+    }
+
+
+    public <T> T withTransaction(Function<Transaction, T> action) {
+        try (Transaction tx = db.beginTx()) {
+            T result = action.apply(tx);
+            tx.commit();
+            return result;
+        }
     }
 }


### PR DESCRIPTION
The ideal solution I suppose is to use `@Context public Transaction tx`, which calls `ProcedureTransactionImpl`.

But with both this and `@Context publicGraphDatabaseAPI` [which calls ProcedureGraphDatabaseAPI] via `db.beginTx()`,

I receive the following error if I login with an user with role `admin` 
(both with the embedded db and with an enterprise instance):
```
Creating new node label on database 'system' is not allowed for user '' 
with FULL overridden by READ overridden by READ. See GRANT CREATE NEW NODE LABEL ON DATABASE system
```

Btw, even trying to explicit `GRANT CREATE NEW NODE LABEL ON DATABASE system TO admin` gives the same result.

I also tried changing `mode = Mode.WRITE` to `Mode.DBMS` but it doesn't change anything.

I think the above one might be a bug, or so, not APOC related.

---

The only working way is to use `@Context public GraphDatabaseAPI`, which calls `GraphDatabaseFacade`.









