### PR TITLE
[NOID] Solves CI bug with NEO4J_VERSION variable not being available

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise' : 'neo4j:5.9.0-enterprise',
-                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") : 'neo4j:5.9.0',
+                'neo4jDockerImage' : project.hasProperty("neo4jVersionOverride") ? 'neo4j:' + project.getProperty("neo4jVersionOverride") + '-enterprise' : 'neo4j:5.9.0-enterprise',
+                'neo4jCommunityDockerImage': project.hasProperty("neo4jVersionOverride") ? 'neo4j:' + project.getProperty("neo4jVersionOverride") : 'neo4j:5.9.0',
                 'coreDir': 'core'
 
         maxHeapSize = "5G"


### PR DESCRIPTION
## What
Changes `System.getProperty("NEO4JVERSION")` for `project.hasProperty("neo4jVersionOverride") ` in the docker images version.

## Why
Because when they've updated the TeamCity jobs to bump the neo4j version, `NEO4JVERSION` was never available because it was never set a system property, causing the docker containers to say:

```
  Caused by: org.testcontainers.containers.ContainerFetchException: Can't get Docker image: RemoteDockerImage(imageName=neo4j:5.8.0-enterprise, imagePullPolicy=DefaultPullPolicy(), imageNameSubstitutor=org.testcontainers.utility.ImageNameSubstitutor$LogWrappedImageNameSubstitutor@278fe428)
```

Further down the file we do set the neo4j version correctly for the Java artifacts:

```
ext {
    publicDir =  "${project.rootDir}"
    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : "5.9.0"
    testContainersVersion = '1.17.6'
}
```