### PR TITLE
[F61iNGQX] Removes parallel execution in TeamCity

### DIFF
--- a/.github/actions/test-gradle-project/action.yaml
+++ b/.github/actions/test-gradle-project/action.yaml
@@ -12,7 +12,7 @@ runs:
     - uses: ./.github/actions/setup-gradle-cache
     - name: Run tests
       shell: bash
-      run: ./gradlew ${{inputs.project-name}}:test
+      run: ./gradlew ${{inputs.project-name}}:test --parallel
     - name: Archive test results
       uses: actions/upload-artifact@v3
       if: always()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
-org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx5G -XX:MaxMetaspaceSize=256m


### PR DESCRIPTION
Keeps it in GitHub Actions.

## Why
Because TeamCity seems to not be very happy with it at the minute. Probably because all projects get executed at the same time, rather than the parallelism been intra-project, like in GitHub Actions