### PR TITLE
[Q8q7GXdk] apoc.export.graphml imports unwanted nodes

### DIFF
--- a/common/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
+++ b/common/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
@@ -35,23 +35,31 @@ public class CypherResultSubGraph implements SubGraph {
         labels.addAll(Iterables.asList(data.getLabels()));
     }
 
-    public void add(Relationship rel) {
+    public void add(Relationship rel, boolean addNodes) {
         final String id = rel.getElementId();
         if (!relationships.containsKey(id)) {
             addRel(id, rel);
-            add(rel.getStartNode());
-            add(rel.getEndNode());
+            // start and end nodes will be added only with the `apoc.meta.*` procedures,
+            // not with the `apoc.export.*.query` ones
+            if (addNodes) {
+                add(rel.getStartNode());
+                add(rel.getEndNode());
+            }
         }
     }
 
     public static SubGraph from(Transaction tx, Result result, boolean addBetween) {
+        return from(tx, result, addBetween, true);
+    }
+
+    public static SubGraph from(Transaction tx, Result result, boolean addBetween, boolean addRelNodes) {
         final CypherResultSubGraph graph = new CypherResultSubGraph();
         final List<String> columns = result.columns();
         try {
             result.forEachRemaining(row -> {
                 for (String column : columns) {
                     final Object value = row.get(column);
-                    graph.addToGraph(value);
+                    graph.addToGraph(value, addRelNodes);
                 }
             });
         } catch (AuthorizationViolationException e) {
@@ -119,16 +127,16 @@ public class CypherResultSubGraph implements SubGraph {
         }
     }
 
-    private void addToGraph(Object value) {
+    private void addToGraph(Object value, boolean addRelNodes) {
         if (value instanceof Node) {
             add((Node) value);
         }
         if (value instanceof Relationship) {
-            add((Relationship) value);
+            add((Relationship) value, addRelNodes);
         }
         if (value instanceof Iterable) {
             for (Object inner : (Iterable) value) {
-                addToGraph(inner);
+                addToGraph(inner, addRelNodes);
             }
         }
     }

--- a/core/src/main/java/apoc/export/cypher/ExportCypher.java
+++ b/core/src/main/java/apoc/export/cypher/ExportCypher.java
@@ -87,7 +87,7 @@ public class ExportCypher {
         ExportConfig c = new ExportConfig(config);
         Result result = tx.execute(query);
         SubGraph graph;
-        graph = CypherResultSubGraph.from(tx, result, c.getRelsInBetween());
+        graph = CypherResultSubGraph.from(tx, result, c.getRelsInBetween(), false);
         String source = String.format("statement: nodes(%d), rels(%d)",
                 Iterables.count(graph.getNodes()), Iterables.count(graph.getRelationships()));
         return exportCypher(fileName, source, graph, c, false);

--- a/core/src/main/java/apoc/export/graphml/ExportGraphML.java
+++ b/core/src/main/java/apoc/export/graphml/ExportGraphML.java
@@ -110,7 +110,7 @@ public class ExportGraphML {
     public Stream<ProgressInfo> query(@Name("statement") String query, @Name("file") String fileName, @Name("config") Map<String, Object> config) throws Exception {
         ExportConfig c = new ExportConfig(config);
         Result result = tx.execute(query);
-        SubGraph graph = CypherResultSubGraph.from(tx, result, c.getRelsInBetween());
+        SubGraph graph = CypherResultSubGraph.from(tx, result, c.getRelsInBetween(), false);
         String source = String.format("statement: nodes(%d), rels(%d)",
                 Iterables.count(graph.getNodes()), Iterables.count(graph.getRelationships()));
         return exportGraphML(fileName, source, graph, c);

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTestUtil.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTestUtil.java
@@ -26,8 +26,8 @@ public class ExportGraphMLTestUtil {
     private static final String KEY_TYPES_EMPTY = "<key id=\"name\" for=\"node\" attr.name=\"name\" attr.type=\"string\"/>%n" +
             "<key id=\"limit\" for=\"node\" attr.name=\"limit\" attr.type=\"long\"/>%n" +
             "<key id=\"labels\" for=\"node\" attr.name=\"labels\" attr.type=\"string\"/>%n";
-    private static final String GRAPH = "<graph id=\"G\" edgedefault=\"directed\">%n";
-    private static final String HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>%n" +
+    public static final String GRAPH = "<graph id=\"G\" edgedefault=\"directed\">%n";
+    public static final String HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>%n" +
             "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">%n";
     private static final String KEY_TYPES_FALSE = "<key id=\"born\" for=\"node\" attr.name=\"born\"/>%n" +
             "<key id=\"values\" for=\"node\" attr.name=\"values\"/>%n" +
@@ -104,7 +104,7 @@ public class ExportGraphMLTestUtil {
             "<node id=\"B\" labels=\":Unit\"><data key=\"Path\">C:\\bright\\itecembed\\obj\\ada\\b3_status.ads</data></node>\n" +
             "<edge source=\"A\" target=\"B\"><!-- <data key=\"Path\">C:\\bright\\itecembed\\obj\\ada\\b3_status.ads</data> --></edge>";
 
-    private static final String FOOTER = "</graph>%n" +
+    public static final String FOOTER = "</graph>%n" +
             "</graphml>";
 
     private static final String DATA_PATH = "<node id=\"n0\" labels=\":Foo:Foo0:Foo2\"><data key=\"TYPE\">:Foo:Foo0:Foo2</data><data key=\"label\">foo</data><data key=\"place\">{\"crs\":\"wgs-84-3d\",\"latitude\":12.78,\"longitude\":56.7,\"height\":100.0}</data><data key=\"name\">foo</data><data key=\"born\">2018-10-10</data></node>%n" +
@@ -141,6 +141,20 @@ public class ExportGraphMLTestUtil {
     public static final String EXPECTED_TYPES_EMPTY = String.format(HEADER + KEY_TYPES_EMPTY + GRAPH + DATA_EMPTY + FOOTER);
     public static final String EXPECTED_TYPES_NO_DATA_KEY = String.format(HEADER + KEY_TYPES_NO_DATA_KEY + GRAPH + DATA_NO_DATA_KEY + FOOTER);
 
+    public static final String EDGES_QUERY = "<edge id=\"e1\" source=\"n3\" target=\"n4\" label=\"REL\"><data key=\"label\">REL</data><data key=\"foo\">bar</data></edge>%n";
+    public static final String EDGES_KEYS_QUERY = "<key id=\"foo\" for=\"edge\" attr.name=\"foo\"/>%n" +
+            "<key id=\"label\" for=\"edge\" attr.name=\"label\"/>%n";
+
+    public static final String START_NODE_QUERY = "<node id=\"n3\" labels=\":Start\"><data key=\"labels\">:Start</data><data key=\"startId\">1</data></node>%n";
+    public static final String START_NODE_KEYS_QUERY = "<key id=\"startId\" for=\"node\" attr.name=\"startId\"/>%n";
+    public static final String LABEL_KEY_QUERY = "<key id=\"labels\" for=\"node\" attr.name=\"labels\"/>%n";
+    public static final String END_NODE_QUERY = "<node id=\"n4\" labels=\":End\"><data key=\"labels\">:End</data><data key=\"endId\">1</data></node>%n";
+    public static final String END_NODE_KEYS_QUERY = "<key id=\"endId\" for=\"node\" attr.name=\"endId\"/>%n";
+    public static final String EXPECTED = String.format(HEADER +
+            END_NODE_KEYS_QUERY + START_NODE_KEYS_QUERY + LABEL_KEY_QUERY + EDGES_KEYS_QUERY +
+            GRAPH +
+            START_NODE_QUERY + END_NODE_QUERY + EDGES_QUERY +
+            FOOTER);
     
     public static void assertXMLEquals(Object output, String xmlString) {
         List<String> attrsWithNodeIds = Arrays.asList("id", "source", "target");


### PR DESCRIPTION
The bug regard the `apoc.export.cypher` as well, since the same method it's called.

- Added `addNodes` parameter with value `false` with export procedures (i.e. not export extra-nodes) 

- Added missing tests with `nodesOfRelationships`