### PR TITLE
[f46vahOr] Fix Cypher export of constraints

### DIFF
--- a/common/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/common/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -93,38 +93,38 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 		String statement = "";
 		switch ( type ) {
 		case UNIQUENESS -> {
-			keysString = getPropertiesQuoted(keys, "node.");
+			keysString = "node.";
 			typeString = "IS UNIQUE";
 			statement = STATEMENT_CONSTRAINTS;
 		}
 		case NODE_KEY -> {
-			keysString = getPropertiesQuoted(keys, "node.");
+			keysString = "node.";
 			typeString = "IS NODE KEY";
 			statement = STATEMENT_CONSTRAINTS;
 		}
 		case NODE_PROPERTY_EXISTENCE -> {
-			keysString = getPropertiesQuoted(keys, "node.");
+			keysString = "node.";
 			typeString = "IS NOT NULL";
 			statement = STATEMENT_CONSTRAINTS;
 		}
 		case RELATIONSHIP_UNIQUENESS -> {
-			keysString = getPropertiesQuoted(keys, "rel.");
+			keysString = "rel.";
 			typeString = "IS UNIQUE";
 			statement = STATEMENT_CONSTRAINTS_REL;
 		}
 		case RELATIONSHIP_KEY -> {
-			keysString = getPropertiesQuoted(keys, "rel.");
+			keysString = "rel.";
 			typeString = "IS NODE KEY";
 			statement = STATEMENT_CONSTRAINTS_REL;
 		}
 		case RELATIONSHIP_PROPERTY_EXISTENCE -> {
-			keysString = getPropertiesQuoted(keys, "rel.");
+			keysString = "rel.";
 			typeString = "IS NOT NULL";
 			statement = STATEMENT_CONSTRAINTS_REL;
 		}
 		}
 
-		return String.format(statement, Util.quote(name), getIfNotExists(ifNotExists), Util.quote(label), keysString, typeString);
+		return String.format(statement, Util.quote(name), getIfNotExists(ifNotExists), Util.quote(label), getPropertiesQuoted(keys, keysString), typeString);
 	}
 
 	@Override

--- a/common/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/common/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import org.neo4j.graphdb.schema.ConstraintType;
 
 import static apoc.export.cypher.formatter.CypherFormatterUtils.Q_UNIQUE_ID_LABEL;
 import static apoc.export.cypher.formatter.CypherFormatterUtils.Q_UNIQUE_ID_REL;
@@ -85,10 +86,15 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 	}
 
 	@Override
-	public String statementForCreateConstraint(String name, String label, Iterable<String> keys, boolean ifNotExists) {
+	public String statementForCreateConstraint(String name, String label, Iterable<String> keys, ConstraintType type, boolean ifNotExists) {
 		String keysString = getPropertiesQuoted(keys, "node.");
+		String typeString = "";
+		switch ( type ) {
+		case UNIQUENESS -> typeString = "IS UNIQUE";
+		case NODE_KEY -> typeString = "IS NODE KEY";
+		}
 
-		return String.format(STATEMENT_CONSTRAINTS, Util.quote(name), getIfNotExists(ifNotExists), Util.quote(label), keysString, Iterables.count(keys) > 1 ? "IS NODE KEY" : "IS UNIQUE");
+		return String.format(STATEMENT_CONSTRAINTS, Util.quote(name), getIfNotExists(ifNotExists), Util.quote(label), keysString, typeString);
 	}
 
 	@Override

--- a/common/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
+++ b/common/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
@@ -9,6 +9,7 @@ import org.neo4j.graphdb.Relationship;
 import java.io.PrintWriter;
 import java.util.Map;
 import java.util.Set;
+import org.neo4j.graphdb.schema.ConstraintType;
 
 /**
  * @author AgileLARUS
@@ -43,7 +44,7 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 	}
 
 	@Override
-	public String statementForCreateConstraint(String name, String label, Iterable<String> keys, boolean ifNotExists) {
+	public String statementForCreateConstraint(String name, String label, Iterable<String> keys, ConstraintType type, boolean ifNotExists) {
 		return "";
 	}
 

--- a/common/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
+++ b/common/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
@@ -7,6 +7,7 @@ import org.neo4j.graphdb.*;
 import java.io.PrintWriter;
 import java.util.Map;
 import java.util.Set;
+import org.neo4j.graphdb.schema.ConstraintType;
 
 /**
  * @author AgileLARUS
@@ -27,7 +28,7 @@ public interface CypherFormatter {
 
 	String statementForRelationshipFullTextIndex(String name, Iterable<RelationshipType> types, Iterable<String> keys);
 
-	String statementForCreateConstraint(String name, String label, Iterable<String> keys, boolean ifNotExist);
+	String statementForCreateConstraint(String name, String label, Iterable<String> keys, ConstraintType type, boolean ifNotExist);
 
 	String statementForDropConstraint(String name);
 

--- a/common/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
+++ b/common/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
@@ -9,6 +9,7 @@ import org.neo4j.graphdb.Relationship;
 import java.io.PrintWriter;
 import java.util.Map;
 import java.util.Set;
+import org.neo4j.graphdb.schema.ConstraintType;
 
 /**
  * @author AgileLARUS
@@ -43,7 +44,7 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 	}
 
 	@Override
-	public String statementForCreateConstraint(String name, String label, Iterable<String> key, boolean ifNotExist) {
+	public String statementForCreateConstraint(String name, String label, Iterable<String> key, ConstraintType type, boolean ifNotExist) {
 		return "";
 	}
 

--- a/common/src/main/java/apoc/export/util/NodesAndRelsSubGraph.java
+++ b/common/src/main/java/apoc/export/util/NodesAndRelsSubGraph.java
@@ -1,6 +1,8 @@
 package apoc.export.util;
 
 import apoc.util.collection.Iterables;
+import java.util.Comparator;
+import java.util.function.BiFunction;
 import org.neo4j.cypher.export.SubGraph;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
@@ -55,22 +57,24 @@ public class NodesAndRelsSubGraph implements SubGraph {
 
     @Override
     public Iterable<IndexDefinition> getIndexes() {
-        Schema schema = tx.schema();
-        ArrayList<IndexDefinition> indexes = new ArrayList<>(labels.size() * 2);
-        for (String label : labels) {
-            Iterables.addAll(indexes, schema.getIndexes(Label.label(label)));
-        }
-        return indexes;
+        return getDefinitions(Schema::getIndexes);
     }
 
     @Override
     public Iterable<ConstraintDefinition> getConstraints() {
+        Comparator<ConstraintDefinition> comp = Comparator.comparing(ConstraintDefinition::getName);
+        ArrayList<ConstraintDefinition> definitions = getDefinitions(Schema::getConstraints);
+        definitions.sort(comp);
+        return definitions;
+    }
+
+    private <T> ArrayList<T> getDefinitions( BiFunction<Schema, Label, Iterable<T>> biFunction) {
         Schema schema = tx.schema();
-        ArrayList<ConstraintDefinition> constraints = new ArrayList<>(labels.size() * 2);
+        ArrayList<T> definitions = new ArrayList<>(labels.size() * 2);
         for (String label : labels) {
-            Iterables.addAll(constraints, schema.getConstraints(Label.label(label)));
+            Iterables.addAll(definitions, biFunction.apply(schema, Label.label(label)));
         }
-        return constraints;
+        return definitions;
     }
 
     @Override

--- a/common/src/main/java/apoc/export/util/NodesAndRelsSubGraph.java
+++ b/common/src/main/java/apoc/export/util/NodesAndRelsSubGraph.java
@@ -64,6 +64,16 @@ public class NodesAndRelsSubGraph implements SubGraph {
     }
 
     @Override
+    public Iterable<ConstraintDefinition> getConstraints() {
+        Schema schema = tx.schema();
+        ArrayList<ConstraintDefinition> constraints = new ArrayList<>(labels.size() * 2);
+        for (String label : labels) {
+            Iterables.addAll(constraints, schema.getConstraints(Label.label(label)));
+        }
+        return constraints;
+    }
+
+    @Override
     public Iterable<ConstraintDefinition> getConstraints(Label label) {
         if (!labels.contains(label.name())) {
             return Collections.emptyList();

--- a/common/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
+++ b/common/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
@@ -162,6 +162,11 @@ public class CypherResultSubGraph implements SubGraph {
     }
 
     @Override
+    public Iterable<ConstraintDefinition> getConstraints() {
+        return constraints;
+    }
+
+    @Override
     public Iterable<ConstraintDefinition> getConstraints(Label label) {
         return constraints.stream()
                 .filter(c -> Util.isNodeCategory(c.getConstraintType()))

--- a/common/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
+++ b/common/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
@@ -41,6 +41,12 @@ public class DatabaseSubGraph implements SubGraph
     }
 
     @Override
+    public Iterable<ConstraintDefinition> getConstraints()
+    {
+        return transaction.schema().getConstraints();
+    }
+
+    @Override
     public Iterable<ConstraintDefinition> getConstraints(Label label) {
         return transaction.schema().getConstraints(label);
     }

--- a/common/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
+++ b/common/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
@@ -1,5 +1,7 @@
 package org.neo4j.cypher.export;
 
+import java.util.Comparator;
+import java.util.stream.StreamSupport;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -43,7 +45,8 @@ public class DatabaseSubGraph implements SubGraph
     @Override
     public Iterable<ConstraintDefinition> getConstraints()
     {
-        return transaction.schema().getConstraints();
+        Comparator<ConstraintDefinition> comp = Comparator.comparing(ConstraintDefinition::getName);
+        return StreamSupport.stream( transaction.schema().getConstraints().spliterator(), false ).sorted(comp).toList();
     }
 
     @Override

--- a/common/src/main/java/org/neo4j/cypher/export/SubGraph.java
+++ b/common/src/main/java/org/neo4j/cypher/export/SubGraph.java
@@ -25,6 +25,8 @@ public interface SubGraph
 
     Iterable<IndexDefinition> getIndexes();
 
+    Iterable<ConstraintDefinition> getConstraints();
+
     Iterable<ConstraintDefinition> getConstraints(Label label);
 
     Iterable<ConstraintDefinition> getConstraints(RelationshipType type);

--- a/common/src/test/resources/init_neo4j_export_csv.cypher
+++ b/common/src/test/resources/init_neo4j_export_csv.cypher
@@ -1,3 +1,6 @@
+CREATE CONSTRAINT SingleUnique FOR (x:Label) REQUIRE (x.prop) IS UNIQUE;
+CREATE CONSTRAINT CompositeUnique FOR (x:Label) REQUIRE (x.prop1, x.prop2) IS UNIQUE;
+CREATE CONSTRAINT SingleNodeKey FOR (x:Label3) REQUIRE (x.prop) IS NODE KEY;
 CREATE CONSTRAINT PersonRequiresNamesConstraint FOR (t:Person) REQUIRE (t.name, t.surname) IS NODE KEY;
 
 CREATE (a:Person {name: 'John', surname: 'Snow'})

--- a/common/src/test/resources/init_neo4j_export_csv.cypher
+++ b/common/src/test/resources/init_neo4j_export_csv.cypher
@@ -1,5 +1,9 @@
 CREATE CONSTRAINT SingleUnique FOR (x:Label) REQUIRE (x.prop) IS UNIQUE;
+CREATE CONSTRAINT SingleUniqueRel FOR ()-[x:TYPE]->() REQUIRE (x.prop) IS UNIQUE;
 CREATE CONSTRAINT CompositeUnique FOR (x:Label) REQUIRE (x.prop1, x.prop2) IS UNIQUE;
+CREATE CONSTRAINT CompositeUniqueRel FOR ()-[x:TYPE]-() REQUIRE (x.prop1, x.prop2) IS UNIQUE;
+CREATE CONSTRAINT SingleExists FOR (x:Label2) REQUIRE (x.prop) IS NOT NULL;
+CREATE CONSTRAINT SingleExistsRel FOR ()<-[r:TYPE2]-() REQUIRE (r.prop) IS NOT NULL;
 CREATE CONSTRAINT SingleNodeKey FOR (x:Label3) REQUIRE (x.prop) IS NODE KEY;
 CREATE CONSTRAINT PersonRequiresNamesConstraint FOR (t:Person) REQUIRE (t.name, t.surname) IS NODE KEY;
 

--- a/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
+++ b/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
@@ -279,11 +279,9 @@ public class MultiStatementCypherSubGraphExporter {
                 .map(constraint-> {
                     String name = constraint.getName();
                     ConstraintType type = constraint.getConstraintType();
-                    String label = "";
-                    switch(type) {
-                    case UNIQUENESS, NODE_KEY, NODE_PROPERTY_EXISTENCE -> label = constraint.getLabel().name();
-                    case RELATIONSHIP_UNIQUENESS, RELATIONSHIP_KEY, RELATIONSHIP_PROPERTY_EXISTENCE -> label = constraint.getRelationshipType().name();
-                    }
+                    String label = Util.isNodeCategory(type)
+                            ? constraint.getLabel().name()
+                            : constraint.getRelationshipType().name();
                     Iterable<String> props = constraint.getPropertyKeys();
                     return this.cypherFormat.statementForCreateConstraint(name, label, props, type, exportConfig.ifNotExists());
                 })

--- a/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
+++ b/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
@@ -276,12 +276,15 @@ public class MultiStatementCypherSubGraphExporter {
 
     private List<String> exportConstraints() {
         return StreamSupport.stream(graph.getConstraints().spliterator(), false)
-                .filter(constraint -> !constraint.isConstraintType(ConstraintType.NODE_PROPERTY_EXISTENCE))
                 .map(constraint-> {
                     String name = constraint.getName();
-                    String label = constraint.getLabel().name();
-                    Iterable<String> props = constraint.getPropertyKeys();
                     ConstraintType type = constraint.getConstraintType();
+                    String label = "";
+                    switch(type) {
+                    case UNIQUENESS, NODE_KEY, NODE_PROPERTY_EXISTENCE -> label = constraint.getLabel().name();
+                    case RELATIONSHIP_UNIQUENESS, RELATIONSHIP_KEY, RELATIONSHIP_PROPERTY_EXISTENCE -> label = constraint.getRelationshipType().name();
+                    }
+                    Iterable<String> props = constraint.getPropertyKeys();
                     return this.cypherFormat.statementForCreateConstraint(name, label, props, type, exportConfig.ifNotExists());
                 })
                 .filter(StringUtils::isNotBlank)

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -65,32 +65,9 @@ public class ExportCypherTest {
     @Rule
     public TestName testName = new TestName();
 
-    private static final String OPTIMIZED = "Optimized";
-    private static final String ODD = "OddDataset";
-
     @Before
     public void setUp() {
-        apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
-        TestUtil.registerProcedure(db, ExportCypher.class, Graphs.class, Schemas.class);
-        db.executeTransactionally("CREATE RANGE INDEX barIndex FOR (n:Bar) ON (n.first_name, n.last_name)");
-        db.executeTransactionally("CREATE RANGE INDEX fooIndex FOR (n:Foo) ON (n.name)");
-        db.executeTransactionally("CREATE CONSTRAINT uniqueConstraint FOR (b:Bar) REQUIRE b.name IS UNIQUE");
-        db.executeTransactionally("CREATE CONSTRAINT uniqueConstraintComposite FOR (b:Bar) REQUIRE (b.name, b.age) IS UNIQUE");
-        if (testName.getMethodName().endsWith(OPTIMIZED)) {
-            db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})-[:KNOWS {since:2016}]->(b:Bar {name:'bar',age:42}),(c:Bar:Person {age:12}),(d:Bar {age:17})," +
-                    " (t:Foo {name:'foo2', born:date('2017-09-29')})-[:KNOWS {since:2015}]->(e:Bar {name:'bar2',age:44}),({age:99})");
-        } else if(testName.getMethodName().endsWith(ODD)) {
-            db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})," +
-                    "(t:Foo {name:'foo2', born:date('2017-09-29')})," +
-                    "(g:Foo {name:'foo3', born:date('2016-03-12')})," +
-                    "(b:Bar {name:'bar',age:42})," +
-                    "(c:Bar {age:12})," +
-                    "(d:Bar {age:4})," +
-                    "(e:Bar {name:'bar2',age:44})," +
-                    "(f)-[:KNOWS {since:2016}]->(b)");
-        } else {
-            db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})-[:KNOWS {since:2016}]->(b:Bar {name:'bar',age:42}),(c:Bar {age:12})");
-        }
+        ExportCypherTestUtils.setUp(db, testName);
     }
 
     @Test

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -1447,7 +1447,11 @@ public class ExportCypherTest {
 
         public static final List<String> EXPECTED_CONSTRAINTS = List.of(
              "CREATE CONSTRAINT SingleUnique FOR (node:Label) REQUIRE (node.prop) IS UNIQUE;",
+             "CREATE CONSTRAINT SingleUniqueRel FOR ()-[rel:TYPE]-() REQUIRE (rel.prop) IS UNIQUE;",
              "CREATE CONSTRAINT CompositeUnique FOR (node:Label) REQUIRE (node.prop1, node.prop2) IS UNIQUE;",
+             "CREATE CONSTRAINT CompositeUniqueRel FOR ()-[rel:TYPE]-() REQUIRE (rel.prop1, rel.prop2) IS UNIQUE;",
+             "CREATE CONSTRAINT SingleExists FOR (node:Label2) REQUIRE (node.prop) IS NOT NULL;",
+             "CREATE CONSTRAINT SingleExistsRel FOR ()-[rel:TYPE2]-() REQUIRE (rel.prop) IS NOT NULL;",
              "CREATE CONSTRAINT SingleNodeKey FOR (node:Label3) REQUIRE (node.prop) IS NODE KEY;",
              "CREATE CONSTRAINT PersonRequiresNamesConstraint FOR (node:Person) REQUIRE (node.name, node.surname) IS NODE KEY;"
         );

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTestUtils.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTestUtils.java
@@ -1,6 +1,43 @@
 package apoc.export.cypher;
 
+import static apoc.ApocConfig.APOC_EXPORT_FILE_ENABLED;
+import static apoc.ApocConfig.apocConfig;
+
+import apoc.graph.Graphs;
+import apoc.schema.Schemas;
+import apoc.util.TestUtil;
+import org.junit.rules.TestName;
+import org.neo4j.graphdb.GraphDatabaseService;
+
 public class ExportCypherTestUtils {
+
+    private static final String OPTIMIZED = "Optimized";
+    private static final String ODD = "OddDataset";
+
+    public static void setUp( GraphDatabaseService db, TestName testName) {
+        apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
+        TestUtil.registerProcedure(db, ExportCypher.class, Graphs.class, Schemas.class);
+        db.executeTransactionally("CREATE RANGE INDEX barIndex FOR (n:Bar) ON (n.first_name, n.last_name)");
+        db.executeTransactionally("CREATE RANGE INDEX fooIndex FOR (n:Foo) ON (n.name)");
+        db.executeTransactionally("CREATE CONSTRAINT uniqueConstraint FOR (b:Bar) REQUIRE b.name IS UNIQUE");
+        db.executeTransactionally("CREATE CONSTRAINT uniqueConstraintComposite FOR (b:Bar) REQUIRE (b.name, b.age) IS UNIQUE");
+        if (testName.getMethodName().endsWith(OPTIMIZED)) {
+            db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})-[:KNOWS {since:2016}]->(b:Bar {name:'bar',age:42}),(c:Bar:Person {age:12}),(d:Bar {age:17})," +
+                    " (t:Foo {name:'foo2', born:date('2017-09-29')})-[:KNOWS {since:2015}]->(e:Bar {name:'bar2',age:44}),({age:99})");
+        } else if(testName.getMethodName().endsWith(ODD)) {
+            db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})," +
+                    "(t:Foo {name:'foo2', born:date('2017-09-29')})," +
+                    "(g:Foo {name:'foo3', born:date('2016-03-12')})," +
+                    "(b:Bar {name:'bar',age:42})," +
+                    "(c:Bar {age:12})," +
+                    "(d:Bar {age:4})," +
+                    "(e:Bar {name:'bar2',age:44})," +
+                    "(f)-[:KNOWS {since:2016}]->(b)");
+        } else {
+            db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})-[:KNOWS {since:2016}]->(b:Bar {name:'bar',age:42}),(c:Bar {age:12})");
+        }
+    }
+
     protected final static String NODES_MULTI_RELS = ":begin\n" +
             "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}) SET n.name=\"MyName\", n:Person;\n" +
             "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) SET n.a=1, n:Project;\n" +

--- a/it/src/test/java/apoc/it/core/ExportCypherEnterpriseFeaturesTest.java
+++ b/it/src/test/java/apoc/it/core/ExportCypherEnterpriseFeaturesTest.java
@@ -3,6 +3,8 @@ import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil.ApocPackage;
 import apoc.util.TestUtil;
 import apoc.util.Util;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -133,9 +135,7 @@ public class ExportCypherEnterpriseFeaturesTest {
     private void assertExportStatement(String expectedStatement, String fileName) {
         // The constraints are exported in arbitrary order, so we cannot assert on the entire file
         String actual = readFileToString(new File(directory, fileName));
-        System.out.println(expectedStatement);
-        System.out.println(readFileToString(new File(directory, fileName)));
-        assertTrue(actual.contains(expectedStatement));
+        MatcherAssert.assertThat(actual, Matchers.containsString(expectedStatement));
         EXPECTED_CONSTRAINTS.forEach(
                 constraint -> assertTrue(String.format("Constraint '%s' not in result", constraint), actual.contains(constraint))
         );

--- a/it/src/test/java/apoc/it/core/ExportCypherEnterpriseFeaturesTest.java
+++ b/it/src/test/java/apoc/it/core/ExportCypherEnterpriseFeaturesTest.java
@@ -13,10 +13,12 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static apoc.export.cypher.ExportCypherTest.ExportCypherResults;
+import static apoc.export.cypher.ExportCypherTest.ExportCypherResults.EXPECTED_CONSTRAINTS;
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestContainerUtil.*;
 import static apoc.util.TestUtil.readFileToString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author as
@@ -129,6 +131,13 @@ public class ExportCypherEnterpriseFeaturesTest {
     }
 
     private void assertExportStatement(String expectedStatement, String fileName) {
-        assertEquals(expectedStatement, readFileToString(new File(directory, fileName)));
+        // The constraints are exported in arbitrary order, so we cannot assert on the entire file
+        String actual = readFileToString(new File(directory, fileName));
+        System.out.println(expectedStatement);
+        System.out.println(readFileToString(new File(directory, fileName)));
+        assertTrue(actual.contains(expectedStatement));
+        EXPECTED_CONSTRAINTS.forEach(
+                constraint -> assertTrue(String.format("Constraint '%s' not in result", constraint), actual.contains(constraint))
+        );
     }
 }

--- a/it/src/test/java/apoc/it/core/ExportCypherS3Test.java
+++ b/it/src/test/java/apoc/it/core/ExportCypherS3Test.java
@@ -1,6 +1,7 @@
 package apoc.it.core;
 
 import apoc.export.cypher.ExportCypher;
+import apoc.export.cypher.ExportCypherTestUtils;
 import apoc.graph.Graphs;
 import apoc.util.TestUtil;
 import apoc.util.s3.S3BaseTest;
@@ -32,33 +33,9 @@ public class ExportCypherS3Test extends S3BaseTest {
     @Rule
     public TestName testName = new TestName();
 
-    private static final String OPTIMIZED = "Optimized";
-    private static final String ODD = "OddDataset";
-
-
     @Before
-    public void setUp() throws Exception {
-        apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
-        TestUtil.registerProcedure(db, ExportCypher.class, Graphs.class);
-        db.executeTransactionally("CREATE RANGE INDEX FOR (n:Bar) ON (n.first_name, n.last_name)");
-        db.executeTransactionally("CREATE RANGE INDEX FOR (n:Foo) ON (n.name)");
-        db.executeTransactionally("CREATE CONSTRAINT uniqueConstraint FOR (b:Bar) REQUIRE b.name IS UNIQUE");
-        db.executeTransactionally("CREATE CONSTRAINT uniqueConstraintComposite FOR (b:Bar) REQUIRE (b.name, b.age) IS UNIQUE");
-        if (testName.getMethodName().endsWith(OPTIMIZED)) {
-            db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})-[:KNOWS {since:2016}]->(b:Bar {name:'bar',age:42}),(c:Bar:Person {age:12}),(d:Bar {age:17})," +
-                    " (t:Foo {name:'foo2', born:date('2017-09-29')})-[:KNOWS {since:2015}]->(e:Bar {name:'bar2',age:44}),({age:99})");
-        } else if(testName.getMethodName().endsWith(ODD)) {
-            db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})," +
-                    "(t:Foo {name:'foo2', born:date('2017-09-29')})," +
-                    "(g:Foo {name:'foo3', born:date('2016-03-12')})," +
-                    "(b:Bar {name:'bar',age:42})," +
-                    "(c:Bar {age:12})," +
-                    "(d:Bar {age:4})," +
-                    "(e:Bar {name:'bar2',age:44})," +
-                    "(f)-[:KNOWS {since:2016}]->(b)");
-        } else {
-            db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})-[:KNOWS {since:2016}]->(b:Bar {name:'bar',age:42}),(c:Bar {age:12})");
-        }
+    public void setUp() {
+        ExportCypherTestUtils.setUp(db, testName);
     }
 
     // -- Whole file test -- //

--- a/it/src/test/java/apoc/it/core/ExportCypherS3Test.java
+++ b/it/src/test/java/apoc/it/core/ExportCypherS3Test.java
@@ -43,8 +43,9 @@ public class ExportCypherS3Test extends S3BaseTest {
         db.executeTransactionally("CREATE RANGE INDEX FOR (n:Bar) ON (n.first_name, n.last_name)");
         db.executeTransactionally("CREATE RANGE INDEX FOR (n:Foo) ON (n.name)");
         db.executeTransactionally("CREATE CONSTRAINT uniqueConstraint FOR (b:Bar) REQUIRE b.name IS UNIQUE");
+        db.executeTransactionally("CREATE CONSTRAINT uniqueConstraintComposite FOR (b:Bar) REQUIRE (b.name, b.age) IS UNIQUE");
         if (testName.getMethodName().endsWith(OPTIMIZED)) {
-            db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})-[:KNOWS {since:2016}]->(b:Bar {name:'bar',age:42}),(c:Bar:Person {age:12}),(d:Bar {age:12})," +
+            db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})-[:KNOWS {since:2016}]->(b:Bar {name:'bar',age:42}),(c:Bar:Person {age:12}),(d:Bar {age:17})," +
                     " (t:Foo {name:'foo2', born:date('2017-09-29')})-[:KNOWS {since:2015}]->(e:Bar {name:'bar2',age:44}),({age:99})");
         } else if(testName.getMethodName().endsWith(ODD)) {
             db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})," +


### PR DESCRIPTION
Fixes #345 

`apoc.export.cypher.all` exported some constraints with wrong type or not at all

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Stop classifying composite UNIQUE constraints as NODE KEY.
  - Stop classifying single NODE KEY constraints as UNIQUE.
  - Support existence constraints.
  - Support relationship constraints.
