### PR TITLE
[bJ4pn0Bj] PeriodicTest.testTerminateCommit is flaky

### DIFF
--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -171,7 +171,7 @@ public class PeriodicTest {
     @Ignore
     @Test
     public void testTerminateCommit() {
-        PeriodicTestUtils.testTerminatePeriodicQuery(db, "CALL apoc.periodic.commit('UNWIND range(0,1000) as id WITH id CREATE (n:Foo {id: id}) RETURN n limit 1000', {})");
+        PeriodicTestUtils.testTerminatePeriodicQuery(db, "CALL apoc.periodic.commit('UNWIND range(0,1000) as id WITH id CREATE (n:Foo {id: id}) WITH n limit 1000 RETURN COUNT(n)', {})");
     }
 
     @Test

--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -7,7 +7,6 @@ import apoc.util.TestUtil;
 import apoc.util.collection.Iterators;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.common.DependencyResolver;
@@ -168,7 +167,6 @@ public class PeriodicTest {
 
     }
 
-    @Ignore
     @Test
     public void testTerminateCommit() {
         PeriodicTestUtils.testTerminatePeriodicQuery(db, "CALL apoc.periodic.commit('UNWIND range(0,1000) as id WITH id CREATE (n:Foo {id: id}) WITH n limit 1000 RETURN COUNT(n)', {})");

--- a/test-utils/src/main/java/apoc/periodic/PeriodicTestUtils.java
+++ b/test-utils/src/main/java/apoc/periodic/PeriodicTestUtils.java
@@ -10,9 +10,7 @@ import org.neo4j.test.rule.DbmsRule;
 
 import java.util.Map;
 
-import static apoc.util.TestUtil.testResult;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
 
 public class PeriodicTestUtils {
     public static void killPeriodicQueryAsync(DbmsRule db) {
@@ -52,7 +50,7 @@ public class PeriodicTestUtils {
                     }),
                 (value) -> value, 15L, TimeUnit.SECONDS);
         } catch(Exception tfe) {
-            assertEquals(tfe.getMessage(),true, tfe.getMessage().contains("terminated"));
+            assertTrue(tfe.getMessage(), tfe.getMessage().contains("terminated"));
         }
     }
 }


### PR DESCRIPTION
I didn't notice it at first glance because locally it works even without the fix.

However the inner query was wrong because it returned a node, instead it is supposed to return a long.

My guess is that it's a timing problem, because if for example we remove the `limit 1000` the query fails almost immediately,
while with `return n` instead of `return count(n)` it fails after a while.

So probably doing `markForTermination()` almost at the same time as it fails causes the flaky assertion error.