### PR TITLE
[1gsD8V8g] Add a more useful error message for export functions

### DIFF
--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -109,6 +109,9 @@ public class Util {
 
     public static final int REDIRECT_LIMIT = 10;
 
+    public static String INVALID_QUERY_MODE_ERROR = "This procedure allows for READ-only, non-schema based queries. " +
+            "It is therefore not possible to perform writes or query the database with commands such as SHOW CONSTRAINTS/INDEXES.";
+
     public static String labelString(List<String> labelNames) {
         return labelNames.stream().map(Util::quote).collect(Collectors.joining(":"));
     }

--- a/core/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/core/src/main/java/apoc/export/csv/CsvFormat.java
@@ -16,6 +16,7 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 
 import java.io.IOException;
@@ -38,6 +39,7 @@ import static apoc.export.util.MetaInformation.collectPropTypesForNodes;
 import static apoc.export.util.MetaInformation.collectPropTypesForRelationships;
 import static apoc.export.util.MetaInformation.getLabelsString;
 import static apoc.export.util.MetaInformation.updateKeyTypes;
+import static apoc.util.Util.INVALID_QUERY_MODE_ERROR;
 import static apoc.util.Util.getNodeId;
 import static apoc.util.Util.getRelationshipId;
 import static apoc.util.Util.joinLabels;
@@ -127,6 +129,8 @@ public class CsvFormat {
             tx.commit();
             reporter.done();
             return reporter.getTotal();
+        } catch (AuthorizationViolationException e) {
+            throw new RuntimeException(INVALID_QUERY_MODE_ERROR);
         }
     }
 

--- a/core/src/main/java/apoc/export/json/JsonFormat.java
+++ b/core/src/main/java/apoc/export/json/JsonFormat.java
@@ -16,12 +16,15 @@ import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.security.AuthorizationViolationException;
 
 import java.io.IOException;
 import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
+
+import static apoc.util.Util.INVALID_QUERY_MODE_ERROR;
 
 
 public class JsonFormat {
@@ -145,6 +148,8 @@ public class JsonFormat {
                 writeJsonContainerEnd(jsonGenerator);
             } catch (IOException e) {
                 throw new RuntimeException(e);
+            } catch (AuthorizationViolationException e) {
+                throw new RuntimeException(INVALID_QUERY_MODE_ERROR);
             }
         };
         return dump(writer.getPrintWriter("json"), reporter, consumer);

--- a/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
+++ b/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
@@ -119,7 +119,7 @@ public class ExportCoreSecurityTest {
                     () -> TestUtil.testCall(db, "CALL " + apocProcedure, (r) -> {})
             );
 
-            assertError(e, ApocConfig.EXPORT_TO_FILE_ERROR, RuntimeException.class, apocProcedure);
+            TestUtil.assertError(e, ApocConfig.EXPORT_TO_FILE_ERROR, RuntimeException.class, apocProcedure);
         }
     }
 
@@ -164,7 +164,7 @@ public class ExportCoreSecurityTest {
                         Result::resultAsString);
                 fail(message);
             } catch (Exception e) {
-                assertError(e, FileUtils.ACCESS_OUTSIDE_DIR_ERROR, IOException.class, apocProcedure);
+                TestUtil.assertError(e, FileUtils.ACCESS_OUTSIDE_DIR_ERROR, IOException.class, apocProcedure);
             } finally {
                 setFileExport(false);
             }
@@ -215,7 +215,7 @@ public class ExportCoreSecurityTest {
                     () -> TestUtil.testCall(db, "CALL " + apocProcedure, (r) -> {})
             );
 
-            assertError(e, FileUtils.ACCESS_OUTSIDE_DIR_ERROR, IOException.class, apocProcedure);
+            TestUtil.assertError(e, FileUtils.ACCESS_OUTSIDE_DIR_ERROR, IOException.class, apocProcedure);
             setFileExport(false);
         }
     }
@@ -381,7 +381,7 @@ public class ExportCoreSecurityTest {
                     () -> TestUtil.testCall(db, "CALL " + apocProcedure, (r) -> {})
             );
 
-            assertError(e, FileUtils.ACCESS_OUTSIDE_DIR_ERROR, IOException.class, apocProcedure);
+            TestUtil.assertError(e, FileUtils.ACCESS_OUTSIDE_DIR_ERROR, IOException.class, apocProcedure);
 
             setFileExport(false);
         }
@@ -452,7 +452,7 @@ public class ExportCoreSecurityTest {
             QueryExecutionException e = Assert.assertThrows(QueryExecutionException.class,
                     () -> TestUtil.testCall(db, String.format("CALL " + apocProcedure, "'./hello', {}"), (r) -> {})
             );
-            assertError(e, ApocConfig.EXPORT_TO_FILE_ERROR, RuntimeException.class, apocProcedure);
+            TestUtil.assertError(e, ApocConfig.EXPORT_TO_FILE_ERROR, RuntimeException.class, apocProcedure);
         }
 
         @Test
@@ -461,15 +461,8 @@ public class ExportCoreSecurityTest {
             QueryExecutionException e = Assert.assertThrows(QueryExecutionException.class,
                     () -> TestUtil.testCall(db, String.format("CALL " + apocProcedure, "'../hello', {}"), (r) -> {})
             );
-            assertError(e, FileUtils.ACCESS_OUTSIDE_DIR_ERROR, IOException.class, apocProcedure);
+            TestUtil.assertError(e, FileUtils.ACCESS_OUTSIDE_DIR_ERROR, IOException.class, apocProcedure);
             setFileExport(false);
         }
     }
-
-    private static void assertError(Exception e, String errorMessage, Class<? extends Exception> exceptionType, String apocProcedure) {
-        final Throwable rootCause = ExceptionUtils.getRootCause(e);
-        assertTrue(apocProcedure + " should throw an instance of " + exceptionType.getSimpleName(), exceptionType.isInstance(rootCause));
-        assertEquals(apocProcedure + " should throw the following message", errorMessage, rootCause.getMessage());
-    }
-
 }

--- a/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
+++ b/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
@@ -8,7 +8,6 @@ import apoc.export.json.ExportJson;
 import apoc.util.FileUtils;
 import apoc.util.TestUtil;
 import junit.framework.TestCase;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -30,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -9,10 +9,12 @@ import apoc.util.CompressionConfig;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import apoc.util.collection.Iterators;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
@@ -35,7 +37,9 @@ import static apoc.util.CompressionAlgo.DEFLATE;
 import static apoc.util.CompressionAlgo.GZIP;
 import static apoc.util.CompressionAlgo.NONE;
 import static apoc.util.MapUtil.map;
+import static apoc.util.TestUtil.assertError;
 import static apoc.util.TestUtil.testResult;
+import static apoc.util.Util.INVALID_QUERY_MODE_ERROR;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertArrayEquals;
@@ -316,6 +320,31 @@ public class ExportCsvTest {
 
                 });
         assertEquals(EXPECTED_QUERY_WITHOUT_QUOTES, readFile(fileName));
+    }
+
+    @Test
+    public void testExportCsvAdminOperationErrorMessage() {
+        String filename = "test.csv";
+        List<String> invalidQueries = List.of(
+                "SHOW CONSTRAINTS YIELD id, name, type RETURN *",
+                "SHOW INDEXES YIELD id, name, type RETURN *"
+        );
+
+        for (String query : invalidQueries) {
+            QueryExecutionException e = Assert.assertThrows(QueryExecutionException.class,
+                    () -> TestUtil.testCall(db, """
+                        CALL apoc.export.csv.query(
+                        $query,
+                        $file,
+                        {quotes: false}
+                        )""",
+                            map("query", query, "file", filename),
+                            (r) -> {}
+                    )
+            );
+
+            assertError(e, INVALID_QUERY_MODE_ERROR, RuntimeException.class, "apoc.export.csv.query");
+        }
     }
 
     @Test

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -9,6 +9,7 @@ import apoc.util.collection.Iterables;
 import junit.framework.TestCase;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,8 +49,10 @@ import static apoc.export.graphml.ExportGraphMLTestUtil.setUpGraphMl;
 import static apoc.util.BinaryTestUtil.getDecompressedData;
 import static apoc.util.BinaryTestUtil.fileToBinary;
 import static apoc.util.MapUtil.map;
+import static apoc.util.TestUtil.assertError;
 import static apoc.util.TransactionTestUtil.checkTerminationGuard;
 import static apoc.util.TestUtil.testResult;
+import static apoc.util.Util.INVALID_QUERY_MODE_ERROR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -812,5 +815,30 @@ public class ExportGraphMLTest {
                     assertStreamResults(r, "database");
                     assertXMLEquals(getDecompressedData(algo, r.get("data")), EXPECTED_FALSE);
                 });
+    }
+
+    @Test
+    public void testExportGraphmlAdminOperationErrorMessage() {
+        String filename = "test.xml";
+        List<String> invalidQueries = List.of(
+                "SHOW CONSTRAINTS YIELD id, name, type RETURN *",
+                "SHOW INDEXES YIELD id, name, type RETURN *"
+        );
+
+        for (String query : invalidQueries) {
+            QueryExecutionException e = Assert.assertThrows(QueryExecutionException.class,
+                    () -> TestUtil.testCall(db, """
+                        CALL apoc.export.graphml.query(
+                        $query,
+                        $file,
+                        {}
+                        )""",
+                            map("query", query, "file", filename),
+                            (r) -> {}
+                    )
+            );
+
+            assertError(e, INVALID_QUERY_MODE_ERROR, RuntimeException.class, "apoc.export.graphml.query");
+        }
     }
 }

--- a/core/src/test/java/apoc/export/json/ExportJsonTest.java
+++ b/core/src/test/java/apoc/export/json/ExportJsonTest.java
@@ -6,12 +6,14 @@ import apoc.util.CompressionAlgo;
 import apoc.util.FileTestUtil;
 import apoc.util.TestUtil;
 import apoc.util.Util;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
@@ -31,6 +33,8 @@ import static apoc.util.CompressionAlgo.FRAMED_SNAPPY;
 import static apoc.util.CompressionAlgo.NONE;
 import static apoc.util.CompressionConfig.COMPRESSION;
 import static apoc.util.MapUtil.map;
+import static apoc.util.TestUtil.assertError;
+import static apoc.util.Util.INVALID_QUERY_MODE_ERROR;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -85,6 +89,30 @@ public class ExportJsonTest {
                 (r) -> assertResults(filename, r, "database")
         );
         assertFileEquals(filename);
+    }
+
+    @Test
+    public void testExportJsonAdminOperationErrorMessage() {
+        String filename = "test.json";
+        List<String> invalidQueries = List.of(
+                "SHOW CONSTRAINTS YIELD id, name, type RETURN *",
+                "SHOW INDEXES YIELD id, name, type RETURN *"
+        );
+
+        for (String query : invalidQueries) {
+            QueryExecutionException e = Assert.assertThrows(QueryExecutionException.class,
+                    () -> TestUtil.testCall(db, """
+                        CALL apoc.export.json.query(
+                        $query,
+                        $file
+                        )""",
+                            map("query", query, "file", filename),
+                            (r) -> {}
+                    )
+            );
+
+            assertError(e, INVALID_QUERY_MODE_ERROR, RuntimeException.class, "apoc.export.json.query");
+        }
     }
 
     @Test

--- a/core/src/test/java/apoc/load/LoadCoreSecurityTest.java
+++ b/core/src/test/java/apoc/load/LoadCoreSecurityTest.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(Enclosed.class)

--- a/core/src/test/java/apoc/load/LoadCoreSecurityTest.java
+++ b/core/src/test/java/apoc/load/LoadCoreSecurityTest.java
@@ -101,7 +101,7 @@ public class LoadCoreSecurityTest {
                         Result::resultAsString);
                 fail(message);
             } catch (Exception e) {
-                assertError(e, ApocConfig.LOAD_FROM_FILE_ERROR, RuntimeException.class, apocProcedure);
+                TestUtil.assertError(e, ApocConfig.LOAD_FROM_FILE_ERROR, RuntimeException.class, apocProcedure);
             }
         }
 
@@ -118,7 +118,7 @@ public class LoadCoreSecurityTest {
                         Result::resultAsString);
                 fail(message);
             } catch (Exception e) {
-                assertError(e, String.format(FileUtils.ERROR_READ_FROM_FS_NOT_ALLOWED, fileName), RuntimeException.class, apocProcedure);
+                TestUtil.assertError(e, String.format(FileUtils.ERROR_READ_FROM_FS_NOT_ALLOWED, fileName), RuntimeException.class, apocProcedure);
             }
         }
 
@@ -144,11 +144,4 @@ public class LoadCoreSecurityTest {
             }
         }
     }
-
-    private static void assertError(Exception e, String errorMessage, Class<? extends Exception> exceptionType, String apocProcedure) {
-        final Throwable rootCause = ExceptionUtils.getRootCause(e);
-        assertTrue(apocProcedure + " should throw an instance of " + exceptionType.getSimpleName(), exceptionType.isInstance(rootCause));
-        assertEquals(apocProcedure + " should throw the following message", errorMessage, rootCause.getMessage());
-    }
-
 }

--- a/test-utils/src/main/java/apoc/util/TestUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestUtil.java
@@ -3,6 +3,7 @@ package apoc.util;
 import apoc.util.collection.Iterables;
 import apoc.util.collection.Iterators;
 import com.google.common.io.Files;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hamcrest.Matcher;
 import org.neo4j.exceptions.KernelException;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -128,6 +129,13 @@ public class TestUtil {
             assertTrue("Didn't fail with "+t.getSimpleName()+" but "+e.getClass().getSimpleName()+" "+e.getMessage(),found);
         }
     }
+
+    public static void assertError(Exception e, String errorMessage, Class<? extends Exception> exceptionType, String apocProcedure) {
+        final Throwable rootCause = ExceptionUtils.getRootCause(e);
+        assertTrue(apocProcedure + " should throw an instance of " + exceptionType.getSimpleName(), exceptionType.isInstance(rootCause));
+        assertEquals(apocProcedure + " should throw the following message ", errorMessage, rootCause.getMessage());
+    }
+
     public static void testResult(GraphDatabaseService db, String call, Consumer<Result> resultConsumer) {
         testResult(db,call,null,resultConsumer);
     }


### PR DESCRIPTION
When trying to use SHOW CONSTRAINTS or SHOW INDEXES, it looks like the current user doesn't have permission to use it instead of the procedure, this adds a more generic error message.