### PR TITLE
[mIPA5H7K] Avoids double DNS lookup in the load methods

### DIFF
--- a/common/src/main/java/apoc/ApocConfig.java
+++ b/common/src/main/java/apoc/ApocConfig.java
@@ -56,6 +56,7 @@ public class ApocConfig extends LifecycleAdapter {
     public static final String APOC_CONFIG_JOBS_QUEUE_SIZE = "apoc.jobs.queue.size";
     public static final String APOC_CONFIG_INITIALIZER = "apoc.initializer";
     public static final String LOAD_FROM_FILE_ERROR = "Import from files not enabled, please set apoc.import.file.enabled=true in your apoc.conf";
+    private static final WebURLAccessRule webAccessRule = new WebURLAccessRule();
 
     // These were earlier added via the Neo4j config using the ApocSettings.java class
     private static final Map<String,Object> configDefaultValues =
@@ -221,11 +222,13 @@ public class ApocConfig extends LifecycleAdapter {
         }
     }
 
-    private void checkAllowedUrl(String url) throws IOException {
+    public URL checkAllowedUrlAndPinToIP(String url) throws IOException {
         try {
+            URL parsedUrl = new URL(url);
             if (blockedIpRanges != null && !blockedIpRanges.isEmpty()) {
-                URL parsedUrl = new URL(url);
-                WebURLAccessRule.checkNotBlocked(parsedUrl, blockedIpRanges);
+                return webAccessRule.checkNotBlockedAndPinToIP(parsedUrl, blockedIpRanges);
+            } else {
+                return parsedUrl;
             }
         } catch (Exception e) {
             throw new IOException(e);
@@ -236,7 +239,7 @@ public class ApocConfig extends LifecycleAdapter {
         if (isFile(url)) {
             isImportFileEnabled();
         } else {
-            checkAllowedUrl(url);
+            checkAllowedUrlAndPinToIP(url);
         }
     }
 

--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -270,8 +270,7 @@ public class Util {
         }
     }
 
-    public static URLConnection openUrlConnection(String url, Map<String, Object> headers) throws IOException {
-        URL src = new URL(url);
+    public static URLConnection openUrlConnection(URL src, Map<String, Object> headers) throws IOException {
         URLConnection con = src.openConnection();
         con.setRequestProperty("User-Agent", "APOC Procedures for Neo4j");
         if (con instanceof HttpURLConnection) {
@@ -372,8 +371,8 @@ public class Util {
     }
 
     public static StreamConnection readHttpInputStream(String urlAddress, Map<String, Object> headers, String payload, int redirectLimit) throws IOException {
-        ApocConfig.apocConfig().checkReadAllowed(urlAddress);
-        URLConnection con = openUrlConnection(urlAddress, headers);
+        URL url = ApocConfig.apocConfig().checkAllowedUrlAndPinToIP(urlAddress);
+        URLConnection con = openUrlConnection(url, headers);
         writePayload(con, payload);
         String newUrl = handleRedirect(con, urlAddress);
         if (newUrl != null && !urlAddress.equals(newUrl)) {


### PR DESCRIPTION
Depends on changes that need to go in the dbms.

Avoids an extra DNS resolve by replacing the domain with the resolved ip address.
