### PR TITLE
[bZQoGhFu] apoc.refactor.mergeNodes is not working with uniqueness index

### DIFF
--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -589,13 +589,15 @@ public class GraphRefactoring {
     private void mergeNodes(Node source, Node target, RefactorConfig conf, List<String> excludeRelIds) {
         try {
             Map<String, Object> properties = source.getAllProperties();
+            final Iterable<Label> labels = source.getLabels();
 
-            copyRelationships(source, copyLabels(source, target), true, conf.isCreatingNewSelfRel());
+            copyRelationships(source, target, true, conf.isCreatingNewSelfRel());
             if (conf.getMergeRelsAllowed()) {
                 mergeRelationshipsWithSameTypeAndDirection(target, conf, Direction.OUTGOING, excludeRelIds);
                 mergeRelationshipsWithSameTypeAndDirection(target, conf, Direction.INCOMING, excludeRelIds);
             }
             source.delete();
+            labels.forEach(target::addLabel);
             PropertiesManager.mergeProperties(properties, target, conf);
         } catch (NotFoundException e) {
             log.warn("skipping a node for merging: " + e.getCause().getMessage());

--- a/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
+++ b/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
@@ -358,6 +358,23 @@ public class GraphRefactoringTest {
                     assertEquals(2L, node.getProperty("ID"));
                 });
     }
+    
+    @Test
+    public void testMergeNodesShouldNotFailWithSamePropKeysConstraints() {
+        db.executeTransactionally("CREATE CONSTRAINT FOR (a:A) REQUIRE a.prop1 IS UNIQUE");
+        db.executeTransactionally("CREATE CONSTRAINT FOR (a:B) REQUIRE a.prop1 IS UNIQUE");
+        String id = db.executeTransactionally("CREATE (a:A {prop1: 1}), (:B {prop1: 1}) RETURN elementId(a) as id", emptyMap(), 
+                r -> Iterators.single(r.columnAs("id")));
+        testCall(db, "MATCH (a:A {prop1:1}), (b:B {prop1:1})\n" +
+                        "CALL apoc.refactor.mergeNodes([a, b]) YIELD node RETURN node;",
+                (r) -> {
+                    Node node = (Node) r.get("node");
+                    assertEquals(id, node.getElementId());
+                    assertTrue(node.hasLabel(label("A")));
+                    assertTrue(node.hasLabel(label("B")));
+                    assertEquals(1L, node.getProperty("prop1"));
+                });
+    }
 
     @Test
     public void testMergeNodesEagerAggregation() {


### PR DESCRIPTION
Added labels at the end of the `mergeNodes()` method, to prevent schema conflicts