### PR TITLE
[NOID] Fix wrong throttle config in Geocode.SupplierWithKey

### DIFF
--- a/core/src/main/java/apoc/spatial/Geocode.java
+++ b/core/src/main/java/apoc/spatial/Geocode.java
@@ -97,7 +97,7 @@ public class Geocode {
             urlTemplate = urlTemplate.replace("KEY", key);
             urlTemplateReverse = urlTemplateReverse.replace("KEY", key);
 
-            this.throttler = new Throttler(terminationGuard, apocConfig().getInt(configKey("throttle"), (int) Throttler.DEFAULT_THROTTLE));
+            this.throttler = new Throttler(terminationGuard, config.getInt(configKey("throttle"), (int) Throttler.DEFAULT_THROTTLE));
         }
 
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
Changed "throttle" configuration by using `config` (like the above values) instead of `apocConfig()`.

I cannot add a non-mocked test to check the change in junit,
because e.g. an opencage api key would be needed to run the query successfully.