### PR TITLE
[madSHaLz] APOC triggers aren't updated after a user deletes a database

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise' : 'neo4j:5.8.0-enterprise',
+                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise' : 'neo4j:5.6.0-enterprise',
                 'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") : 'neo4j:5.8.0',
                 'coreDir': 'core'
 
@@ -128,6 +128,6 @@ subprojects {
 }
 
 ext {
-    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : "5.8.0"
+    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : "5.6.0"
     testContainersVersion = '1.17.6'
 }

--- a/common/src/main/java/apoc/ApocExtensionFactory.java
+++ b/common/src/main/java/apoc/ApocExtensionFactory.java
@@ -12,6 +12,7 @@ import org.neo4j.kernel.extension.context.ExtensionContext;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.kernel.monitoring.DatabaseEventListeners;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.internal.LogService;
 import org.neo4j.scheduler.JobScheduler;
@@ -43,6 +44,7 @@ public class ApocExtensionFactory extends ExtensionFactory<ApocExtensionFactory.
         AvailabilityGuard availabilityGuard();
         DatabaseManagementService databaseManagementService();
         ApocConfig apocConfig();
+        DatabaseEventListeners databaseEventListeners();
         @SuppressWarnings("unused") // used from extended
         GlobalProcedures globalProceduresRegistry();
         RegisterComponentFactory.RegisterComponentLifecycle registerComponentLifecycle();

--- a/core/src/main/java/apoc/CoreApocGlobalComponents.java
+++ b/core/src/main/java/apoc/CoreApocGlobalComponents.java
@@ -33,6 +33,10 @@ public class CoreApocGlobalComponents implements ApocGlobalComponents {
 
     @Override
     public Iterable<AvailabilityListener> getListeners(GraphDatabaseAPI db, ApocExtensionFactory.Dependencies dependencies) {
-        return Collections.singleton(new CypherInitializer(db, dependencies.log().getUserLog(CypherInitializer.class)));
+        return Collections.singleton(new CypherInitializer(db,
+                dependencies.log().getUserLog(CypherInitializer.class),
+                dependencies.databaseManagementService(),
+                dependencies.databaseEventListeners())
+        );
     }
 }

--- a/core/src/main/java/apoc/cypher/CypherInitializer.java
+++ b/core/src/main/java/apoc/cypher/CypherInitializer.java
@@ -1,35 +1,56 @@
 package apoc.cypher;
 
 import apoc.ApocConfig;
+import apoc.SystemLabels;
 import apoc.util.Util;
 import apoc.util.collection.Iterators;
 import apoc.version.Version;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.common.DependencyResolver;
+import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.dbms.api.DatabaseManagementService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.event.DatabaseEventContext;
+import org.neo4j.graphdb.event.DatabaseEventListener;
+import org.neo4j.kernel.api.procedure.GlobalProcedures;
 import org.neo4j.kernel.availability.AvailabilityListener;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.kernel.monitoring.DatabaseEventListeners;
 import org.neo4j.logging.Log;
 
 import java.util.Collection;
 
+import java.util.ConcurrentModificationException;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.BiConsumer;
+
+import static apoc.SystemPropertyKeys.database;
 
 public class CypherInitializer implements AvailabilityListener {
 
     private final GraphDatabaseAPI db;
     private final Log userLog;
     private final DependencyResolver dependencyResolver;
+    private final DatabaseManagementService databaseManagementService;
+    private final DatabaseEventListeners databaseEventListeners;
 
     /**
      * indicates the status of the initializer, to be used for tests to ensure initializer operations are already done
      */
     private volatile boolean finished = false;
 
-    public CypherInitializer(GraphDatabaseAPI db, Log userLog) {
+    public CypherInitializer(GraphDatabaseAPI db, Log userLog,
+                             DatabaseManagementService databaseManagementService,
+                             DatabaseEventListeners databaseEventListeners) {
         this.db = db;
         this.userLog = userLog;
+        this.databaseManagementService = databaseManagementService;
+        this.databaseEventListeners = databaseEventListeners;
         this.dependencyResolver = db.getDependencyResolver();
     }
 
@@ -58,9 +79,19 @@ public class CypherInitializer implements AvailabilityListener {
                     if (isVersionDifferent(neo4jVersion, apocVersion))
                     {
                         userLog.warn( "The apoc version (%s) and the Neo4j DBMS versions %s are incompatible. \n" +
-                                      "The two first numbers of both versions needs to be the same.",
-                                      apocVersion, neo4jVersion );
+                                        "The two first numbers of both versions needs to be the same.",
+                                apocVersion, neo4jVersion );
                     }
+                }
+
+                    // this block is already in system db, so we can directly execute system operation
+                    // for backward compatibility: clear system nodes at start-up if the corresponding database name doesn't exist
+                    // placed here instead of e.g. `ApocConfig` because at this point we are sure that all databases are recovered
+                    cleanUpSystemNodes();
+
+                    // create listener for each database
+                    databaseEventListeners.registerDatabaseEventListener(new SystemFunctionalityListener());
+
                 }
 
                 Configuration config = dependencyResolver.resolveDependency(ApocConfig.class).getConfig();
@@ -112,8 +143,78 @@ public class CypherInitializer implements AvailabilityListener {
         }
     }
 
+    private void awaitApocProceduresRegistered() {
+        while (!areProceduresRegistered("apoc")) {
+            Util.sleep(100);
+        }
+    }
+
+    private void awaitDbmsComponentsProcedureRegistered() {
+        while (!areProceduresRegistered("dbms.components")) {
+            Util.sleep(100);
+        }
+    }
+
+    private boolean areProceduresRegistered(String procStart) {
+        try {
+            return procs.getAllProcedures().stream().anyMatch(signature -> signature.name().toString().startsWith(procStart));
+        } catch (ConcurrentModificationException e) {
+            // if a CME happens (possible during procedure scanning)
+            // we return false and the caller will try again
+            return false;
+        }
+    }
+
     @Override
     public void unavailable() {
         // intentionally empty
+    }
+
+    private void cleanUpSystemNodes() {
+
+        List<String> databases = databaseManagementService.listDatabases();
+
+        forEachSystemLabel((tx, label) -> {
+                tx.findNodes(label).forEachRemaining(node -> {
+                    boolean dbNonExistent = node.hasProperty(database.name())
+                            && !databases.contains( (String) node.getProperty(database.name()) );
+                    if (dbNonExistent) {
+                        node.delete();
+                    }
+                });
+        });
+    }
+
+    private class SystemFunctionalityListener implements DatabaseEventListener {
+
+        @Override
+        public void databaseDrop(DatabaseEventContext eventContext) {
+
+            forEachSystemLabel((tx, label) -> {
+                tx.findNodes(label, database.name(), eventContext.getDatabaseName())
+                        .forEachRemaining(Node::delete);
+            });
+        }
+
+        @Override
+        public void databaseStart(DatabaseEventContext eventContext) {}
+
+        @Override
+        public void databaseShutdown(DatabaseEventContext eventContext) {}
+
+        @Override
+        public void databasePanic(DatabaseEventContext eventContext) {}
+
+        @Override
+        public void databaseCreate(DatabaseEventContext eventContext) {}
+    }
+
+    private void forEachSystemLabel(BiConsumer<Transaction, Label> consumer) {
+        try (Transaction tx = db.beginTx()) {
+            for (Label label: SystemLabels.values()) {
+                consumer.accept(tx, label);
+            }
+            tx.commit();
+        }
     }
 }

--- a/core/src/main/java/apoc/cypher/CypherInitializer.java
+++ b/core/src/main/java/apoc/cypher/CypherInitializer.java
@@ -8,14 +8,12 @@ import apoc.version.Version;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.common.DependencyResolver;
-import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.event.DatabaseEventContext;
 import org.neo4j.graphdb.event.DatabaseEventListener;
-import org.neo4j.kernel.api.procedure.GlobalProcedures;
 import org.neo4j.kernel.availability.AvailabilityListener;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.monitoring.DatabaseEventListeners;
@@ -23,8 +21,6 @@ import org.neo4j.logging.Log;
 
 import java.util.Collection;
 
-import java.util.ConcurrentModificationException;
-import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.BiConsumer;
@@ -79,20 +75,13 @@ public class CypherInitializer implements AvailabilityListener {
                     if (isVersionDifferent(neo4jVersion, apocVersion))
                     {
                         userLog.warn( "The apoc version (%s) and the Neo4j DBMS versions %s are incompatible. \n" +
-                                        "The two first numbers of both versions needs to be the same.",
-                                apocVersion, neo4jVersion );
+                                      "The two first numbers of both versions needs to be the same.",
+                                      apocVersion, neo4jVersion );
                     }
                 }
 
-                    // this block is already in system db, so we can directly execute system operation
-                    // for backward compatibility: clear system nodes at start-up if the corresponding database name doesn't exist
-                    // placed here instead of e.g. `ApocConfig` because at this point we are sure that all databases are recovered
-                    cleanUpSystemNodes();
-
-                    // create listener for each database
-                    databaseEventListeners.registerDatabaseEventListener(new SystemFunctionalityListener());
-
-                }
+                // create listener for each database
+                databaseEventListeners.registerDatabaseEventListener(new SystemFunctionalityListener());
 
                 Configuration config = dependencyResolver.resolveDependency(ApocConfig.class).getConfig();
                 for (String query : collectInitializers(config)) {
@@ -143,46 +132,9 @@ public class CypherInitializer implements AvailabilityListener {
         }
     }
 
-    private void awaitApocProceduresRegistered() {
-        while (!areProceduresRegistered("apoc")) {
-            Util.sleep(100);
-        }
-    }
-
-    private void awaitDbmsComponentsProcedureRegistered() {
-        while (!areProceduresRegistered("dbms.components")) {
-            Util.sleep(100);
-        }
-    }
-
-    private boolean areProceduresRegistered(String procStart) {
-        try {
-            return procs.getAllProcedures().stream().anyMatch(signature -> signature.name().toString().startsWith(procStart));
-        } catch (ConcurrentModificationException e) {
-            // if a CME happens (possible during procedure scanning)
-            // we return false and the caller will try again
-            return false;
-        }
-    }
-
     @Override
     public void unavailable() {
         // intentionally empty
-    }
-
-    private void cleanUpSystemNodes() {
-
-        List<String> databases = databaseManagementService.listDatabases();
-
-        forEachSystemLabel((tx, label) -> {
-                tx.findNodes(label).forEachRemaining(node -> {
-                    boolean dbNonExistent = node.hasProperty(database.name())
-                            && !databases.contains( (String) node.getProperty(database.name()) );
-                    if (dbNonExistent) {
-                        node.delete();
-                    }
-                });
-        });
     }
 
     private class SystemFunctionalityListener implements DatabaseEventListener {

--- a/core/src/test/java/apoc/trigger/TriggerRestartTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerRestartTest.java
@@ -1,10 +1,7 @@
 package apoc.trigger;
 
 import apoc.ApocConfig;
-import apoc.SystemLabels;
 import apoc.util.TestUtil;
-import apoc.util.Util;
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -13,28 +10,19 @@ import org.junit.rules.TemporaryFolder;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.TestDatabaseManagementServiceBuilder;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import static apoc.ApocConfig.SUN_JAVA_COMMAND;
-import static apoc.SystemLabels.ApocTrigger;
-import static apoc.SystemPropertyKeys.database;
-import static apoc.SystemPropertyKeys.name;
 import static apoc.trigger.TriggerTestUtil.TRIGGER_DEFAULT_REFRESH;
 import static apoc.trigger.TriggerTestUtil.awaitTriggerDiscovered;
 import static apoc.util.TestUtil.waitDbsAvailable;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class TriggerRestartTest {
 

--- a/it/src/test/java/apoc/it/core/TriggerEnterpriseFeaturesTest.java
+++ b/it/src/test/java/apoc/it/core/TriggerEnterpriseFeaturesTest.java
@@ -18,12 +18,14 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import static apoc.ApocConfig.APOC_CONFIG_INITIALIZER;
 import static apoc.ApocConfig.APOC_TRIGGER_ENABLED;
 import static apoc.trigger.TriggerHandler.TRIGGER_REFRESH;
 import static apoc.trigger.TriggerTestUtil.TIMEOUT;
 import static apoc.trigger.TriggerTestUtil.TRIGGER_DEFAULT_REFRESH;
 import static apoc.util.TestContainerUtil.createEnterpriseDB;
 import static apoc.util.TestContainerUtil.testCall;
+import static apoc.util.TestContainerUtil.testCallEmpty;
 import static apoc.util.TestContainerUtil.testResult;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -37,6 +39,7 @@ import static org.neo4j.test.assertion.Assert.assertEventually;
 
 public class TriggerEnterpriseFeaturesTest {
     private static final String FOO_DB = "foo";
+    private static final String INIT_DB = "initdb";
 
     private static final String NO_ADMIN_USER = "nonadmin";
     private static final String NO_ADMIN_PWD = "test1234";
@@ -46,10 +49,15 @@ public class TriggerEnterpriseFeaturesTest {
 
     @BeforeClass
     public static void beforeAll() {
+        final String cypherInitializer = String.format("%s.%s.0",
+                APOC_CONFIG_INITIALIZER, SYSTEM_DATABASE_NAME);
+        final String createInitDb = String.format("CREATE DATABASE %s IF NOT EXISTS", INIT_DB);
+
         // We build the project, the artifact will be placed into ./build/libs
         neo4jContainer = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.CORE), true)
                 .withEnv(APOC_TRIGGER_ENABLED, "true")
-                .withEnv(TRIGGER_REFRESH, String.valueOf(TRIGGER_DEFAULT_REFRESH));
+                .withEnv(TRIGGER_REFRESH, String.valueOf(TRIGGER_DEFAULT_REFRESH))
+                .withEnv(cypherInitializer, createInitDb);
         neo4jContainer.start();
         session = neo4jContainer.getSession();
         


### PR DESCRIPTION
Implemented 3rd solution - `DatabaseEventListener`,
so that we can delete every system node belonging to the database that we delete.

Added a `cleanUpSystemNodes()` for backward compatibility