### PR TITLE
[hyxhNENW] remove antlr4 from core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'java-library'
     id 'com.github.johnrengelman.shadow' version '7.1.0'  apply false
     id 'maven-publish'
-    id 'antlr'
     id "com.github.hierynomus.license-report" version"0.16.1"
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -3,7 +3,6 @@ import org.gradle.api.internal.artifacts.DefaultExcludeRule
 plugins {
     id 'java'
     id 'maven-publish'
-    id 'antlr'
     id "com.diffplug.spotless" version "6.7.2"
 }
 
@@ -25,19 +24,9 @@ javadoc {
     options.addStringOption('Xdoclint:none', '-quiet')
 }
 
-generateGrammarSource {
-    arguments += ["-package", "apoc.custom"]
-}
-
 dependencies {
     apt project(':processor')
     apt group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
-
-    antlr "org.antlr:antlr4:4.7.2", {
-        exclude group: 'org.glassfish'
-        exclude group: 'com.ibm.icu'
-        exclude group: 'org.abego.treelayout'
-    }
 
     def withoutServers = {
         exclude group: 'org.eclipse.jetty'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,7 +3,6 @@ import org.gradle.api.internal.artifacts.DefaultExcludeRule
 plugins {
     id 'java'
     id 'maven-publish'
-    id 'antlr'
     id "com.diffplug.spotless" version "6.7.2"
 }
 
@@ -41,19 +40,9 @@ javadoc {
 }
 
 
-generateGrammarSource {
-    arguments += ["-package", "apoc.custom"]
-}
-
 dependencies {
     apt project(':processor')
     apt group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
-
-    antlr "org.antlr:antlr4:4.7.2", {
-        exclude group: 'org.glassfish'
-        exclude group: 'com.ibm.icu'
-        exclude group: 'org.abego.treelayout'
-    }
 
     def withoutServers = {
         exclude group: 'org.eclipse.jetty'


### PR DESCRIPTION
Removed `antlr4` and `generateGrammarSource` (which is only used by `apoc.custom*` extended).

No need to change Extended, 
since `generateGrammarSource` and `antlr` are already included in `extended/build.gradle`