### PR TITLE
[eBlQUOcs] Bug in apoc.create.cloneToVirtual

### DIFF
--- a/common/src/main/java/apoc/result/VirtualPath.java
+++ b/common/src/main/java/apoc/result/VirtualPath.java
@@ -1,5 +1,6 @@
 package apoc.result;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
@@ -8,6 +9,7 @@ import org.neo4j.graphdb.traversal.Paths;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -127,17 +129,19 @@ public class VirtualPath implements Path {
     }
 
     private void requireConnected(Relationship relationship) {
-        Node previousEndNode;
-        Relationship previousRelationship = lastRelationship();
-        if (previousRelationship != null) {
-            previousEndNode = previousRelationship.getEndNode();
-        } else {
-            previousEndNode = endNode();
-        }
-        if (!relationship.getStartNode().equals(previousEndNode)
-                && !relationship.getEndNode().equals(previousEndNode)) {
+        final List<Node> previousNodes = getPreviousNodes();
+        boolean isRelConnectedToPrevious = CollectionUtils.containsAny( previousNodes, relationship.getNodes() );
+        if (!isRelConnectedToPrevious) {
             throw new IllegalArgumentException("Relationship is not part of current path.");
         }
+    }
+
+    private List<Node> getPreviousNodes() {
+        Relationship previousRelationship = lastRelationship();
+        if (previousRelationship != null) {
+            return Arrays.asList(previousRelationship.getNodes());
+        }
+        return List.of(endNode());
     }
 
     public static final class Builder {

--- a/core/src/test/java/apoc/create/CreateTest.java
+++ b/core/src/test/java/apoc/create/CreateTest.java
@@ -314,6 +314,34 @@ public class CreateTest {
     }
 
     @Test
+    public void testClonePathWithMixedDirectionRelationships() {
+        // rel `:b` is to the left, rel `d` is to the right
+        db.executeTransactionally("CREATE (:a {id: 1})<-[:b {id: 10}]-(:c {id: 2})-[:d {id: 20}]->(:e {id: 3})");
+
+        testCall(db, """
+                MATCH p = (:a)<-[:b]-(:c)-[:d]->(:e)
+                CALL apoc.create.clonePathToVirtual(p) YIELD path RETURN path""", r -> {
+            Path path = (Path) r.get("path");
+            Iterator<Node> nodes = path.nodes().iterator();
+            Node node = nodes.next();
+            assertEquals(Map.of("id", 1L), node.getAllProperties());
+            node = nodes.next();
+            assertEquals(Map.of("id", 2L), node.getAllProperties());
+            node = nodes.next();
+            assertEquals(Map.of("id", 3L), node.getAllProperties());
+            assertFalse(nodes.hasNext());
+
+            Iterator<Relationship> rels = path.relationships().iterator();
+            Relationship rel = rels.next();
+            assertEquals(Map.of("id", 10L), rel.getAllProperties());
+            rel = rels.next();
+            assertEquals(Map.of("id", 20L), rel.getAllProperties());
+            assertFalse(rels.hasNext());
+
+        });
+    }
+
+    @Test
     public void testClonePathShouldNotDuplicateRelsWithMultipaths() {
         //create path with single rels
         db.executeTransactionally("""


### PR DESCRIPTION
The relationship check should verify either the start or the end node