### PR TITLE
[F61iNGQX] Executes integration tests sequentially

### DIFF
--- a/it/build.gradle
+++ b/it/build.gradle
@@ -1,5 +1,9 @@
 description = 'APOC :: Integration Tests Module'
 
+test {
+    maxParallelForks = 1
+}
+
 dependencies {
     testImplementation project(':common')
     testImplementation project(':core')


### PR DESCRIPTION
## Why
Because these tests spin up a lot of docker containers, especially in TeamCity, which can lead to flakiness