### PR TITLE
[MCKik4qR] Remove Relationship Constraint Feature Flag

### DIFF
--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -12,7 +12,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.neo4j.configuration.GraphDatabaseInternalSettings;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.graphdb.*;
 import org.neo4j.test.rule.DbmsRule;
@@ -58,8 +57,7 @@ public class MetaTest {
     public DbmsRule db = new ImpermanentDbmsRule()
             .withSetting(GraphDatabaseSettings.procedure_unrestricted, singletonList("apoc.*"))
             .withSetting(newBuilder( "internal.dbms.debug.track_cursor_close", BOOL, false ).build(), false)
-            .withSetting(newBuilder( "internal.dbms.debug.trace_cursors", BOOL, false ).build(), false)
-            .withSetting(GraphDatabaseInternalSettings.rel_unique_constraints, true);
+            .withSetting(newBuilder( "internal.dbms.debug.trace_cursors", BOOL, false ).build(), false);
 
     @Before
     public void setUp() {

--- a/core/src/test/java/apoc/schema/SchemasTest.java
+++ b/core/src/test/java/apoc/schema/SchemasTest.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.neo4j.configuration.GraphDatabaseInternalSettings;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.QueryExecutionException;
@@ -55,8 +54,7 @@ public class SchemasTest {
             "RETURN * ORDER BY label, type";
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule()
-            .withSetting(GraphDatabaseSettings.procedure_unrestricted, Collections.singletonList("apoc.*"))
-            .withSetting(GraphDatabaseInternalSettings.rel_unique_constraints, true);
+            .withSetting(GraphDatabaseSettings.procedure_unrestricted, Collections.singletonList("apoc.*"));
 
     private static void accept(Result result) {
         Map<String, Object> r = result.next();

--- a/test-utils/src/main/java/apoc/util/TestContainerUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestContainerUtil.java
@@ -131,7 +131,6 @@ public class TestContainerUtil {
                 .withNeo4jConfig("dbms.logs.http.enabled", "true")
                 .withNeo4jConfig("dbms.logs.debug.level", "DEBUG")
                 .withNeo4jConfig("dbms.routing.driver.logging.level", "DEBUG")
-                .withNeo4jConfig("internal.dbms.relationship_uniqueness_constraints", "true")
                 .withFileSystemBind(canonicalPath, "/var/lib/neo4j/import") // map the "target/import" dir as the Neo4j's import dir
                 .withCreateContainerCmdModifier(cmd -> cmd.withMemory(2024 * 1024 * 1024L)) // 2gb
                 .withExposedPorts(7687, 7473, 7474)


### PR DESCRIPTION
Removes usage of the feature flag for relationship constraints. This flag has been switched to true already, so removing this won't break, as well as allow a safe removal of the flag in the other code base :)

See [here](https://github.com/neo4j/apoc/pull/270/files) for original PR!