### PR TITLE
[Bc2lkk3N] Fixed testImportCsvTerminate and added TerminationGuard to apoc.import.csv

### DIFF
--- a/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
+++ b/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
@@ -12,6 +12,7 @@ import com.opencsv.CSVReader;
 import com.opencsv.CSVReaderBuilder;
 import org.neo4j.graphdb.*;
 import org.neo4j.logging.Log;
+import org.neo4j.procedure.TerminationGuard;
 
 import java.io.IOException;
 import java.util.*;
@@ -25,14 +26,17 @@ public class CsvEntityLoader {
     private final ProgressReporter reporter;
     private final Log log;
 
+    private final TerminationGuard terminationGuard;
+
     /**
      * @param clc configuration object
      * @param reporter
      */
-    public CsvEntityLoader(CsvLoaderConfig clc, ProgressReporter reporter, Log log) {
+    public CsvEntityLoader(CsvLoaderConfig clc, ProgressReporter reporter, Log log, TerminationGuard terminationGuard) {
         this.clc = clc;
         this.reporter = reporter;
         this.log = log;
+        this.terminationGuard = terminationGuard;
     }
 
     /**
@@ -82,6 +86,7 @@ public class CsvEntityLoader {
             BatchTransaction btx = new BatchTransaction(db, clc.getBatchSize(), reporter);
             try {
                 csv.forEach(line -> {
+                    terminationGuard.check();
                     lineNo.getAndIncrement();
 
                     final EnumSet<Results> results = EnumSet.of(Results.map);
@@ -196,6 +201,7 @@ public class CsvEntityLoader {
                 BatchTransaction btx = new BatchTransaction(db, clc.getBatchSize(), reporter);
                 try {
                     csv.forEach(line -> {
+                        terminationGuard.check();
                         lineNo.getAndIncrement();
 
                         final EnumSet<Results> results = EnumSet.of(Results.map);

--- a/core/src/main/java/apoc/export/csv/ImportCsv.java
+++ b/core/src/main/java/apoc/export/csv/ImportCsv.java
@@ -23,6 +23,9 @@ public class ImportCsv {
     @Context
     public Log log;
 
+    @Context
+    public TerminationGuard terminationGuard;
+
     @Procedure(name = "apoc.import.csv", mode = Mode.SCHEMA)
     @Description("Imports nodes and relationships with the given labels and types from the provided CSV file.")
     public Stream<ProgressInfo> importCsv(
@@ -41,7 +44,7 @@ public class ImportCsv {
                     }
                     final CsvLoaderConfig clc = CsvLoaderConfig.from(config);
                     final ProgressReporter reporter = new ProgressReporter(null, null, new ProgressInfo(file, source, "csv"));
-                    final CsvEntityLoader loader = new CsvEntityLoader(clc, reporter, log);
+                    final CsvEntityLoader loader = new CsvEntityLoader(clc, reporter, log, terminationGuard);
 
                     final Map<String, Map<String, String>> idMapping = new HashMap<>();
                     for (Map<String, Object> node : nodes) {

--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -41,6 +41,9 @@ public class GraphRefactoring {
     @Context
     public Pools pools;
 
+    @Context
+    public TerminationGuard terminationGuard;
+
     private Stream<NodeRefactorResult> doCloneNodes(@Name("nodes") List<Node> nodes, @Name("withRelationships") boolean withRelationships, List<String> skipProperties) {
         if (nodes == null) return Stream.empty();
         return nodes.stream().map(node -> Util.rebind(tx, node)).map(node -> {
@@ -199,6 +202,7 @@ public class GraphRefactoring {
 
         // clone nodes and populate copy map
         for (Node node : nodes) {
+            terminationGuard.check();
             if (node == null || standinMap.containsKey(node)) continue;
             // standinNodes will NOT be cloned
 
@@ -223,6 +227,8 @@ public class GraphRefactoring {
 
         // clone relationships, will be between cloned nodes and/or standins
         for (Relationship rel : rels) {
+            terminationGuard.check();
+
             if (rel == null) continue;
 
             Node oldStart = rel.getStartNode();

--- a/core/src/test/java/apoc/cypher/CypherTest.java
+++ b/core/src/test/java/apoc/cypher/CypherTest.java
@@ -185,7 +185,7 @@ public class CypherTest {
         TestUtil.testCall(db, query,
                 Map.of("innerQuery", innerLongQuery),
                 row -> assertEquals(Map.of("0", 0L), row.get("value")));
-        
+
         lastTransactionChecks(db, query, timeBefore);
     }
 

--- a/core/src/test/java/apoc/export/BigGraphTest.java
+++ b/core/src/test/java/apoc/export/BigGraphTest.java
@@ -8,6 +8,7 @@ import apoc.export.json.ExportJson;
 import apoc.export.json.ImportJson;
 import apoc.graph.Graphs;
 import apoc.meta.Meta;
+import apoc.periodic.PeriodicTestUtils;
 import apoc.refactor.GraphRefactoring;
 import apoc.refactor.rename.Rename;
 import apoc.util.TestUtil;
@@ -29,7 +30,8 @@ import java.util.stream.IntStream;
 import static apoc.ApocConfig.APOC_EXPORT_FILE_ENABLED;
 import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;
-import static apoc.util.TransactionTestUtil.checkTerminationGuard;
+import static apoc.util.TransactionTestUtil.*;
+import static java.util.Collections.emptyMap;
 import static org.neo4j.configuration.GraphDatabaseSettings.TransactionStateMemoryAllocation.OFF_HEAP;
 import static org.neo4j.configuration.SettingValueParsers.BYTES;
 
@@ -79,7 +81,11 @@ public class BigGraphTest {
 
     @Test
     public void testTerminateRenameNodeProp() {
-        checkTerminationGuard(db, "CALL apoc.refactor.rename.nodeProperty('name', 'nameTwo')");
+        // this procedure leverage the apoc.periodic.iterate, so we should check in the same way
+        String innerLongQuery = "match (n) where n.`name` IS NOT NULL return n";
+        String query = "CALL apoc.refactor.rename.nodeProperty('name', 'nameTwo')";
+
+        PeriodicTestUtils.testTerminateWithCommand(db, query, innerLongQuery);
     }
 
     @Test
@@ -88,14 +94,20 @@ public class BigGraphTest {
     }
 
     @Test
-    public void testTerminateRefactorProcs() {
+    public void testTerminateRefactorCloneNodes() {
         List<Node> nodes = db.executeTransactionally("MATCH (n:Person) RETURN collect(n) as nodes", Collections.emptyMap(),
                 r -> r.<List<Node>>columnAs("nodes").next());
         
-        checkTerminationGuard(db, "CALL apoc.refactor.cloneNodes($nodes)", 
+        checkTerminationGuard(db, "CALL apoc.refactor.cloneNodes($nodes)",
                 Map.of("nodes", nodes));
+    }
+
+    @Test
+    public void testTerminateRefactorCloneSubgraph() {
+        List<Node> nodes = db.executeTransactionally("MATCH (n:Person) RETURN collect(n) as nodes", Collections.emptyMap(),
+                r -> r.<List<Node>>columnAs("nodes").next());
 
         checkTerminationGuard(db, "CALL apoc.refactor.cloneSubgraph($nodes)",
-                Map.of("nodes", nodes));
+                Map.of("nodes", Util.rebind(nodes, db.beginTx())));
     }
 }

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -191,9 +191,13 @@ public class ImportCsvTest {
     
     @Test
     public void testImportCsvTerminate() {
-        checkTerminationGuard(db, "CALL apoc.import.csv([{fileName: $nodeFile, labels: ['Person']}], [], $config)",
-                map("nodeFile", "file:/largeFile.csv",
-                        "config", map("batchSize", 100L)));
+        // multiple files
+        String files = Stream.of( "Person", "Movie", "Foo", "Bar", "Baz")
+                .map(i -> "{fileName: $nodeFile, labels: ['" + i + "']}")
+                .collect(Collectors.joining(","));
+        checkTerminationGuard(db, "CALL apoc.import.csv([" + files +"], [], {})",
+                    map("nodeFile", "file:/largeFile.csv",
+                            "config", map("batchSize", 100L)));
     }
 
     @Test

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -192,7 +192,7 @@ public class ImportCsvTest {
     @Test
     public void testImportCsvTerminate() {
         // multiple files
-        String files = Stream.of( "Person", "Movie", "Foo", "Bar", "Baz")
+        String files = Stream.of( "Person", "Movie", "Foo", "Bar", "Baz", "Aaa", "Bbb", "Ccc")
                 .map(i -> "{fileName: $nodeFile, labels: ['" + i + "']}")
                 .collect(Collectors.joining(","));
         checkTerminationGuard(db, "CALL apoc.import.csv([" + files +"], [], {})",

--- a/core/src/test/java/apoc/export/json/ImportJsonTest.java
+++ b/core/src/test/java/apoc/export/json/ImportJsonTest.java
@@ -52,6 +52,7 @@ import static org.junit.Assert.fail;
 
 
 public class ImportJsonTest {
+    public static String LARGE_REMOTE_FILE = "https://devrel-data-science.s3.us-east-2.amazonaws.com/twitch_all.json";
 
     private static final long NODES_BIG_JSON = 16L;
     private static final long RELS_BIG_JSON = 4L;
@@ -192,11 +193,9 @@ public class ImportJsonTest {
 
         createConstraints(List.of("Stream", "User", "Game", "Team", "Language"));
 
-        String filename = "https://devrel-data-science.s3.us-east-2.amazonaws.com/twitch_all.json";
-
         final String query = "CALL apoc.import.json($file)";
 
-        TransactionTestUtil.checkTerminationGuard(db, query, map("file", filename));
+        TransactionTestUtil.checkTerminationGuard(db, query, map("file", LARGE_REMOTE_FILE));
     }
 
     @Test
@@ -305,12 +304,6 @@ public class ImportJsonTest {
                 (r) -> assertionsAllJsonProgressInfo(r, true));
 
         assertionsAllJsonDbResult();
-    }
-
-    @Test
-    public void shouldTerminateImportJson()  {
-        createConstraints(List.of("Movie", "Other", "Person"));
-        checkTerminationGuard(db, "CALL apoc.import.json('testTerminate.json',{})");
     }
 
     private void assertionsAllJsonProgressInfo(Map<String, Object> r, boolean isBinary) {

--- a/core/src/test/java/apoc/load/LoadJsonTest.java
+++ b/core/src/test/java/apoc/load/LoadJsonTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static apoc.ApocConfig.*;
+import static apoc.export.json.ImportJsonTest.LARGE_REMOTE_FILE;
 import static apoc.util.BinaryTestUtil.fileToBinary;
 import static apoc.util.CompressionConfig.COMPRESSION;
 import static apoc.convert.ConvertJsonTest.EXPECTED_AS_PATH_LIST;
@@ -422,8 +423,8 @@ public class LoadJsonTest {
 
     @Test
     public void shouldTerminateLoadJson()  {
-        URL url = ClassLoader.getSystemResource("exportJSON/testTerminate.json");
         checkTerminationGuard(db, "CALL apoc.load.json($file)",
-                Map.of("file", url.toString()));
+                Map.of("file", LARGE_REMOTE_FILE)
+        );
     }
 }

--- a/core/src/test/java/apoc/load/XmlTest.java
+++ b/core/src/test/java/apoc/load/XmlTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseInternalSettings;
+import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.test.rule.DbmsRule;
@@ -40,12 +41,17 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.neo4j.configuration.GraphDatabaseSettings.TransactionStateMemoryAllocation.OFF_HEAP;
+import static org.neo4j.configuration.SettingValueParsers.BYTES;
 
 public class XmlTest {
     public static final String FILE_SHORTENED = "src/test/resources/xml/humboldt_soemmering01_1791.TEI-P5-shortened.xml";
     
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(GraphDatabaseSettings.memory_tracking, true)
+            .withSetting(GraphDatabaseSettings.tx_state_memory_allocation, OFF_HEAP)
+            .withSetting(GraphDatabaseSettings.tx_state_max_off_heap_memory, BYTES.parse("1G"))
             .withSetting(GraphDatabaseInternalSettings.cypher_ip_blocklist, List.of(new IPAddressString("127.0.0.0/8")));
 
     @Before
@@ -560,6 +566,6 @@ public class XmlTest {
     @Test
     public void testTerminateImportXml() {
         final String file = ClassLoader.getSystemResource("largeFile.graphml").toString();
-        TransactionTestUtil.checkTerminationGuard(db, "call apoc.import.xml($file)", Map.of("file", file));
+        TransactionTestUtil.checkTerminationGuard(db,  3L, "call apoc.import.xml($file)", Map.of("file", file));
     }
 }

--- a/test-utils/src/main/java/apoc/periodic/PeriodicTestUtils.java
+++ b/test-utils/src/main/java/apoc/periodic/PeriodicTestUtils.java
@@ -1,6 +1,7 @@
 package apoc.periodic;
 
 import apoc.util.TransactionTestUtil;
+import apoc.util.Util;
 import apoc.util.collection.Iterators;
 import java.util.concurrent.TimeUnit;
 import org.neo4j.common.DependencyResolver;
@@ -58,7 +59,7 @@ public class PeriodicTestUtils {
                 db.executeTransactionally(periodicQuery, Map.of(),
                     result -> {
                         Map<String, Object> row = Iterators.single(result);
-                        return (boolean) row.get("wasTerminated");
+                        return Util.toBoolean(row.get("wasTerminated"));
                     }),
                 (value) -> value, 15L, TimeUnit.SECONDS);
         } catch(Exception tfe) {

--- a/test-utils/src/main/java/apoc/util/TransactionTestUtil.java
+++ b/test-utils/src/main/java/apoc/util/TransactionTestUtil.java
@@ -64,6 +64,7 @@ public class TransactionTestUtil {
                 (msg) -> Stream.of("terminated", "failed", "closed").anyMatch(msg::contains)
         );
 
+        // check that the transaction is not present and the time is less than `timeout`
         lastTransactionChecks(db, timeout, query, timeTransactionTerminated);
     }
 
@@ -76,7 +77,7 @@ public class TransactionTestUtil {
             String s = transaction.execute(query, params).resultAsString();
             System.out.println("s = " + s);
             transaction.commit();
-            fail("Should fail because of transaction timeout");
+            fail("Should fail because of TransactionFailureException");
         } catch (Exception e) {
             final String msg = e.getMessage();
             assertTrue( "Actual message is: " + msg,

--- a/test-utils/src/main/java/apoc/util/TransactionTestUtil.java
+++ b/test-utils/src/main/java/apoc/util/TransactionTestUtil.java
@@ -36,19 +36,27 @@ public class TransactionTestUtil {
     }
 
     public static void checkTerminationGuard(GraphDatabaseService db, long timeout, String query, Map<String, Object> params) {
+        checkTerminationGuard(db, timeout, query, params, query);
+    }
+
+    public static void checkTerminationGuard(GraphDatabaseService db, long timeout, String query, Map<String, Object> params, String innerQuery) {
         // Check that without `TERMINATE TRANSACTION` the transaction fails due to timeout exception
         //  in order to prevent possible false positive due to a query of too short a duration
         //  which, together with terminate transaction, would retrieve a false
         // In fact, even if the procedure is not correctly terminated when the transaction is finished,
         //  the procedure would return a `transaction terminated` even though it would actually complete the whole procedure anyway.
+        long timeTransactionTimeout = System.currentTimeMillis();
         executeTransactionWithTimeout(db, timeout, query, params,
                 (msg) -> msg.contains("The transaction has not completed within the specified timeout"));
 
+        long secondPassed = getSecondPassed(timeTransactionTimeout);
+        checkTransactionTimeoutTime(timeout, secondPassed);
 
-        terminateTransactionAsync(db, timeout, query);
+        // in a new thread, terminate the following transaction
+        terminateTransactionAsync(db, timeout, innerQuery);
 
         // check that the procedure/function fails with TransactionFailureException when transaction is terminated
-        long timePassed = System.currentTimeMillis();
+        long timeTransactionTerminated = System.currentTimeMillis();
         // Usually returns org.neo4j.kernel.api.exceptions.Transaction.Status.Terminated,
         //  but sometimes returns a Status.TransactionMarkedAsFailed
         //  or `The transaction has been closed.`
@@ -56,7 +64,7 @@ public class TransactionTestUtil {
                 (msg) -> Stream.of("terminated", "failed", "closed").anyMatch(msg::contains)
         );
 
-        lastTransactionChecks(db, timeout, query, timePassed);
+        lastTransactionChecks(db, timeout, query, timeTransactionTerminated);
     }
 
     private static void executeTransactionWithTimeout(GraphDatabaseService db,
@@ -65,7 +73,8 @@ public class TransactionTestUtil {
                                                       Map<String, Object> params,
                                                       Function<String, Boolean> assertionException) {
         try(Transaction transaction = db.beginTx(timeout, TimeUnit.SECONDS)) {
-            transaction.execute(query, params).resultAsString();
+            String s = transaction.execute(query, params).resultAsString();
+            System.out.println("s = " + s);
             transaction.commit();
             fail("Should fail because of transaction timeout");
         } catch (Exception e) {
@@ -76,7 +85,7 @@ public class TransactionTestUtil {
     }
 
     public static void lastTransactionChecks(GraphDatabaseService db, long timeout, String query, long timePassed) {
-        checkTransactionTime(timeout, timePassed);
+        checkTransactionTerminatedTime(timeout, timePassed);
         checkTransactionNotInList(db, query);
     }
 
@@ -84,10 +93,20 @@ public class TransactionTestUtil {
         lastTransactionChecks(db, DEFAULT_TIMEOUT, query, timeBefore);
     }
 
-    private static void checkTransactionTime(long timeout, long timePassed) {
-        timePassed = (System.currentTimeMillis() - timePassed) / 1000;
+    private static void checkTransactionTerminatedTime(long timeout, long timePassed) {
+        timePassed = getSecondPassed(timePassed);
         assertTrue("The transaction hasn't been terminated before the timeout time, but after " + timePassed + " seconds",
                 timePassed <= timeout);
+    }
+
+    private static void checkTransactionTimeoutTime(long timeout, long timePassed) {
+        timePassed = getSecondPassed(timePassed);
+        assertTrue("The transaction hasn't been terminated after the timeout time, but before " + timePassed + " seconds",
+                timePassed > timeout);
+    }
+
+    private static long getSecondPassed(long timePassed) {
+        return (System.currentTimeMillis() - timePassed) / 1000;
     }
 
     public static void checkTransactionNotInList(GraphDatabaseService db, String query) {


### PR DESCRIPTION
- Added `TerminationGuard` to `apoc.import.csv`

---

The test didn't fail because it produced a false positive, 
since without the TerminationGuard, the procedure complete the whole procedure when the `TERMINATE TRANSACTION <procTransactionId>` is called, but despite this an `"Explicitly terminated by the user."` is eventually returned.

Therefore, with procedure duration less than the set `db.transaction.timeout`, 
both with and without the TerminationGuard, the test was green.
Apparently I didn't replicate it because, unlike gh actions and locally, 
with teamcity sometimes the procedure lasts more then `timeout` time.

So, I added an additional check to `checkTerminationGuard`, 
to verify that the procedure actually lasts longer than the timeout 
and I weighted the `testImportCsvTerminate`.

---

Not strictly card-related (to make the pr green):
- Added `TerminationGuard` to  `apoc.refactor.cloneSubgraph`


