### PR TITLE
[tq7tdrWZ] Update Hadoop and JsonPath dependencies

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -51,8 +51,7 @@ dependencies {
     }
 
     // These will be dependencies packaged with the .jar
-    // when json-path is changed, it have to be changed in json-path-version version in antora.yml as well (placed in neo4j/docs-apoc repo )
-    api group: 'com.jayway.jsonpath', name: 'json-path', version: '2.7.0'
+    api group: 'com.jayway.jsonpath', name: 'json-path', version: '2.8.0'
     api group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
     api group: 'org.apache.commons', name: 'commons-collections4', version: '4.2'
     // We need this to avoid seeing SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder" on startup
@@ -72,7 +71,7 @@ dependencies {
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
     compileOnly group: 'org.apache.commons', name: 'commons-configuration2', version: '2.8.0'
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.425'
-    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.4', withoutServers
+    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.5', withoutServers
     compileOnly group: 'com.google.cloud', name: 'google-cloud-storage', version: '2.6.2'
 
     // These dependencies affect the tests only, they will not be packaged in the resulting .jar

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -30,9 +30,9 @@ dependencies {
     api group: 'org.neo4j.community', name: 'it-test-support', version: neo4jVersionEffective // , classifier: "tests"
     api group: 'org.neo4j', name: 'log-test-utils', version: neo4jVersionEffective // , classifier: "tests"
     api group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.0.0'
-    api group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.4', withoutServers.andThen(withoutLoggers)
-    api group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.4', withoutServers.andThen(withoutLoggers)
-    api group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '3.3.4', withoutServers.andThen(withoutLoggers)
+    api group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.5', withoutServers.andThen(withoutLoggers)
+    api group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.5', withoutServers.andThen(withoutLoggers)
+    api group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '3.3.5', withoutServers.andThen(withoutLoggers)
     api group: 'org.testcontainers', name: 'testcontainers', version: testContainersVersion
     api group: 'org.testcontainers', name: 'neo4j', version: testContainersVersion
     api group: 'org.testcontainers', name: 'elasticsearch', version: testContainersVersion


### PR DESCRIPTION
Updates Hadoop and JsonPath dependencies to their newest releases. The test coverage for these isn't great, but I couldn't see any breaking changes in the changelogs for them.