### PR TITLE
[gULAAkri] apoc.periodic.repeat doesn't always work

### DIFF
--- a/common/src/main/java/apoc/periodic/PeriodicUtils.java
+++ b/common/src/main/java/apoc/periodic/PeriodicUtils.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.QueryStatistics;
+import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.TerminationGuard;
@@ -269,7 +270,8 @@ public class PeriodicUtils {
         Map<String,Object> params = (Map) config.getOrDefault("params", Collections.emptyMap());
         JobInfo info = submitJob(name, () -> {
             try {
-                db.executeTransactionally(statement, params);
+                // `resultAsString` in order to consume result
+                db.executeTransactionally(statement, params, Result::resultAsString);
             } catch(Exception e) {
                 log.warn("in background task via submit", e);
                 throw new RuntimeException(e);

--- a/core/src/main/java/apoc/periodic/Periodic.java
+++ b/core/src/main/java/apoc/periodic/Periodic.java
@@ -188,7 +188,8 @@ public class Periodic {
         validateQuery(statement);
         Map<String,Object> params = (Map)config.getOrDefault("params", Collections.emptyMap());
         JobInfo info = schedule(name, () -> {
-            db.executeTransactionally(statement, params);
+            // `resultAsString` in order to consume result
+            db.executeTransactionally(statement, params, Result::resultAsString);
         },0,rate);
         return Stream.of(info);
     }


### PR DESCRIPTION
Fixes #17

Most likely the bug occurs when there is a `RETURN ...` preceded by a void procedure with mode = "READ" (like the related gh issue)

- Added `Result::resultAsString` in order to consume results with void procedures.
- Check that the `db.prepareForReplanning` (which is a void read procedure) logs correctly 


