### PR TITLE
[NOID] Fix error message for apoc.schema.nodes/relationships with include and exclude confs both valuated

### DIFF
--- a/core/src/main/java/apoc/schema/SchemaConfig.java
+++ b/core/src/main/java/apoc/schema/SchemaConfig.java
@@ -7,11 +7,15 @@ import java.util.*;
  * @since 17.12.18
  */
 public class SchemaConfig {
-
-    private Set<String> labels;
-    private Set<String> excludeLabels;
-    private Set<String> relationships;
-    private Set<String> excludeRelationships;
+    private static final String LABELS_KEY = "labels";
+    private static final String EXCLUDE_LABELS_KEY = "excludeLabels";
+    private static final String RELATIONSHIPS_KEY = "relationships";
+    private static final String EXCLUDE_RELATIONSHIPS_KEY = "excludeRelationships";
+    
+    private final Set<String> labels;
+    private final Set<String> excludeLabels;
+    private final Set<String> relationships;
+    private final Set<String> excludeRelationships;
 
     public Set<String> getLabels() {
         return labels;
@@ -31,16 +35,18 @@ public class SchemaConfig {
 
     public SchemaConfig(Map<String,Object> config) {
         config = config != null ? config : Collections.emptyMap();
-        this.labels = new HashSet<>((Collection<String>)config.getOrDefault("labels", Collections.EMPTY_SET));
-        this.excludeLabels = new HashSet<>((Collection<String>) config.getOrDefault("excludeLabels", Collections.EMPTY_SET));
-        validateParameters(this.labels, this.excludeLabels, "labels");
-        this.relationships = new HashSet<>((Collection<String>)config.getOrDefault("relationships", Collections.EMPTY_SET));
-        this.excludeRelationships = new HashSet<>((Collection<String>)config.getOrDefault("excludeRelationships", Collections.EMPTY_SET));
-        validateParameters(this.relationships, this.excludeRelationships, "relationships");
+        this.labels = new HashSet<>((Collection<String>)config.getOrDefault(LABELS_KEY, Collections.EMPTY_SET));
+        this.excludeLabels = new HashSet<>((Collection<String>) config.getOrDefault(EXCLUDE_LABELS_KEY, Collections.EMPTY_SET));
+        validateParameters(this.labels, this.excludeLabels, LABELS_KEY, EXCLUDE_LABELS_KEY);
+        this.relationships = new HashSet<>((Collection<String>)config.getOrDefault(RELATIONSHIPS_KEY, Collections.EMPTY_SET));
+        this.excludeRelationships = new HashSet<>((Collection<String>)config.getOrDefault(EXCLUDE_RELATIONSHIPS_KEY, Collections.EMPTY_SET));
+        validateParameters(this.relationships, this.excludeRelationships, RELATIONSHIPS_KEY, EXCLUDE_RELATIONSHIPS_KEY);
     }
 
-    private void validateParameters(Set<String> include, Set<String> exclude, String parameterType){
+    private void validateParameters(Set<String> include, Set<String> exclude, String includeParameterType, String excludeParameterType){
         if(!include.isEmpty() && !exclude.isEmpty())
-            throw new IllegalArgumentException(String.format("Parameters %s and exclude%s are both valuated. Please check parameters and valuate only one.", parameterType, parameterType));
+            throw new IllegalArgumentException( String.format("Parameters %s and %s are both valuated. Please check parameters and valuate only one.", 
+                    includeParameterType, 
+                    excludeParameterType) );
     }
 }

--- a/core/src/test/java/apoc/schema/SchemasTest.java
+++ b/core/src/test/java/apoc/schema/SchemasTest.java
@@ -754,7 +754,7 @@ public class SchemasTest {
         QueryExecutionException e = Assert.assertThrows(QueryExecutionException.class,
                 () ->  testResult(db, "CALL apoc.schema.nodes({labels:['Foo', 'Person', 'Bar'], excludeLabels:['Bar']})", (result) -> {})
         );
-        TestCase.assertTrue(e.getMessage().contains("Parameters labels and excludelabels are both valuated. Please check parameters and valuate only one."));
+        TestCase.assertTrue(e.getMessage().contains("Parameters labels and excludeLabels are both valuated. Please check parameters and valuate only one."));
     }
 
     @Test
@@ -773,7 +773,7 @@ public class SchemasTest {
         QueryExecutionException e = Assert.assertThrows(QueryExecutionException.class,
                 () ->  testResult(db, "CALL apoc.schema.relationships({relationships:['LIKED'], excludeRelationships:['SINCE']})", (result) -> {})
         );
-        TestCase.assertTrue(e.getMessage().contains("Parameters relationships and excluderelationships are both valuated. Please check parameters and valuate only one."));
+        TestCase.assertTrue(e.getMessage().contains("Parameters relationships and excludeRelationships are both valuated. Please check parameters and valuate only one."));
     }
 
     @Test

--- a/it/src/test/java/apoc/it/core/SchemasEnterpriseFeaturesTest.java
+++ b/it/src/test/java/apoc/it/core/SchemasEnterpriseFeaturesTest.java
@@ -612,7 +612,7 @@ public class SchemasEnterpriseFeaturesTest {
         ClientException e = Assert.assertThrows(ClientException.class,
                 () ->  testResult(session, "CALL apoc.schema.relationships({relationships:['LIKED'], excludeRelationships:['SINCE']})", (result) -> {})
         );
-        TestCase.assertTrue(e.getMessage().contains("Parameters relationships and excluderelationships are both valuated. Please check parameters and valuate only one."));
+        TestCase.assertTrue(e.getMessage().contains("Parameters relationships and excludeRelationships are both valuated. Please check parameters and valuate only one."));
 
         session.writeTransaction(tx -> {
             tx.run("DROP CONSTRAINT like_con");


### PR DESCRIPTION
Since the config keys are case sensitive, these error messages are wrong:
```
Parameters relationships and excluderelationships are both valuated. 

Parameters labels and excludelabels are both valuated.
```