### PR TITLE
[NOID] Uses big heap size for running the tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx4G


### PR DESCRIPTION
## What
Uses big heap size in apoc tests to avoid exhausting it
## Why
Because we are seeing some consistent redness lately in the CI tests