### PR TITLE
[D2VH2D8O] Only create trigger listeners on system db.

### DIFF
--- a/core/src/main/java/apoc/cypher/CypherInitializer.java
+++ b/core/src/main/java/apoc/cypher/CypherInitializer.java
@@ -78,10 +78,8 @@ public class CypherInitializer implements AvailabilityListener {
                                       "The two first numbers of both versions needs to be the same.",
                                       apocVersion, neo4jVersion );
                     }
+                    databaseEventListeners.registerDatabaseEventListener(new SystemFunctionalityListener());
                 }
-
-                // create listener for each database
-                databaseEventListeners.registerDatabaseEventListener(new SystemFunctionalityListener());
 
                 Configuration config = dependencyResolver.resolveDependency(ApocConfig.class).getConfig();
                 for (String query : collectInitializers(config)) {

--- a/it/src/test/java/apoc/it/core/TriggerEnterpriseFeaturesTest.java
+++ b/it/src/test/java/apoc/it/core/TriggerEnterpriseFeaturesTest.java
@@ -1,4 +1,5 @@
 package apoc.it.core;
+import apoc.SystemLabels;
 import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
 import org.junit.After;
@@ -20,6 +21,7 @@ import java.util.stream.Stream;
 
 import static apoc.ApocConfig.APOC_CONFIG_INITIALIZER;
 import static apoc.ApocConfig.APOC_TRIGGER_ENABLED;
+import static apoc.SystemPropertyKeys.database;
 import static apoc.trigger.TriggerHandler.TRIGGER_REFRESH;
 import static apoc.trigger.TriggerTestUtil.TIMEOUT;
 import static apoc.trigger.TriggerTestUtil.TRIGGER_DEFAULT_REFRESH;
@@ -201,6 +203,38 @@ public class TriggerEnterpriseFeaturesTest {
         testCallEmpty(sysSession, "CALL apoc.trigger.show($dbName)",
                 Map.of("dbName", dbToDelete)
         );
+    }
+
+    @Test
+    public void testNotDeleteUserDbTriggerNodeAfterDatabaseDeletion() {
+        final String dbToDelete = "todelete";
+
+         // create a node in the Neo4j db that looks like a trigger
+        try (Session defaultSession = neo4jContainer.getDriver().session(forDatabase(DEFAULT_DATABASE_NAME))) {
+            defaultSession.writeTransaction(tx -> tx.run(String.format("CREATE (:%s {%s:'%s'})", SystemLabels.ApocTrigger, database.name(), dbToDelete)));
+        }
+
+        try (Session sysSession = neo4jContainer.getDriver().session(forDatabase(SYSTEM_DATABASE_NAME)))
+        {
+            // create database with name `todelete`
+            sysSession.writeTransaction( tx -> tx.run( String.format( "CREATE DATABASE %s WAIT;", dbToDelete ) ) );
+
+            // install a trigger for the database
+            final String defaultTriggerName = UUID.randomUUID().toString();
+            testCall( sysSession, "CALL apoc.trigger.install($dbName, $name, 'return 1', {})", Map.of( "dbName", dbToDelete, "name", defaultTriggerName ),
+                    r -> assertEquals( defaultTriggerName, r.get( "name" ) ) );
+
+            // drop database
+            sysSession.writeTransaction( tx -> tx.run( String.format( "DROP DATABASE %s WAIT;", dbToDelete ) ) );
+        }
+
+        // check that the node in Neo4j database is still there
+        try (Session defaultSession = neo4jContainer.getDriver().session(forDatabase(DEFAULT_DATABASE_NAME))) {
+            testCall(defaultSession, String.format("MATCH (n:%s) RETURN n.%s AS result", SystemLabels.ApocTrigger, database.name()),
+                Map.of(),
+                r -> assertEquals(dbToDelete, r.get("result"))
+            );
+        }
     }
 
     @Test


### PR DESCRIPTION
Adding listeners to each database can cause nodes from user databases to be removed, as well as cause issues with concurrent drop database commands.