### PR TITLE
[ST3nW88b] Upgrade commons-configuration2 to 2.9.0.

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     // These will be dependencies not packaged with the .jar
     // They need to be provided either through the database or in an extra .jar
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
-    compileOnly group: 'org.apache.commons', name: 'commons-configuration2', version: '2.8.0'
+    compileOnly group: 'org.apache.commons', name: 'commons-configuration2', version: '2.9.0'
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.425'
     compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.5', withoutServers
     compileOnly group: 'com.google.cloud', name: 'google-cloud-storage', version: '2.6.2'


### PR DESCRIPTION
This was reported as a vulnerability for 4.4, solved here: https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3522

Thought it wouldn't hurt to upgrade the dependency in 5.x as well.
