### PR TITLE
[4cnpX39y] Bump mockserver-netty version and org.apache.arrow version

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     implementation group: 'com.opencsv', name: 'opencsv', version: '5.7.1'
     implementation group: 'org.roaringbitmap', name: 'RoaringBitmap', version: '0.7.17'
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
-    implementation group: 'org.apache.arrow', name: 'arrow-vector', version: '7.0.0', {
+    implementation group: 'org.apache.arrow', name: 'arrow-vector', version: '10.0.1', {
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
@@ -88,7 +88,7 @@ dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.348'
-    testImplementation group: 'org.mock-server', name: 'mockserver-netty', version: '5.13.0'
+    testImplementation group: 'org.mock-server', name: 'mockserver-netty', version: '5.15.0'
     testImplementation group: 'com.github.adejanovski', name: 'cassandra-jdbc-wrapper', version: '3.1.0'
     testImplementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: '2.13.2'
 

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -41,8 +41,8 @@ dependencies {
     api group: 'org.testcontainers', name: 'postgresql', version: testContainersVersion
     api group: 'org.testcontainers', name: 'cassandra', version: testContainersVersion
     api group: 'org.testcontainers', name: 'localstack', version: testContainersVersion
-    api group: 'org.apache.arrow', name: 'arrow-vector', version: '7.0.0'
-    api group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '7.0.0'
+    api group: 'org.apache.arrow', name: 'arrow-vector', version: '10.0.1'
+    api group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '10.0.1'
 
     implementation project(":common")
     implementation group: 'org.neo4j', name: 'neo4j-common', version: neo4jVersionEffective, classifier: "tests"


### PR DESCRIPTION
Bumps versions to fix vulnerabilities (no CVE present)