### PR TITLE
[nw2aWxrX] Upgrade aws-java-sdk-s3 to 1.12.425 to partially address CVE-2022-42003

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     // They need to be provided either through the database or in an extra .jar
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
     compileOnly group: 'org.apache.commons', name: 'commons-configuration2', version: '2.8.0'
-    compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.348'
+    compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.425'
     compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.4', withoutServers
     compileOnly group: 'com.google.cloud', name: 'google-cloud-storage', version: '2.6.2'
 

--- a/core/src/test/java/apoc/hashing/FingerprintingTest.java
+++ b/core/src/test/java/apoc/hashing/FingerprintingTest.java
@@ -8,7 +8,6 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.neo4j.fabric.stream.StatementResult;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;

--- a/it/build.gradle
+++ b/it/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testImplementation project(':common').sourceSets.test.output
     testImplementation project(':core').sourceSets.test.output
 
-    testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.348'
+    testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.425'
     testImplementation group: 'org.xmlunit', name: 'xmlunit-core', version: '2.9.1'
 
     configurations.all {

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation group: 'org.neo4j', name: 'neo4j-io', version: neo4jVersionEffective, classifier: "tests"
     implementation group: 'org.gradle', name: 'gradle-tooling-api', version: '7.2'
     implementation group: 'org.jetbrains', name: 'annotations', version: "17.0.0"
-    implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.348'
+    implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.425'
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: '2.13.2'
 }
 


### PR DESCRIPTION
Cherry-pick of core parts of https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3485