### PR TITLE
[HJwIMwqg] apoc.export.csv.graph incorrectly exports properties with datatype float

### DIFF
--- a/common/src/main/java/apoc/export/util/BulkImportUtil.java
+++ b/common/src/main/java/apoc/export/util/BulkImportUtil.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 public class BulkImportUtil {
 
-    private static Map<Class<?>, String> allowedMapping = Collections.unmodifiableMap(new HashMap(){{
+    public static Map<Class<?>, String> allowedMapping = Collections.unmodifiableMap(new HashMap(){{
         put(Double.class, "double");
         put(Float.class, "float");
         put(Integer.class, "int");

--- a/common/src/main/java/apoc/export/util/MetaInformation.java
+++ b/common/src/main/java/apoc/export/util/MetaInformation.java
@@ -37,10 +37,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static apoc.export.util.BulkImportUtil.allowedMapping;
 import static apoc.gephi.GephiFormatUtils.getCaption;
 import static apoc.meta.tablesforlabels.PropertyTracker.typeMappings;
 import static apoc.util.collection.Iterables.stream;
 import static java.util.Arrays.asList;
+import static org.apache.commons.lang3.ClassUtils.primitiveToWrapper;
 
 /**
  * @author mh
@@ -113,9 +115,17 @@ public class MetaInformation {
     
     public static String typeFor(Class value, Set<String> allowed) {
         if (value == void.class) return null; // Is this necessary?
+        final boolean isArray = value.isArray();
+        value = isArray ? value.getComponentType() : value;
+        // csv case
+        if (allowed == null) {
+            return allowedMapping.getOrDefault(primitiveToWrapper(value), "string")
+                    + (isArray ? "[]" : "");
+        }
+        // graphML case
+        String name = value.getSimpleName().toLowerCase();
+        boolean isAllowed = allowed.contains(name);
         Types type = Types.of(value);
-        String name = (value.isArray() ? value.getComponentType() : value).getSimpleName().toLowerCase();
-        boolean isAllowed = allowed != null && allowed.contains(name);
         switch (type) {
             case NULL:
                 return null;

--- a/common/src/main/java/apoc/export/util/MetaInformation.java
+++ b/common/src/main/java/apoc/export/util/MetaInformation.java
@@ -118,9 +118,9 @@ public class MetaInformation {
         final boolean isArray = value.isArray();
         value = isArray ? value.getComponentType() : value;
         // csv case
+        // consistent with https://neo4j.com/docs/operations-manual/current/tools/neo4j-admin/neo4j-admin-import/#import-tool-header-format-properties
         if (allowed == null) {
-            return allowedMapping.getOrDefault(primitiveToWrapper(value), "string")
-                    + (isArray ? "[]" : "");
+            return allowedMapping.getOrDefault( primitiveToWrapper(value), "string" );
         }
         // graphML case
         String name = value.getSimpleName().toLowerCase();

--- a/common/src/main/resources/manyTypes.csv
+++ b/common/src/main/resources/manyTypes.csv
@@ -1,5 +1,5 @@
-_id:id,_labels:label,alpha:short,beta:byte[],epsilon:int,eta:long,five:date,four:localdatetime,gamma:char,iota,kappa:string[],one:datetime,seven,six:duration,theta:double,three:localtime,two:time,zeta:float,_start:id,_end:id,_type:label,rel:point
-0,:SuperNode,,,,,2020-01-01,2021-06-08T00:00,,,,2018-05-10T10:30+02:00[Europe/Berlin],2020,P5M1DT12H,,17:58:30,18:02:33Z,,,,,
-1,:AnotherNode,1,"cXdlcnR5",1,1,,,A,bar,["un","deux","trois"],,,,10.1,,,1.1,,,,
-,,,,,,,,,,,,,,,,,,0,1,REL_TYPE,{"crs":"cartesian","x":56.7,"y":12.78,"z":null}
+_id:id,_labels:label,alpha:short,beta:byte,epsilon:int,eta:long,five:date,four:localdatetime,gamma:char,iota,one:datetime,seven,six:duration,theta:double,three:localtime,two:time,zeta:float,_start:id,_end:id,_type:label,rel:point
+0,:SuperNode,,,,,2020-01-01,2021-06-08T00:00,,,2018-05-10T10:30+02:00[Europe/Berlin],2020,P5M1DT12H,,17:58:30,18:02:33Z,,,,,
+1,:AnotherNode,1,"cXdlcnR5",1,1,,,A,bar,,,,10.1,,,1.1,,,,
+,,,,,,,,,,,,,,,,,0,1,REL_TYPE,{"crs":"cartesian","x":56.7,"y":12.78,"z":null}
 

--- a/common/src/main/resources/manyTypes.csv
+++ b/common/src/main/resources/manyTypes.csv
@@ -1,0 +1,5 @@
+_id:id,_labels:label,alpha:short,beta:byte[],epsilon:int,eta:long,five:date,four:localdatetime,gamma:char,iota,kappa:string[],one:datetime,seven,six:duration,theta:double,three:localtime,two:time,zeta:float,_start:id,_end:id,_type:label,rel:point
+0,:SuperNode,,,,,2020-01-01,2021-06-08T00:00,,,,2018-05-10T10:30+02:00[Europe/Berlin],2020,P5M1DT12H,,17:58:30,18:02:33Z,,,,,
+1,:AnotherNode,1,"cXdlcnR5",1,1,,,A,bar,["un","deux","trois"],,,,10.1,,,1.1,,,,
+,,,,,,,,,,,,,,,,,,0,1,REL_TYPE,{"crs":"cartesian","x":56.7,"y":12.78,"z":null}
+

--- a/core/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/core/src/main/java/apoc/export/csv/CsvFormat.java
@@ -291,9 +291,13 @@ public class CsvFormat {
     }
 
     private List<Map.Entry<String, String>> generateHeader(Map<String, Class> propTypes, boolean useTypes, String... starters) {
+        // we create a List of Entry<PropertyName, PropertyDataType>,
+        // so that the headers will look like nameProp:typeProp,nameProp2:typeProp2,...
+        // or, with config `useTypes: false`, like nameProp,nameProp2,...
         List<Map.Entry<String, String>> result = Arrays.stream(starters)
                 .map(item -> {
                     final String[] split = item.split(":");
+                    // with the config `useTypes: true`, we add `:<typeProp>` to each colum
                     return new AbstractMap.SimpleEntry<>(split[0], useTypes ? (":" + split[1]) : "");
                 })
                 .collect(Collectors.toList());
@@ -301,6 +305,7 @@ public class CsvFormat {
         result.addAll(propTypes.entrySet().stream()
                 .map(entry -> {
                     String type = MetaInformation.typeFor(entry.getValue(), null);
+                    // with the config `useTypes: true`, if the type is not null , we add `:<typeProp>` to each colum
                     return new AbstractMap.SimpleEntry<>(entry.getKey(),
                             (type == null || type.equals("string") || !useTypes) ? "" : ":" + type);
                 })

--- a/core/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/core/src/main/java/apoc/export/csv/CsvFormat.java
@@ -40,7 +40,9 @@ import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -163,15 +165,22 @@ public class CsvFormat {
     public void writeAll(SubGraph graph, Reporter reporter, ExportConfig config, CSVWriter out) {
         Map<String, Class> nodePropTypes = collectPropTypesForNodes(graph, db, config);
         Map<String, Class> relPropTypes = collectPropTypesForRelationships(graph, db, config);
-        List<String> nodeHeader = generateHeader(nodePropTypes, config.useTypes(), NODE_HEADER_FIXED_COLUMNS);
-        List<String> relHeader = generateHeader(relPropTypes, config.useTypes(), REL_HEADER_FIXED_COLUMNS);
-        List<String> header = new ArrayList<>(nodeHeader);
+        List<Map.Entry<String, String>> nodeHeader = generateHeader(nodePropTypes, config.useTypes(), NODE_HEADER_FIXED_COLUMNS);
+        List<Map.Entry<String, String>> relHeader = generateHeader(relPropTypes, config.useTypes(), REL_HEADER_FIXED_COLUMNS);
+        List<Map.Entry<String, String>> header = new ArrayList<>(nodeHeader);
         header.addAll(relHeader);
-        out.writeNext(header.toArray(new String[header.size()]), applyQuotesToAll);
+        out.writeNext(header.stream().map(e -> e.getKey() + e.getValue()).toArray(String[]::new), applyQuotesToAll);
         int cols = header.size();
 
-        writeNodes(graph, out, reporter, nodeHeader.subList(NODE_HEADER_FIXED_COLUMNS.length, nodeHeader.size()), cols, config.getBatchSize());
-        writeRels(graph, out, reporter, relHeader.subList(REL_HEADER_FIXED_COLUMNS.length, relHeader.size()), cols, nodeHeader.size(), config.getBatchSize());
+        writeNodes(graph, out, reporter, getNamesHeader(nodeHeader, NODE_HEADER_FIXED_COLUMNS.length), cols, config.getBatchSize());
+        writeRels(graph, out, reporter, getNamesHeader(relHeader, REL_HEADER_FIXED_COLUMNS.length), cols, nodeHeader.size(), config.getBatchSize());
+    }
+
+    private List<String> getNamesHeader(List<Map.Entry<String, String>> nodeHeader, int length) {
+        return nodeHeader.subList(length, nodeHeader.size())
+                .stream()
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
     }
 
     private void writeAllBulkImport(SubGraph graph, Reporter reporter, ExportConfig config, ExportFileManager writer) {
@@ -281,20 +290,21 @@ public class CsvFormat {
         }
     }
 
-    private List<String> generateHeader(Map<String, Class> propTypes, boolean useTypes, String... starters) {
-        List<String> result = new ArrayList<>();
-        if (useTypes) {
-            Collections.addAll(result, starters);
-        } else {
-            result.addAll(Stream.of(starters).map(s -> s.split(":")[0]).collect(Collectors.toList()));
-        }
+    private List<Map.Entry<String, String>> generateHeader(Map<String, Class> propTypes, boolean useTypes, String... starters) {
+        List<Map.Entry<String, String>> result = Arrays.stream(starters)
+                .map(item -> {
+                    final String[] split = item.split(":");
+                    return new AbstractMap.SimpleEntry<>(split[0], useTypes ? (":" + split[1]) : "");
+                })
+                .collect(Collectors.toList());
+
         result.addAll(propTypes.entrySet().stream()
                 .map(entry -> {
                     String type = MetaInformation.typeFor(entry.getValue(), null);
-                    return (type == null || type.equals("string") || !useTypes)
-                            ? entry.getKey() : entry.getKey() + ":" + type;
+                    return new AbstractMap.SimpleEntry<>(entry.getKey(),
+                            (type == null || type.equals("string") || !useTypes) ? "" : ":" + type);
                 })
-                .sorted()
+                .sorted(Map.Entry.comparingByKey())
                 .collect(Collectors.toList()));
         return result;
     }

--- a/core/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/core/src/main/java/apoc/export/csv/CsvFormat.java
@@ -176,8 +176,8 @@ public class CsvFormat {
         writeRels(graph, out, reporter, getNamesHeader(relHeader, REL_HEADER_FIXED_COLUMNS.length), cols, nodeHeader.size(), config.getBatchSize());
     }
 
-    private List<String> getNamesHeader(List<Map.Entry<String, String>> nodeHeader, int length) {
-        return nodeHeader.subList(length, nodeHeader.size())
+    private List<String> getNamesHeader(List<Map.Entry<String, String>> header, int length) {
+        return header.subList(length, header.size())
                 .stream()
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toList());

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -139,7 +139,7 @@ public class ExportCsvTest {
             ",,,,,,,,0,1,KNOWS%n" +
             ",,,,,,,,3,4,NEXT_DELIVERY%n");
 
-    private static final File directory = new File("target/import");
+    public static final File directory = new File("target/import");
     static {
         //noinspection ResultOfMethodCallIgnored
         directory.mkdirs();
@@ -158,11 +158,11 @@ public class ExportCsvTest {
         db.executeTransactionally("CREATE (f:Address1:Address {name:'Andrea', city: 'Milano', street:'Via Garibaldi, 7'})-[:NEXT_DELIVERY]->(a:Address {name: 'Bar Sport'}), (b:Address {street: 'via Benni'})");
     }
 
-    private String readFile(String fileName) {
+    public static String readFile(String fileName) {
         return readFile(fileName, UTF_8, CompressionAlgo.NONE);
     }
     
-    private String readFile(String fileName, Charset charset, CompressionAlgo compression) {
+    public static String readFile(String fileName, Charset charset, CompressionAlgo compression) {
         return BinaryTestUtil.readFileToString(new File(directory, fileName), charset, compression);
     }
 
@@ -394,11 +394,11 @@ public class ExportCsvTest {
         assertEquals(EXPECTED_QUERY_NODES, readFile(fileName));
     }
 
-    private void assertResults(String fileName, Map<String, Object> r, final String source) {
+    public static void assertResults(String fileName, Map<String, Object> r, final String source) {
         assertResults(fileName, r, source, 6L, 2L, 12L, true);
     }
 
-    private void assertResults(String fileName, Map<String, Object> r, final String source, 
+    public static void assertResults(String fileName, Map<String, Object> r, final String source,
                                Long expectedNodes, Long expectedRelationships, Long expectedProperties, boolean assertPropEquality) {
         assertEquals(expectedNodes, r.get("nodes"));
         assertEquals(expectedRelationships, r.get("relationships"));
@@ -412,7 +412,7 @@ public class ExportCsvTest {
         assertCsvCommon(fileName, r);
     }
 
-    private void assertCsvCommon(String fileName, Map<String, Object> r) {
+    private static void assertCsvCommon(String fileName, Map<String, Object> r) {
         assertEquals(fileName, r.get("file"));
         assertEquals("csv", r.get("format"));
         assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -50,6 +50,8 @@ import java.util.function.Consumer;
 import static apoc.ApocConfig.APOC_EXPORT_FILE_ENABLED;
 import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;
+import static apoc.export.util.ExportConfig.IF_NEEDED_QUUOTES;
+import static apoc.export.util.ExportConfig.NONE_QUOTES;
 import static apoc.util.BinaryTestUtil.getDecompressedData;
 import static apoc.util.CompressionAlgo.DEFLATE;
 import static apoc.util.CompressionAlgo.GZIP;
@@ -70,6 +72,16 @@ import static org.junit.Assert.fail;
  * @since 22.05.16
  */
 public class ExportCsvTest {
+    public static final String CALL_ALL = "CALL apoc.export.csv.all($file, $config)";
+    public static final String CALL_QUERY = "CALL apoc.export.csv.query($query,$file, $config)";
+    public static final String CALL_DATA = """
+            CALL apoc.graph.fromDB('test',{}) yield graph
+            CALL apoc.export.csv.data(graph.nodes, graph.relationships, $file, $config)
+            YIELD nodes, relationships, properties, file, source,format, time RETURN *""";
+    public static final String CALL_GRAPH = """
+            CALL apoc.graph.fromDB('test',{}) yield graph
+            CALL apoc.export.csv.graph(graph, $file, $config)
+            YIELD nodes, relationships, properties, file, source,format, time RETURN *""";
 
     private static final String EXPECTED_QUERY_NODES = String.format("\"u\"%n" +
             "\"{\"\"id\"\":0,\"\"labels\"\":[\"\"User\"\",\"\"User1\"\"],\"\"properties\"\":{\"\"name\"\":\"\"foo\"\",\"\"age\"\":42,\"\"male\"\":true,\"\"kids\"\":[\"\"a\"\",\"\"b\"\",\"\"c\"\"]}}\"%n" +
@@ -95,18 +107,20 @@ public class ExportCsvTest {
             "Andrea,Milano,\"Via Garibaldi, 7\",\"[\"Address1\",\"Address\"]\"%n" +
             "Bar Sport,,,\"[\"Address\"]\"%n" +
             ",,via Benni,\"[\"Address\"]\"%n");
-    private static final String EXPECTED = String.format("\"_id\",\"_labels\",\"age\",\"city\",\"kids\",\"male\",\"name\",\"street\",\"_start\",\"_end\",\"_type\"%n" +
-            "\"0\",\":User:User1\",\"42\",\"\",\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",\"true\",\"foo\",\"\",,,%n" +
+    private static final String EXPECTED_BODY = "\"0\",\":User:User1\",\"42\",\"\",\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",\"true\",\"foo\",\"\",,,%n" +
             "\"1\",\":User\",\"42\",\"\",\"\",\"\",\"bar\",\"\",,,%n" +
             "\"2\",\":User\",\"12\",\"\",\"\",\"\",\"\",\"\",,,%n" +
             "\"3\",\":Address:Address1\",\"\",\"Milano\",\"\",\"\",\"Andrea\",\"Via Garibaldi, 7\",,,%n" +
             "\"4\",\":Address\",\"\",\"\",\"\",\"\",\"Bar Sport\",\"\",,,%n" +
             "\"5\",\":Address\",\"\",\"\",\"\",\"\",\"\",\"via Benni\",,,%n" +
             ",,,,,,,,\"0\",\"1\",\"KNOWS\"%n" +
-            ",,,,,,,,\"3\",\"4\",\"NEXT_DELIVERY\"%n");
+            ",,,,,,,,\"3\",\"4\",\"NEXT_DELIVERY\"%n";
+    private static final String EXPECTED_WITH_USE_TYPES = String.format("\"_id:id\",\"_labels:label\",\"age:long\",\"city\",\"kids\",\"male:boolean\",\"name\",\"street\",\"_start:id\",\"_end:id\",\"_type:label\"%n" +
+            EXPECTED_BODY);
+    private static final String EXPECTED = String.format("\"_id\",\"_labels\",\"age\",\"city\",\"kids\",\"male\",\"name\",\"street\",\"_start\",\"_end\",\"_type\"%n" +
+            EXPECTED_BODY);
 
-    private static final String EXP_SAMPLE = "\"_id\",\"_labels\",\"address\",\"age\",\"baz\",\"city\",\"foo\",\"kids\",\"last:Name\",\"male\",\"name\",\"street\",\"_start\",\"_end\",\"_type\",\"one\",\"three\"\n" +
-            "\"0\",\":User:User1\",\"\",\"42\",\"\",\"\",\"\",\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",\"\",\"true\",\"foo\",\"\",,,,,\n" +
+    private static final String EXP_SAMPLE_BODY = "\"0\",\":User:User1\",\"\",\"42\",\"\",\"\",\"\",\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",\"\",\"true\",\"foo\",\"\",,,,,\n" +
             "\"1\",\":User\",\"\",\"42\",\"\",\"\",\"\",\"\",\"\",\"\",\"bar\",\"\",,,,,\n" +
             "\"2\",\":User\",\"\",\"12\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",,,,,\n" +
             "\"3\",\":Address:Address1\",\"\",\"\",\"\",\"Milano\",\"\",\"\",\"\",\"\",\"Andrea\",\"Via Garibaldi, 7\",,,,,\n" +
@@ -119,25 +133,35 @@ public class ExportCsvTest {
             ",,,,,,,,,,,,\"0\",\"1\",\"KNOWS\",\"\",\"\"\n" +
             ",,,,,,,,,,,,\"3\",\"4\",\"NEXT_DELIVERY\",\"\",\"\"\n" +
             ",,,,,,,,,,,,\"8\",\"9\",\"KNOWS\",\"two\",\"four\"\n";
+    private static final String EXP_SAMPLE_WITH_USE_TYPES = "\"_id:id\",\"_labels:label\",\"address\",\"age:long\",\"baz\",\"city\",\"foo\",\"kids\",\"last:Name\",\"male:boolean\",\"name\",\"street\",\"_start:id\",\"_end:id\",\"_type:label\",\"one\",\"three\"\n" +
+            EXP_SAMPLE_BODY;
+    private static final String EXP_SAMPLE = "\"_id\",\"_labels\",\"address\",\"age\",\"baz\",\"city\",\"foo\",\"kids\",\"last:Name\",\"male\",\"name\",\"street\",\"_start\",\"_end\",\"_type\",\"one\",\"three\"\n" +
+            EXP_SAMPLE_BODY;
 
-    private static final String EXPECTED_NONE_QUOTES = String.format("_id,_labels,age,city,kids,male,name,street,_start,_end,_type%n" +
-            "0,:User:User1,42,,[\"a\",\"b\",\"c\"],true,foo,,,,%n" +
+    private static final String EXPECTED_NONE_QUOTES_BODY = "0,:User:User1,42,,[\"a\",\"b\",\"c\"],true,foo,,,,%n" +
             "1,:User,42,,,,bar,,,,%n" +
             "2,:User,12,,,,,,,,%n" +
             "3,:Address:Address1,,Milano,,,Andrea,Via Garibaldi, 7,,,%n" +
             "4,:Address,,,,,Bar Sport,,,,%n" +
             "5,:Address,,,,,,via Benni,,,%n" +
             ",,,,,,,,0,1,KNOWS%n" +
-            ",,,,,,,,3,4,NEXT_DELIVERY%n");
-    private static final String EXPECTED_NEEDED_QUOTES = String.format("_id,_labels,age,city,kids,male,name,street,_start,_end,_type%n" +
-            "0,:User:User1,42,,\"[\"a\",\"b\",\"c\"]\",true,foo,,,,%n" +
+            ",,,,,,,,3,4,NEXT_DELIVERY%n";
+    private static final String EXPECTED_NONE_QUOTES = String.format("_id,_labels,age,city,kids,male,name,street,_start,_end,_type%n" +
+            EXPECTED_NONE_QUOTES_BODY);
+    private static final String EXPECTED_NONE_QUOTES_WITH_USE_TYPES = String.format("_id:id,_labels:label,age:long,city,kids,male:boolean,name,street,_start:id,_end:id,_type:label%n" +
+            EXPECTED_NONE_QUOTES_BODY);
+    public static final String EXPECTED_NEEDED_QUOTES_BODY = "0,:User:User1,42,,\"[\"a\",\"b\",\"c\"]\",true,foo,,,,%n" +
             "1,:User,42,,,,bar,,,,%n" +
             "2,:User,12,,,,,,,,%n" +
             "3,:Address:Address1,,Milano,,,Andrea,\"Via Garibaldi, 7\",,,%n" +
             "4,:Address,,,,,Bar Sport,,,,%n" +
             "5,:Address,,,,,,via Benni,,,%n" +
             ",,,,,,,,0,1,KNOWS%n" +
-            ",,,,,,,,3,4,NEXT_DELIVERY%n");
+            ",,,,,,,,3,4,NEXT_DELIVERY%n";
+    private static final String EXPECTED_NEEDED_QUOTES = String.format("_id,_labels,age,city,kids,male,name,street,_start,_end,_type%n" +
+            EXPECTED_NEEDED_QUOTES_BODY);
+    private static final String EXPECTED_NEEDED_QUOTES_WITH_USE_TYPES = String.format("_id:id,_labels:label,age:long,city,kids,male:boolean,name,street,_start:id,_end:id,_type:label%n" +
+            EXPECTED_NEEDED_QUOTES_BODY);
 
     public static final File directory = new File("target/import");
     static {
@@ -184,7 +208,7 @@ public class ExportCsvTest {
     public void testExportAllCsvCompressed() {
         final CompressionAlgo compressionAlgo = DEFLATE;
         String fileName = "all.csv.zz";
-        TestUtil.testCall(db, "CALL apoc.export.csv.all($file, $config)",
+        TestUtil.testCall(db, CALL_ALL,
                 map("file", fileName, "config", map("compression", compressionAlgo.name())),
                 (r) -> assertResults(fileName, r, "database"));
         assertEquals(EXPECTED, readFile(fileName, UTF_8, compressionAlgo));
@@ -197,7 +221,7 @@ public class ExportCsvTest {
         String fileName = "separatedFiles.csv.gzip";
         final Map<String, Object> params = map("file", fileName, "query", "MATCH (u:Roundtrip) return u.name as name", 
                 "config", map(CompressionConfig.COMPRESSION, GZIP.name()));
-        TestUtil.testCall(db, "CALL apoc.export.csv.query($query, $file, $config)", params,
+        TestUtil.testCall(db, CALL_QUERY, params,
                 (r) -> assertEquals(fileName, r.get("file")));
 
         final String deleteQuery = "MATCH (n:Roundtrip) DETACH DELETE n";
@@ -240,24 +264,52 @@ public class ExportCsvTest {
 
     @Test
     public void testExportAllCsvWithSample() throws IOException {
+        // quotes: 'none' to simplify header testing
+        Map<String, Object> configWithSample = Map.of("sampling", true,
+                "samplingConfig", Map.of("sample", 1L),
+                "quotes", NONE_QUOTES
+        );
+        List<String> headers = List.of("_id", "_labels", "_start", "_end", "_type");
+
+        testExportSampleCommon(Map.of(), EXP_SAMPLE,
+                configWithSample, headers);
+    }
+
+    @Test
+    public void testExportAllCsvWithSampleAndUseTypes() throws IOException {
+        Map<String, Object> configWithoutSample = Map.of("useTypes", true);
+
+        // quotes: 'none' to simplify header testing
+        Map<String, Object> configWithSample = Map.of("sampling", true,
+                "samplingConfig", Map.of("sample", 1L),
+                "quotes", NONE_QUOTES,
+                "useTypes", true);
+
+        List<String> headers = List.of("_id:id", "_labels:label", "_start:id", "_end:id", "_type:label");
+
+        testExportSampleCommon(configWithoutSample, EXP_SAMPLE_WITH_USE_TYPES,
+                configWithSample, headers);
+    }
+
+    private static void testExportSampleCommon(Map<String, Object> configWithoutSample, String expSample, Map<String, Object> configWithSample, List<String> headers) throws IOException {
         db.executeTransactionally("CREATE (:User:Sample {`last:Name`:'Galilei'}), (:User:Sample {address:'Universe'}),\n" +
                 "(:User:Sample {foo:'bar'})-[:KNOWS {one: 'two', three: 'four'}]->(:User:Sample {baz:'baa', foo: true})");
         String fileName = "all.csv";
         final long totalNodes = 10L;
         final long totalRels = 3L;
         final long totalProps = 19L;
-        TestUtil.testCall(db, "CALL apoc.export.csv.all($file, null)", map("file", fileName),
+        TestUtil.testCall(db, CALL_ALL, map("file", fileName, "config", configWithoutSample),
                 (r) -> assertResults(fileName, r, "database", totalNodes, totalRels, totalProps, true));
-        assertEquals(EXP_SAMPLE, readFile(fileName));
+        assertEquals(expSample, readFile(fileName));
 
-        // quotes: 'none' to simplify header testing
-        TestUtil.testCall(db, "CALL apoc.export.csv.all($file, {sampling: true, samplingConfig: {sample: 1}, quotes: 'none'})", map("file", fileName),
+        // check that totalNodes, totalRels and totalProps are consistent with non-sample export
+        TestUtil.testCall(db, CALL_ALL, map("file", fileName, "config", configWithSample),
                 (r) -> assertResults(fileName, r, "database", totalNodes, totalRels, totalProps, false));
-        
+
         final String[] s = Files.lines(new File(directory, fileName).toPath()).findFirst().get().split(",");
         assertTrue(s.length < 17);
-        assertTrue(Arrays.asList(s).containsAll(List.of("_id", "_labels", "_start", "_end", "_type")));
-        
+        assertTrue(Arrays.asList(s).containsAll(headers));
+
         db.executeTransactionally("MATCH (n:Sample) DETACH DELETE n");
     }
 
@@ -271,12 +323,33 @@ public class ExportCsvTest {
     }
 
     @Test
+    public void testExportAllCsvWithQuotesAndUseTypes() {
+        String fileName = "all.csv";
+        Map<String, Object> config = Map.of("useTypes", true, "quotes", true);
+        TestUtil.testCall(db, CALL_ALL,
+                map("file", fileName, "config", config),
+                (r) -> assertResults(fileName, r, "database"));
+        assertEquals(EXPECTED_WITH_USE_TYPES, readFile(fileName));
+    }
+
+    @Test
     public void testExportAllCsvWithoutQuotes() {
         String fileName = "all.csv";
         TestUtil.testCall(db, "CALL apoc.export.csv.all($file,{quotes: 'none'})",
                 map("file", fileName),
                 (r) -> assertResults(fileName, r, "database"));
         assertEquals(EXPECTED_NONE_QUOTES, readFile(fileName));
+    }
+
+
+    @Test
+    public void testExportAllCsvWithoutQuotesAndUseTypes() {
+        String fileName = "all.csv";
+        Map<String, Object> config = Map.of("useTypes", true, "quotes", NONE_QUOTES);
+        TestUtil.testCall(db, CALL_ALL,
+                map("file", fileName, "config", config),
+                (r) -> assertResults(fileName, r, "database"));
+        assertEquals(EXPECTED_NONE_QUOTES_WITH_USE_TYPES, readFile(fileName));
     }
 
     @Test
@@ -289,33 +362,105 @@ public class ExportCsvTest {
     }
 
     @Test
+    public void testExportAllCsvNeededQuotesAndUseTypes() {
+        String fileName = "all.csv";
+        Map<String, Object> config = Map.of("useTypes", true, "quotes", IF_NEEDED_QUUOTES);
+        TestUtil.testCall(db, CALL_ALL,
+                map("file", fileName, "config", config),
+                (r) -> assertResults(fileName, r, "database"));
+        assertEquals(EXPECTED_NEEDED_QUOTES_WITH_USE_TYPES, readFile(fileName));
+    }
+
+    @Test
     public void testExportGraphCsv() {
         String fileName = "graph.csv";
-        TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
-                        "CALL apoc.export.csv.graph(graph, $file,{quotes: 'none'}) " +
-                        "YIELD nodes, relationships, properties, file, source,format, time " +
-                        "RETURN *", map("file", fileName),
+        Map<String, Object> config = Map.of("quotes", NONE_QUOTES);
+        TestUtil.testCall(db, CALL_GRAPH, map("file", fileName, "config", config),
                 (r) -> assertResults(fileName, r, "graph"));
         assertEquals(EXPECTED_NONE_QUOTES, readFile(fileName));
     }
 
     @Test
+    public void testExportGraphCsvAndUseTypes() {
+        String fileName = "graph.csv";
+        Map<String, Object> config = Map.of("useTypes", true, "quotes", NONE_QUOTES);
+        TestUtil.testCall(db, CALL_GRAPH, map("file", fileName, "config", config),
+                (r) -> assertResults(fileName, r, "graph"));
+        assertEquals(EXPECTED_NONE_QUOTES_WITH_USE_TYPES, readFile(fileName));
+    }
+
+    @Test
     public void testExportGraphCsvWithoutQuotes() {
         String fileName = "graph.csv";
-        TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
-                        "CALL apoc.export.csv.graph(graph, $file,null) " +
-                        "YIELD nodes, relationships, properties, file, source,format, time " +
-                        "RETURN *", map("file", fileName),
+        TestUtil.testCall(db, CALL_GRAPH, map("file", fileName, "config", Map.of()),
                 (r) -> assertResults(fileName, r, "graph"));
         assertEquals(EXPECTED, readFile(fileName));
+    }
+    @Test
+    public void testExportGraphCsvWithUseTypesAndWithoutQuotes() {
+        String fileName = "graph.csv";
+        Map<String, Object> config = Map.of("useTypes", true);
+        TestUtil.testCall(db, CALL_GRAPH, map("file", fileName, "config", config),
+                (r) -> assertResults(fileName, r, "graph"));
+        assertEquals(EXPECTED_WITH_USE_TYPES, readFile(fileName));
+    }
+
+    @Test
+    public void testExportCsvData() {
+        String fileName = "data.csv";
+        Map<String, Object> config = Map.of("quotes", NONE_QUOTES);
+        TestUtil.testCall(db, CALL_DATA, map("file", fileName, "config", config),
+                (r) -> assertResults(fileName, r, "data"));
+        assertEquals(EXPECTED_NONE_QUOTES, readFile(fileName));
+    }
+
+    @Test
+    public void testExportCsvDataWithUseTypes() {
+        String fileName = "data.csv";
+        Map<String, Object> config = Map.of("useTypes", true, "quotes", NONE_QUOTES);
+        TestUtil.testCall(db, CALL_DATA, map("file", fileName, "config", config),
+                (r) -> assertResults(fileName, r, "data"));
+        assertEquals(EXPECTED_NONE_QUOTES_WITH_USE_TYPES, readFile(fileName));
+    }
+
+    @Test
+    public void testExportCsvDataWithoutQuotes() {
+        String fileName = "data.csv";
+        TestUtil.testCall(db, CALL_DATA, map("file", fileName, "config", Map.of()),
+                (r) -> assertResults(fileName, r, "data"));
+        assertEquals(EXPECTED, readFile(fileName));
+    }
+    @Test
+    public void testExportCsvDataWithUseTypesAndWithoutQuotes() {
+        String fileName = "data.csv";
+        Map<String, Object> config = Map.of("useTypes", true);
+        TestUtil.testCall(db, CALL_DATA, map("file", fileName, "config", config),
+                (r) -> assertResults(fileName, r, "data"));
+        assertEquals(EXPECTED_WITH_USE_TYPES, readFile(fileName));
     }
 
     @Test
     public void testExportQueryCsv() {
         String fileName = "query.csv";
         String query = "MATCH (u:User) return u.age, u.name, u.male, u.kids, labels(u)";
-        TestUtil.testCall(db, "CALL apoc.export.csv.query($query,$file,null)",
-                map("file", fileName, "query", query),
+        TestUtil.testCall(db, CALL_QUERY,
+                map("file", fileName, "query", query, "config", Map.of()),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(5)"));
+                    assertEquals(fileName, r.get("file"));
+                    assertEquals("csv", r.get("format"));
+
+                });
+        assertEquals(EXPECTED_QUERY, readFile(fileName));
+    }
+
+    @Test
+    public void testExportQueryCsvWithUseTypes() {
+        String fileName = "query.csv";
+        String query = "MATCH (u:User) return u.age, u.name, u.male, u.kids, labels(u)";
+        Map<String, Object> config = Map.of("useTypes", true);
+        TestUtil.testCall(db, CALL_QUERY,
+                map("file", fileName, "query", query, "config", config),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(5)"));
                     assertEquals(fileName, r.get("file"));
@@ -329,8 +474,25 @@ public class ExportCsvTest {
     public void testExportQueryCsvWithoutQuotes() {
         String fileName = "query.csv";
         String query = "MATCH (u:User) return u.age, u.name, u.male, u.kids, labels(u)";
-        TestUtil.testCall(db, "CALL apoc.export.csv.query($query,$file,{quotes: false})",
-                map("file", fileName, "query", query),
+        Map<String, Object> config = Map.of("quotes", false);
+        TestUtil.testCall(db, CALL_QUERY,
+                map("file", fileName, "query", query, "config", config),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(5)"));
+                    assertEquals(fileName, r.get("file"));
+                    assertEquals("csv", r.get("format"));
+
+                });
+        assertEquals(EXPECTED_QUERY_WITHOUT_QUOTES, readFile(fileName));
+    }
+
+    @Test
+    public void testExportQueryCsvWithUseTypesWithoutQuotes() {
+        String fileName = "query.csv";
+        String query = "MATCH (u:User) return u.age, u.name, u.male, u.kids, labels(u)";
+        Map<String, Object> config = Map.of("useTypes", true, "quotes", false);
+        TestUtil.testCall(db, CALL_QUERY,
+                map("file", fileName, "query", query, "config", config),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(5)"));
                     assertEquals(fileName, r.get("file"));
@@ -348,15 +510,11 @@ public class ExportCsvTest {
                 "SHOW INDEXES YIELD id, name, type RETURN *"
         );
 
+        Map<String, Object> config = Map.of("quotes", false);
         for (String query : invalidQueries) {
             QueryExecutionException e = Assert.assertThrows(QueryExecutionException.class,
-                    () -> TestUtil.testCall(db, """
-                        CALL apoc.export.csv.query(
-                        $query,
-                        $file,
-                        {quotes: false}
-                        )""",
-                            map("query", query, "file", filename),
+                    () -> TestUtil.testCall(db, CALL_QUERY,
+                            map("query", query, "file", filename, "config", config),
                             (r) -> {}
                     )
             );
@@ -369,8 +527,8 @@ public class ExportCsvTest {
     public void testExportQueryNodesCsv() {
         String fileName = "query_nodes.csv";
         String query = "MATCH (u:User) return u";
-        TestUtil.testCall(db, "CALL apoc.export.csv.query($query,$file,null)",
-                map("file", fileName, "query", query),
+        TestUtil.testCall(db, CALL_QUERY,
+                map("file", fileName, "query", query, "config", Map.of()),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
                     assertEquals(fileName, r.get("file"));
@@ -384,7 +542,26 @@ public class ExportCsvTest {
     public void testExportQueryNodesCsvParams() {
         String fileName = "query_nodes.csv";
         String query = "MATCH (u:User) WHERE u.age > $age return u";
-        TestUtil.testCall(db, "CALL apoc.export.csv.query($query,$file,{params:{age:10}})", map("file", fileName,"query",query),
+        Map<String, Object> config = Map.of("params", Map.of("age", 10));
+        TestUtil.testCall(db, CALL_QUERY,
+                map("file", fileName,"query",query, "config", config),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
+                    assertEquals(fileName, r.get("file"));
+                    assertEquals("csv", r.get("format"));
+
+                });
+        assertEquals(EXPECTED_QUERY_NODES, readFile(fileName));
+    }
+
+    @Test
+    public void testExportQueryNodesCsvParamsWithUseTypes() {
+        String fileName = "query_nodes.csv";
+        String query = "MATCH (u:User) WHERE u.age > $age return u";
+        Map<String, Object> config = Map.of("params", Map.of("age", 10),
+                "useTypes", true);
+        TestUtil.testCall(db, CALL_QUERY,
+                map("file", fileName,"query",query, "config", config),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
                     assertEquals(fileName, r.get("file"));
@@ -420,17 +597,29 @@ public class ExportCsvTest {
 
     @Test public void testExportAllCsvStreaming() {
         String statement = "CALL apoc.export.csv.all(null,{stream:true,batchSize:2,useOptimizations:{unwindBatchSize:2}})";
-        assertExportStreaming(statement, NONE);
+        assertExportStreaming(statement, NONE, EXPECTED);
+    }
+
+    @Test public void testExportAllCsvStreamingWithUseTypes() {
+        String statement = "CALL apoc.export.csv.all(null,{useTypes: true, stream:true, batchSize:2,useOptimizations:{unwindBatchSize:2}})";
+        assertExportStreaming(statement, NONE, EXPECTED_WITH_USE_TYPES);
     }
     
     @Test
     public void testExportAllCsvStreamingCompressed() {
         final CompressionAlgo algo = GZIP;
         String statement = "CALL apoc.export.csv.all(null, {compression: '" + algo.name() + "',stream:true,batchSize:2,useOptimizations:{unwindBatchSize:2}})";
-        assertExportStreaming(statement, algo);
+        assertExportStreaming(statement, algo, EXPECTED);
     }
 
-    private void assertExportStreaming(String statement, CompressionAlgo algo) {
+    @Test
+    public void testExportAllCsvStreamingCompressedWithUseTypes() {
+        final CompressionAlgo algo = GZIP;
+        String statement = "CALL apoc.export.csv.all(null, {useTypes: true, compression: '" + algo.name() + "', stream:true, batchSize:2, useOptimizations:{unwindBatchSize:2}})";
+        assertExportStreaming(statement, GZIP, EXPECTED_WITH_USE_TYPES);
+    }
+
+    private void assertExportStreaming(String statement, CompressionAlgo algo, String expected) {
         StringBuilder sb=new StringBuilder();
         testResult(db, statement, (res) -> {
             Map<String, Object> r = res.next();
@@ -473,7 +662,7 @@ public class ExportCsvTest {
             sb.append(getDecompressedData(algo, r.get("data")));
             res.close();
         });
-        assertEquals(EXPECTED, sb.toString());
+        assertEquals(expected, sb.toString());
     }
 
     @Test public void testCypherCsvStreaming() {

--- a/core/src/test/java/apoc/export/csv/ExportCsvUseTypeTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvUseTypeTest.java
@@ -1,0 +1,82 @@
+package apoc.export.csv;
+
+import apoc.graph.Graphs;
+import apoc.util.TestUtil;
+import apoc.util.Util;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import static apoc.ApocConfig.APOC_EXPORT_FILE_ENABLED;
+import static apoc.ApocConfig.apocConfig;
+import static apoc.export.csv.ExportCsvTest.assertResults;
+import static apoc.export.csv.ExportCsvTest.readFile;
+import static apoc.util.MapUtil.map;
+import static apoc.util.TestUtil.testCall;
+import static org.junit.Assert.assertEquals;
+
+// Created to not affect ExportCsvTest results
+public class ExportCsvUseTypeTest {
+
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(GraphDatabaseSettings.load_csv_file_url_root, ExportCsvTest.directory.toPath().toAbsolutePath());
+
+
+    @BeforeClass
+    public static void setUp() {
+        TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class);
+        apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
+
+        db.executeTransactionally("CREATE (n:SuperNode { one: datetime('2018-05-10T10:30[Europe/Berlin]'), two: time('18:02:33'), three: localtime('17:58:30'), \n" +
+                "four: localdatetime('2021-06-08'), five: date('2020'), six: duration({months: 5, days: 1.5}), seven : '2020'}) \n" +
+                "WITH n CREATE (n)-[:REL_TYPE {rel: point({x: 56.7, y: 12.78, crs: 'cartesian'})}]->(m:AnotherNode)");
+        
+        try(Transaction tx = db.beginTx()) {
+            final Node node = tx.findNodes(Label.label("AnotherNode")).next();
+            // force property type
+            node.setProperty("alpha", (short) 1);
+            node.setProperty("beta", "qwerty".getBytes());
+            node.setProperty("gamma", 'A');
+            node.setProperty("epsilon", 1);
+            node.setProperty("zeta", 1.1F);
+            node.setProperty("eta", 1L);
+            node.setProperty("theta", 10.1D);
+            node.setProperty("iota", "bar");
+            node.setProperty("kappa", new String[] {"un", "deux", "trois"});
+            node.setProperty("lambda", new long[] { 10L, 20L, 30L });
+            tx.commit();
+        }
+    }
+
+    @Test
+    public void testExportCsvAll() {
+        String fileName = "manyTypes.csv";
+        testCall(db, "CALL apoc.export.csv.all($file, {useTypes: true, quotes: 'none'})", map("file", fileName),
+                (r) -> assertResults(fileName, r, "database", 2L, 1L, 18L, true));
+        final String expected = Util.readResourceFile("manyTypes.csv");
+        assertEquals(expected, readFile(fileName));
+
+        // -- streaming mode
+        String statement = "CALL apoc.export.csv.all(null, {stream:true, useTypes: true, quotes: 'none'})";
+        testCall(db, statement, (r) -> assertEquals(expected, r.get("data")));
+    }
+
+    @Test
+    public void testExportCsvGraph() {
+        String fileName = "manyTypes.csv";
+        testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
+                        "CALL apoc.export.csv.graph(graph, $file,{useTypes: true, quotes: 'none'}) " +
+                        "YIELD nodes, relationships, properties, file, source,format, time " +
+                        "RETURN *", map("file", fileName),
+                (r) -> assertResults(fileName, r, "graph", 2L, 1L, 18L, true));
+        final String expected = Util.readResourceFile("manyTypes.csv");
+        assertEquals(expected, readFile(fileName));
+    }
+}

--- a/core/src/test/java/apoc/export/csv/ExportCsvUseTypeTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvUseTypeTest.java
@@ -49,8 +49,6 @@ public class ExportCsvUseTypeTest {
             node.setProperty("eta", 1L);
             node.setProperty("theta", 10.1D);
             node.setProperty("iota", "bar");
-            node.setProperty("kappa", new String[] {"un", "deux", "trois"});
-            node.setProperty("lambda", new long[] { 10L, 20L, 30L });
             tx.commit();
         }
     }
@@ -59,7 +57,7 @@ public class ExportCsvUseTypeTest {
     public void testExportCsvAll() {
         String fileName = "manyTypes.csv";
         testCall(db, "CALL apoc.export.csv.all($file, {useTypes: true, quotes: 'none'})", map("file", fileName),
-                (r) -> assertResults(fileName, r, "database", 2L, 1L, 18L, true));
+                (r) -> assertResults(fileName, r, "database", 2L, 1L, 16L, true));
         final String expected = Util.readResourceFile("manyTypes.csv");
         assertEquals(expected, readFile(fileName));
 
@@ -75,7 +73,7 @@ public class ExportCsvUseTypeTest {
                         "CALL apoc.export.csv.graph(graph, $file,{useTypes: true, quotes: 'none'}) " +
                         "YIELD nodes, relationships, properties, file, source,format, time " +
                         "RETURN *", map("file", fileName),
-                (r) -> assertResults(fileName, r, "graph", 2L, 1L, 18L, true));
+                (r) -> assertResults(fileName, r, "graph", 2L, 1L, 16L, true));
         final String expected = Util.readResourceFile("manyTypes.csv");
         assertEquals(expected, readFile(fileName));
     }

--- a/core/src/test/java/apoc/export/csv/ExportCsvUseTypeTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvUseTypeTest.java
@@ -55,7 +55,7 @@ public class ExportCsvUseTypeTest {
 
     @Test
     public void testExportCsvAll() {
-        String fileName = "manyTypes.csv";
+        String fileName = "output.csv";
         testCall(db, "CALL apoc.export.csv.all($file, {useTypes: true, quotes: 'none'})", map("file", fileName),
                 (r) -> assertResults(fileName, r, "database", 2L, 1L, 16L, true));
         final String expected = Util.readResourceFile("manyTypes.csv");
@@ -68,12 +68,24 @@ public class ExportCsvUseTypeTest {
 
     @Test
     public void testExportCsvGraph() {
-        String fileName = "manyTypes.csv";
+        String fileName = "output.csv";
         testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
                         "CALL apoc.export.csv.graph(graph, $file,{useTypes: true, quotes: 'none'}) " +
                         "YIELD nodes, relationships, properties, file, source,format, time " +
                         "RETURN *", map("file", fileName),
                 (r) -> assertResults(fileName, r, "graph", 2L, 1L, 16L, true));
+        final String expected = Util.readResourceFile("manyTypes.csv");
+        assertEquals(expected, readFile(fileName));
+    }
+
+    @Test
+    public void testExportCsvData() {
+        String fileName = "output.csv";
+        testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
+                        "CALL apoc.export.csv.data(graph.nodes, graph.relationships, $file,{useTypes: true, quotes: 'none'}) " +
+                        "YIELD nodes, relationships, properties, file, source,format, time " +
+                        "RETURN *", map("file", fileName),
+                (r) -> assertResults(fileName, r, "data", 2L, 1L, 16L, true));
         final String expected = Util.readResourceFile("manyTypes.csv");
         assertEquals(expected, readFile(fileName));
     }


### PR DESCRIPTION
Added data types with config `useTypes:true`, 
consistently with [these ones](https://neo4j.com/docs/operations-manual/current/tools/neo4j-admin/neo4j-admin-import/#import-tool-header-format-properties)