### PR TITLE
[TOQo1n9M] Core part - apoc-hadoop dependency is conflicting 5.x (neo4j-contrib/neo4j-apoc-procedures#3450)

### DIFF
--- a/it/src/test/java/apoc/it/core/StartupTest.java
+++ b/it/src/test/java/apoc/it/core/StartupTest.java
@@ -1,5 +1,5 @@
 package apoc.it.core;
-import apoc.ApocSignaturesCore;
+import apoc.ApocSignatures;
 import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
 import apoc.util.TestUtil;
@@ -75,8 +75,8 @@ public class StartupTest {
                             .list(record -> record.get("name").asString());
 
 
-                    assertEquals(sorted(ApocSignaturesCore.PROCEDURES), procedureNames);
-                    assertEquals(sorted(ApocSignaturesCore.FUNCTIONS), functionNames);
+                    assertEquals(sorted(ApocSignatures.PROCEDURES), procedureNames);
+                    assertEquals(sorted(ApocSignatures.FUNCTIONS), functionNames);
                 }
 
                 neo4jContainer.close();

--- a/it/src/test/java/apoc/it/core/StartupTest.java
+++ b/it/src/test/java/apoc/it/core/StartupTest.java
@@ -1,5 +1,5 @@
 package apoc.it.core;
-import apoc.ApocSignatures;
+import apoc.ApocSignaturesCore;
 import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
 import apoc.util.TestUtil;
@@ -75,8 +75,8 @@ public class StartupTest {
                             .list(record -> record.get("name").asString());
 
 
-                    assertEquals(sorted(ApocSignatures.PROCEDURES), procedureNames);
-                    assertEquals(sorted(ApocSignatures.FUNCTIONS), functionNames);
+                    assertEquals(sorted(ApocSignaturesCore.PROCEDURES), procedureNames);
+                    assertEquals(sorted(ApocSignaturesCore.FUNCTIONS), functionNames);
                 }
 
                 neo4jContainer.close();

--- a/test-utils/src/main/java/apoc/util/TestContainerUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestContainerUtil.java
@@ -86,7 +86,6 @@ public class TestContainerUtil {
             dockerImage = neo4jCommunityDockerImageVersion;
         }
 
-        pluginsFolder = new File(baseDir, "build/plugins");
         try {
             FileUtils.deleteDirectory( pluginsFolder );
         } catch (IOException e) {


### PR DESCRIPTION
Cherry-pick (core part) of https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3450

Extended part: https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3454.

- Because of split, now we have 2 equivalent `apoc.ApocSignatures` which collect the list of procedures and functions, 
one for core and one for extended, so I added a `String projectPath` in order to create 2 different classes (`ApocSignaturesCore` and `ApocSignaturesExtended`).
- Created a `copyFilesToPlugin(..)` to be reused in Extended
- Changed baseDir, pluginsFolder and extendedDir to public, reusable in Ext. too