### PR TITLE
[NOID] Allow new constraint types to be introduced

### DIFF
--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -1054,6 +1054,7 @@ public class Util {
         return switch (type) {
             case NODE_KEY, NODE_PROPERTY_EXISTENCE, UNIQUENESS -> ConstraintCategory.NODE;
             case RELATIONSHIP_KEY, RELATIONSHIP_UNIQUENESS, RELATIONSHIP_PROPERTY_EXISTENCE -> ConstraintCategory.RELATIONSHIP;
+            default -> throw new IllegalStateException("Constraint with a type not supported by apoc");
         };
     }
 


### PR DESCRIPTION
apoc will still compile if new constraint types are added, but then needs to be updated with support for these types before they are available for use.