### PR TITLE
[EaALzior] runTimeboxed doesn't always work

### DIFF
--- a/core/src/main/java/apoc/cypher/Timeboxed.java
+++ b/core/src/main/java/apoc/cypher/Timeboxed.java
@@ -66,11 +66,11 @@ public class Timeboxed {
                     final Map<String, Object> map = result.next();
                     offerToQueue(queue, map, timeout);
                 }
-                offerToQueue(queue, POISON, timeout);
                 innerTx.commit();
             } catch (TransactionTerminatedException e) {
                 log.warn("query " + cypher + " has been terminated");
             } finally {
+                offerToQueue(queue, POISON, timeout);
                 txAtomic.set(null);
             }
         });

--- a/test-utils/src/main/java/apoc/util/TransactionTestUtil.java
+++ b/test-utils/src/main/java/apoc/util/TransactionTestUtil.java
@@ -61,7 +61,7 @@ public class TransactionTestUtil {
         lastTransactionChecks(db, DEFAULT_TIMEOUT, query, timeBefore);
     }
 
-    private static void checkTransactionTime(long timeout, long timePassed) {
+    public static void checkTransactionTime(long timeout, long timePassed) {
         timePassed = (System.currentTimeMillis() - timePassed) / 1000;
         assertTrue("The transaction hasn't been terminated before the timeout time, but after " + timePassed + " seconds",
                 timePassed <= timeout);


### PR DESCRIPTION
If the inner query throws an error, 
the `apoc.cypher.runTimeboxed(...)` continues the execution until the `timeout` terminates.