### PR TITLE
[d0LvEgnK] Check the correct behaviour with indexes/constraint using the apoc.export.cypher.data/graph procedures

### DIFF
--- a/common/src/main/java/apoc/export/util/NodesAndRelsSubGraph.java
+++ b/common/src/main/java/apoc/export/util/NodesAndRelsSubGraph.java
@@ -103,19 +103,14 @@ public class NodesAndRelsSubGraph implements SubGraph {
 
     private <T> ArrayList<T> getDefinitions(
             BiFunction<Schema, Label, Iterable<T>> nodeFunction,
-            BiFunction<Schema, RelationshipType, Iterable<T>> relFunction
-    ) {
+            BiFunction<Schema, RelationshipType, Iterable<T>> relFunction) {
         Schema schema = tx.schema();
         ArrayList<T> definitions = new ArrayList<>(labels.size() * 2);
         for (String label : labels) {
-            Iterables.addAll(definitions,
-                    nodeFunction.apply(schema, Label.label(label))
-            );
+            Iterables.addAll(definitions, nodeFunction.apply(schema, Label.label(label)));
         }
         for (String type : types) {
-            Iterables.addAll(definitions,
-                    relFunction.apply(schema, RelationshipType.withName(type))
-            );
+            Iterables.addAll(definitions, relFunction.apply(schema, RelationshipType.withName(type)));
         }
         return definitions;
     }

--- a/common/src/main/java/apoc/export/util/NodesAndRelsSubGraph.java
+++ b/common/src/main/java/apoc/export/util/NodesAndRelsSubGraph.java
@@ -87,22 +87,35 @@ public class NodesAndRelsSubGraph implements SubGraph {
         return getDefinitions(
                 (schema, label) -> StreamSupport.stream(schema.getIndexes(label).spliterator(), false)
                         .filter(indexDefinition -> indexDefinition.getIndexType() != IndexType.VECTOR)
+                        .toList(),
+                (schema, type) -> StreamSupport.stream(schema.getIndexes(type).spliterator(), false)
+                        .filter(indexDefinition -> indexDefinition.getIndexType() != IndexType.VECTOR)
                         .toList());
     }
 
     @Override
     public Iterable<ConstraintDefinition> getConstraints() {
         Comparator<ConstraintDefinition> comp = Comparator.comparing(ConstraintDefinition::getName);
-        ArrayList<ConstraintDefinition> definitions = getDefinitions(Schema::getConstraints);
+        ArrayList<ConstraintDefinition> definitions = getDefinitions(Schema::getConstraints, Schema::getConstraints);
         definitions.sort(comp);
         return definitions;
     }
 
-    private <T> ArrayList<T> getDefinitions(BiFunction<Schema, Label, Iterable<T>> biFunction) {
+    private <T> ArrayList<T> getDefinitions(
+            BiFunction<Schema, Label, Iterable<T>> nodeFunction,
+            BiFunction<Schema, RelationshipType, Iterable<T>> relFunction
+    ) {
         Schema schema = tx.schema();
         ArrayList<T> definitions = new ArrayList<>(labels.size() * 2);
         for (String label : labels) {
-            Iterables.addAll(definitions, biFunction.apply(schema, Label.label(label)));
+            Iterables.addAll(definitions,
+                    nodeFunction.apply(schema, Label.label(label))
+            );
+        }
+        for (String type : types) {
+            Iterables.addAll(definitions,
+                    relFunction.apply(schema, RelationshipType.withName(type))
+            );
         }
         return definitions;
     }

--- a/common/src/test/resources/init_neo4j_export_csv.cypher
+++ b/common/src/test/resources/init_neo4j_export_csv.cypher
@@ -6,10 +6,12 @@ CREATE CONSTRAINT SingleExists FOR (x:Label2) REQUIRE (x.prop) IS NOT NULL;
 CREATE CONSTRAINT SingleExistsRel FOR ()<-[r:TYPE2]-() REQUIRE (r.prop) IS NOT NULL;
 CREATE CONSTRAINT SingleNodeKey FOR (x:Label3) REQUIRE (x.prop) IS NODE KEY;
 CREATE CONSTRAINT PersonRequiresNamesConstraint FOR (t:Person) REQUIRE (t.name, t.surname) IS NODE KEY;
+CREATE CONSTRAINT KnowsConsNotNull FOR ()-[r:KNOWS]-() REQUIRE (r.foo) IS NOT NULL;
+CREATE CONSTRAINT KnowsConsUnique FOR ()-[r:KNOWS]-() REQUIRE (r.two) IS UNIQUE;
 
 CREATE (a:Person {name: 'John', surname: 'Snow'})
 CREATE (b:Person {name: 'Matt', surname: 'Jackson'})
 CREATE (c:Person {name: 'Jenny', surname: 'White'})
 CREATE (d:Person {name: 'Susan', surname: 'Brown'})
 CREATE (e:Person {name: 'Tom', surname: 'Taylor'})
-CREATE (a)-[:KNOWS]->(b);
+CREATE (a)-[:KNOWS {foo: 1}]->(b);

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -1037,38 +1037,98 @@ public class ExportCypherTest {
     @Test
     public void shouldExportFulltextIndexForRelationship() {
         // given
-        db.executeTransactionally("CREATE (s:TempNode)-[:REL{rel_value: 'the rel value'}]->(e:TempNode2)");
-        db.executeTransactionally(
-                "CREATE FULLTEXT INDEX MyCoolRelFulltextIndex FOR ()-[rel:REL]-() ON EACH [rel.rel_value]");
+        createFullTextRelIndex();
         String query = "MATCH (t:TempNode)-[r:REL{rel_value: 'the rel value'}]->(e:TempNode2) return t,r";
         Map<String, Object> config = map("awaitForIndexes", 3000);
-        String expected = String.format(":begin%n"
-                + "CREATE FULLTEXT INDEX MyCoolRelFulltextIndex FOR ()-[rel:REL]-() ON EACH [rel.`rel_value`];%n"
-                + "CREATE CONSTRAINT UNIQUE_IMPORT_NAME FOR (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n"
-                + ":commit%n"
-                + "CALL db.awaitIndexes(3000);%n"
-                + ":begin%n"
-                + "UNWIND [{_id:3, properties:{}}] AS row%n"
-                + "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:TempNode;%n"
-                + ":commit%n"
-                + ":begin%n"
-                + "UNWIND [{start: {_id:3}, end: {_id:4}, properties:{rel_value:\"the rel value\"}}] AS row%n"
-                + "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})%n"
-                + "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})%n"
-                + "CREATE (start)-[r:REL]->(end) SET r += row.properties;%n"
-                + ":commit%n"
-                + ":begin%n"
-                + "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n"
-                + ":commit%n"
-                + ":begin%n"
-                + "DROP CONSTRAINT UNIQUE_IMPORT_NAME;%n"
-                + ":commit%n");
 
         // when
         TestUtil.testCall(db, exportQuery, map("query", query, "file", null, "config", config), (r) -> {
             // then
-            assertEquals(expected, r.get("cypherStatements"));
+            assertEquals(EXPECTED_TEMPNODE, r.get("cypherStatements"));
         });
+    }
+
+    @Test
+    public void shouldExportDataWithFulltextIndexForRelationship() {
+        createFullTextRelIndex();
+        Map<String, Object> config = map("awaitForIndexes", 3000);
+        TestUtil.testCall(db, """
+                MATCH (start:TempNode)-[rel:REL]->(end:TempNode2)
+                CALL apoc.export.cypher.data([start], [rel], null, $config)
+                YIELD nodes, relationships, properties, cypherStatements, schemaStatements RETURN *""",
+                map("config", config),
+                (r) -> {
+                    // then
+                    assertEquals(EXPECTED_TEMPNODE, r.get("cypherStatements"));
+                });
+    }
+
+    @Test
+    public void shouldExportGraphWithFulltextIndexForRelationship() {
+        createFullTextRelIndex();
+        Map<String, Object> config = map("awaitForIndexes", 3000);
+        TestUtil.testCall(db, """
+                MATCH (start:TempNode)-[rel:REL]->(end:TempNode2)
+                WITH {nodes: [start], relationships: [rel]} AS graph
+                CALL apoc.export.cypher.graph(graph, null, $config)
+                YIELD nodes, relationships, properties, cypherStatements, schemaStatements RETURN *""",
+                map( "config", config),
+                (r) -> {
+                    // then
+                    assertEquals(EXPECTED_TEMPNODE, r.get("cypherStatements"));
+                });
+    }
+
+    @Test
+    public void shouldExportGraphWithFulltextIndexes() {
+        createFullTextNodeAndRelIndex();
+
+        TestUtil.testCall(db, """
+                MATCH (start:TempNode)-[rel:REL]->(end:TempNode2)
+                WITH {nodes: [start, end], relationships: [rel]} AS graph
+                CALL apoc.export.cypher.graph(graph, null, $config)
+                YIELD nodes, relationships, properties, cypherStatements, schemaStatements RETURN *""",
+                Map.of( "config", Map.of("awaitForIndexes", 3000)),
+                (r) -> {
+                    assertEquals(EXPECTED_TEMPNODE_AND_REL, r.get("cypherStatements"));
+                });
+    }
+
+    @Test
+    public void shouldExportDataWithFulltextIndexes() {
+        createFullTextNodeAndRelIndex();
+
+        TestUtil.testCall(db, """
+                MATCH (start:TempNode)-[rel:REL]->(end:TempNode2)
+                CALL apoc.export.cypher.data([start, end], [rel], null, $config)
+                YIELD nodes, relationships, properties, cypherStatements, schemaStatements RETURN *""",
+                Map.of( "config", Map.of("awaitForIndexes", 3000)),
+                (r) -> {
+                    assertEquals(EXPECTED_TEMPNODE_AND_REL, r.get("cypherStatements"));
+                });
+    }
+
+    @Test
+    public void shouldExportQueryWithFulltextIndexes() {
+        createFullTextNodeAndRelIndex();
+
+        TestUtil.testCall(db, exportQuery,
+                map("query", "MATCH (start:TempNode)-[rel:REL]->(end:TempNode2) RETURN start, rel, end",
+                        "file", null,
+                        "config", Map.of("awaitForIndexes", 3000)),
+                (r) -> {
+                    assertEquals(EXPECTED_TEMPNODE_AND_REL, r.get("cypherStatements"));
+                });
+    }
+
+    private void createFullTextRelIndex() {
+        db.executeTransactionally("CREATE (s:TempNode)-[:REL{rel_value: 'the rel value'}]->(e:TempNode2)");
+        db.executeTransactionally("CREATE FULLTEXT INDEX MyCoolRelFulltextIndex FOR ()-[rel:REL]-() ON EACH [rel.rel_value]");
+    }
+
+    private void createFullTextNodeAndRelIndex() {
+        createFullTextRelIndex();
+        db.executeTransactionally("CREATE FULLTEXT INDEX MyCoolNodeFulltextIndex FOR (n:TempNode) ON EACH [n.rel_value]");
     }
 
     @Test
@@ -1237,6 +1297,76 @@ public class ExportCypherTest {
                 map("ifNotExists", true, "saveIndexNames", true));
 
         db.executeTransactionally("DROP INDEX rel_index_name");
+    }
+
+    @Test
+    public void shouldSaveCorrectlyRelRangeIndexe() {
+        db.executeTransactionally("CREATE RANGE INDEX rel_index_name FOR ()-[r:KNOWS]-() ON (r.since, r.foo)");
+
+        // check that `apoc.export.cypher.data`, `apoc.export.cypher.graph` and `apoc.export.cypher.query`
+        // return consistent results
+        Map<String, Object> config = Map.of("format", "neo4j-shell");
+        assertExportWithRangeIndex(EXPECTED_SCHEMA_WITH_RELS_OPTIMIZED,
+                exportQuery,
+                map("query", "MATCH (start:Foo)-[rel:KNOWS]->(end:Bar) RETURN start, rel, end",
+                        "file", null,
+                        "config", config));
+
+        assertExportWithRangeIndex(EXPECTED_SCHEMA_WITH_RELS_OPTIMIZED, """
+                MATCH (start:Foo)-[rel:KNOWS]->(end:Bar)
+                CALL apoc.export.cypher.data([start, end], [rel], null, $config)
+                YIELD cypherStatements RETURN *
+                """, map("config", config));
+        assertExportWithRangeIndex(EXPECTED_SCHEMA_WITH_RELS_OPTIMIZED, """
+                MATCH (start:Foo)-[rel:KNOWS]->(end:Bar)
+                CALL apoc.export.cypher.data([start, end], [rel], null, $config)
+                YIELD cypherStatements RETURN *""", map("config", config));
+
+        db.executeTransactionally("DROP INDEX rel_index_name");
+    }
+
+    @Test
+    public void shouldSaveCorrectlyRelRangeIndexWithName() {
+        db.executeTransactionally("CREATE RANGE INDEX rel_index_name FOR ()-[r:KNOWS]-() ON (r.since, r.foo)");
+
+        // check that `apoc.export.cypher.data`, `apoc.export.cypher.graph` and `apoc.export.cypher.query`
+        // return consistent results
+        Map<String, Object> config = Map.of("format", "neo4j-shell", "saveIndexNames", true);
+        assertExportWithRangeIndex(EXPECTED_SCHEMA_WITH_RELS_AND_NAME_OPTIMIZED, exportQuery, map("query", "MATCH (start:Foo)-[rel:KNOWS]->(end:Bar) RETURN start, rel, end",
+                "file", null,
+                "config", config));
+        assertExportWithRangeIndex(EXPECTED_SCHEMA_WITH_RELS_AND_NAME_OPTIMIZED, """
+                MATCH (start:Foo)-[rel:KNOWS]->(end:Bar)
+                CALL apoc.export.cypher.data([start, end], [rel], null, $config)
+                YIELD cypherStatements RETURN *
+                """, map("config", config));
+        assertExportWithRangeIndex(EXPECTED_SCHEMA_WITH_RELS_AND_NAME_OPTIMIZED, """
+                MATCH (start:Foo)-[rel:KNOWS]->(end:Bar)
+                CALL apoc.export.cypher.data([start, end], [rel], null, $config)
+                YIELD cypherStatements RETURN *""", map("config", config));
+
+        db.executeTransactionally("DROP INDEX rel_index_name");
+    }
+
+    private void assertExportWithRangeIndex(String expectedSchema, String query, Map<String, Object> params) {
+        String expectedNodesAndRels = """
+                BEGIN
+                UNWIND [{_id:0, properties:{born:date('2018-10-31'), name:"foo"}}] AS row
+                CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;
+                UNWIND [{name:"bar", properties:{age:42}}] AS row
+                CREATE (n:Bar{name: row.name}) SET n += row.properties;
+                COMMIT
+                BEGIN
+                UNWIND [{start: {_id:0}, end: {name:"bar"}, properties:{since:2016}}] AS row
+                MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})
+                MATCH (end:Bar{name: row.end.name})
+                CREATE (start)-[r:KNOWS]->(end) SET r += row.properties;
+                COMMIT
+                """;
+        String expected = expectedSchema + expectedNodesAndRels + EXPECTED_CLEAN_UP;
+
+        TestUtil.testCall(db, query, params,
+                r -> assertEquals(expected, r.get("cypherStatements")));
     }
 
     @Test
@@ -1618,6 +1748,52 @@ public class ExportCypherTest {
     }
 
     public static class ExportCypherResults {
+        static final String EXPECTED_TEMPNODE_AND_REL = String.format(":begin%n" +
+                "CREATE FULLTEXT INDEX MyCoolNodeFulltextIndex FOR (n:TempNode) ON EACH [n.`rel_value`];%n" +
+                "CREATE FULLTEXT INDEX MyCoolRelFulltextIndex FOR ()-[rel:REL]-() ON EACH [rel.`rel_value`];%n" +
+                "CREATE CONSTRAINT UNIQUE_IMPORT_NAME FOR (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                ":commit%n" +
+                "CALL db.awaitIndexes(3000);%n" +
+                ":begin%n" +
+                "UNWIND [{_id:3, properties:{}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:TempNode;%n" +
+                "UNWIND [{_id:4, properties:{}}] AS row\n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:TempNode2;%n" +
+                ":commit%n" +
+                ":begin%n" +
+                "UNWIND [{start: {_id:3}, end: {_id:4}, properties:{rel_value:\"the rel value\"}}] AS row%n" +
+                "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})%n" +
+                "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})%n" +
+                "CREATE (start)-[r:REL]->(end) SET r += row.properties;%n" +
+                ":commit%n" +
+                ":begin%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                ":commit%n" +
+                ":begin%n" +
+                "DROP CONSTRAINT UNIQUE_IMPORT_NAME;%n" +
+                ":commit%n");
+        static final String EXPECTED_TEMPNODE = String.format(":begin%n" +
+                "CREATE FULLTEXT INDEX MyCoolRelFulltextIndex FOR ()-[rel:REL]-() ON EACH [rel.`rel_value`];%n" +
+                "CREATE CONSTRAINT UNIQUE_IMPORT_NAME FOR (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                ":commit%n" +
+                "CALL db.awaitIndexes(3000);%n" +
+                ":begin%n" +
+                "UNWIND [{_id:3, properties:{}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:TempNode;%n" +
+                ":commit%n" +
+                ":begin%n" +
+                "UNWIND [{start: {_id:3}, end: {_id:4}, properties:{rel_value:\"the rel value\"}}] AS row%n" +
+                "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})%n" +
+                "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})%n" +
+                "CREATE (start)-[r:REL]->(end) SET r += row.properties;%n" +
+                ":commit%n" +
+                ":begin%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                ":commit%n" +
+                ":begin%n" +
+                "DROP CONSTRAINT UNIQUE_IMPORT_NAME;%n" +
+                ":commit%n");
+
         static final String EXPECTED_ISOLATED_NODE =
                 "CREATE (:Bar:`UNIQUE IMPORT LABEL` {age:12, `UNIQUE IMPORT ID`:2});\n";
         static final String EXPECTED_BAR_END_NODE = "CREATE (:Bar {age:42, name:\"bar\"});%n";
@@ -2102,14 +2278,17 @@ public class ExportCypherTest {
                 convertToCypherShellFormat(EXPECTED_ONLY_SCHEMA_NEO4J_SHELL);
 
         public static final List<String> EXPECTED_CONSTRAINTS = List.of(
-                "CREATE CONSTRAINT SingleUnique FOR (node:Label) REQUIRE (node.prop) IS UNIQUE;",
-                "CREATE CONSTRAINT SingleUniqueRel FOR ()-[rel:TYPE]-() REQUIRE (rel.prop) IS UNIQUE;",
-                "CREATE CONSTRAINT CompositeUnique FOR (node:Label) REQUIRE (node.prop1, node.prop2) IS UNIQUE;",
-                "CREATE CONSTRAINT CompositeUniqueRel FOR ()-[rel:TYPE]-() REQUIRE (rel.prop1, rel.prop2) IS UNIQUE;",
-                "CREATE CONSTRAINT SingleExists FOR (node:Label2) REQUIRE (node.prop) IS NOT NULL;",
-                "CREATE CONSTRAINT SingleExistsRel FOR ()-[rel:TYPE2]-() REQUIRE (rel.prop) IS NOT NULL;",
-                "CREATE CONSTRAINT SingleNodeKey FOR (node:Label3) REQUIRE (node.prop) IS NODE KEY;",
-                "CREATE CONSTRAINT PersonRequiresNamesConstraint FOR (node:Person) REQUIRE (node.name, node.surname) IS NODE KEY;");
+             "CREATE CONSTRAINT SingleUnique FOR (node:Label) REQUIRE (node.prop) IS UNIQUE;",
+             "CREATE CONSTRAINT SingleUniqueRel FOR ()-[rel:TYPE]-() REQUIRE (rel.prop) IS UNIQUE;",
+             "CREATE CONSTRAINT CompositeUnique FOR (node:Label) REQUIRE (node.prop1, node.prop2) IS UNIQUE;",
+             "CREATE CONSTRAINT CompositeUniqueRel FOR ()-[rel:TYPE]-() REQUIRE (rel.prop1, rel.prop2) IS UNIQUE;",
+             "CREATE CONSTRAINT SingleExists FOR (node:Label2) REQUIRE (node.prop) IS NOT NULL;",
+             "CREATE CONSTRAINT SingleExistsRel FOR ()-[rel:TYPE2]-() REQUIRE (rel.prop) IS NOT NULL;",
+             "CREATE CONSTRAINT SingleNodeKey FOR (node:Label3) REQUIRE (node.prop) IS NODE KEY;",
+             "CREATE CONSTRAINT PersonRequiresNamesConstraint FOR (node:Person) REQUIRE (node.name, node.surname) IS NODE KEY;",
+             "CREATE CONSTRAINT KnowsConsNotNull FOR ()-[rel:KNOWS]-() REQUIRE (rel.foo) IS NOT NULL;",
+             "CREATE CONSTRAINT KnowsConsUnique FOR ()-[rel:KNOWS]-() REQUIRE (rel.two) IS UNIQUE;"
+        );
 
         public static final String EXPECTED_NEO4J_SHELL_WITH_COMPOUND_CONSTRAINT =
                 String.format("COMMIT%n" + "SCHEMA AWAIT%n"
@@ -2118,7 +2297,7 @@ public class ExportCypherTest {
                         + "CREATE (n:Person{surname: row.surname, name: row.name}) SET n += row.properties;%n"
                         + "COMMIT%n"
                         + "BEGIN%n"
-                        + "UNWIND [{start: {name:\"John\", surname:\"Snow\"}, end: {name:\"Matt\", surname:\"Jackson\"}, properties:{}}] AS row%n"
+                        + "UNWIND [{start: {name:\"John\", surname:\"Snow\"}, end: {name:\"Matt\", surname:\"Jackson\"}, properties:{foo:1}}] AS row%n"
                         + "MATCH (start:Person{surname: row.start.surname, name: row.start.name})%n"
                         + "MATCH (end:Person{surname: row.end.surname, name: row.end.name})%n"
                         + "CREATE (start)-[r:KNOWS]->(end) SET r += row.properties;%n"
@@ -2130,7 +2309,7 @@ public class ExportCypherTest {
         public static final String EXPECTED_PLAIN_FORMAT_WITH_COMPOUND_CONSTRAINT = String.format(
                 "UNWIND [{surname:\"Snow\", name:\"John\", properties:{}}, {surname:\"Jackson\", name:\"Matt\", properties:{}}, {surname:\"White\", name:\"Jenny\", properties:{}}, {surname:\"Brown\", name:\"Susan\", properties:{}}, {surname:\"Taylor\", name:\"Tom\", properties:{}}] AS row%n"
                         + "CREATE (n:Person{surname: row.surname, name: row.name}) SET n += row.properties;%n"
-                        + "UNWIND [{start: {name:\"John\", surname:\"Snow\"}, end: {name:\"Matt\", surname:\"Jackson\"}, properties:{}}] AS row%n"
+                        + "UNWIND [{start: {name:\"John\", surname:\"Snow\"}, end: {name:\"Matt\", surname:\"Jackson\"}, properties:{foo:1}}] AS row%n"
                         + "MATCH (start:Person{surname: row.start.surname, name: row.start.name})%n"
                         + "MATCH (end:Person{surname: row.end.surname, name: row.end.name})%n"
                         + "CREATE (start)-[r:KNOWS]->(end) SET r += row.properties;%n");

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -1052,7 +1052,9 @@ public class ExportCypherTest {
     public void shouldExportDataWithFulltextIndexForRelationship() {
         createFullTextRelIndex();
         Map<String, Object> config = map("awaitForIndexes", 3000);
-        TestUtil.testCall(db, """
+        TestUtil.testCall(
+                db,
+                """
                 MATCH (start:TempNode)-[rel:REL]->(end:TempNode2)
                 CALL apoc.export.cypher.data([start], [rel], null, $config)
                 YIELD nodes, relationships, properties, cypherStatements, schemaStatements RETURN *""",
@@ -1067,12 +1069,14 @@ public class ExportCypherTest {
     public void shouldExportGraphWithFulltextIndexForRelationship() {
         createFullTextRelIndex();
         Map<String, Object> config = map("awaitForIndexes", 3000);
-        TestUtil.testCall(db, """
+        TestUtil.testCall(
+                db,
+                """
                 MATCH (start:TempNode)-[rel:REL]->(end:TempNode2)
                 WITH {nodes: [start], relationships: [rel]} AS graph
                 CALL apoc.export.cypher.graph(graph, null, $config)
                 YIELD nodes, relationships, properties, cypherStatements, schemaStatements RETURN *""",
-                map( "config", config),
+                map("config", config),
                 (r) -> {
                     // then
                     assertEquals(EXPECTED_TEMPNODE, r.get("cypherStatements"));
@@ -1083,52 +1087,58 @@ public class ExportCypherTest {
     public void shouldExportGraphWithFulltextIndexes() {
         createFullTextNodeAndRelIndex();
 
-        TestUtil.testCall(db, """
+        TestUtil.testCall(
+                db,
+                """
                 MATCH (start:TempNode)-[rel:REL]->(end:TempNode2)
                 WITH {nodes: [start, end], relationships: [rel]} AS graph
                 CALL apoc.export.cypher.graph(graph, null, $config)
                 YIELD nodes, relationships, properties, cypherStatements, schemaStatements RETURN *""",
-                Map.of( "config", Map.of("awaitForIndexes", 3000)),
-                (r) -> {
-                    assertEquals(EXPECTED_TEMPNODE_AND_REL, r.get("cypherStatements"));
-                });
+                Map.of("config", Map.of("awaitForIndexes", 3000)),
+                (r) -> assertEquals(EXPECTED_TEMPNODE_AND_REL, r.get("cypherStatements")));
     }
 
     @Test
     public void shouldExportDataWithFulltextIndexes() {
         createFullTextNodeAndRelIndex();
 
-        TestUtil.testCall(db, """
+        TestUtil.testCall(
+                db,
+                """
                 MATCH (start:TempNode)-[rel:REL]->(end:TempNode2)
                 CALL apoc.export.cypher.data([start, end], [rel], null, $config)
                 YIELD nodes, relationships, properties, cypherStatements, schemaStatements RETURN *""",
-                Map.of( "config", Map.of("awaitForIndexes", 3000)),
-                (r) -> {
-                    assertEquals(EXPECTED_TEMPNODE_AND_REL, r.get("cypherStatements"));
-                });
+                Map.of("config", Map.of("awaitForIndexes", 3000)),
+                (r) -> assertEquals(EXPECTED_TEMPNODE_AND_REL, r.get("cypherStatements")));
     }
 
     @Test
     public void shouldExportQueryWithFulltextIndexes() {
         createFullTextNodeAndRelIndex();
 
-        TestUtil.testCall(db, exportQuery,
-                map("query", "MATCH (start:TempNode)-[rel:REL]->(end:TempNode2) RETURN start, rel, end",
-                        "file", null,
-                        "config", Map.of("awaitForIndexes", 3000)),
-                (r) -> {
-                    assertEquals(EXPECTED_TEMPNODE_AND_REL, r.get("cypherStatements"));
-                });
+        TestUtil.testCall(
+                db,
+                exportQuery,
+                map(
+                        "query",
+                        "MATCH (start:TempNode)-[rel:REL]->(end:TempNode2) RETURN start, rel, end",
+                        "file",
+                        null,
+                        "config",
+                        Map.of("awaitForIndexes", 3000)),
+                (r) -> assertEquals(EXPECTED_TEMPNODE_AND_REL, r.get("cypherStatements")));
     }
 
     private void createFullTextRelIndex() {
         db.executeTransactionally("CREATE (s:TempNode)-[:REL{rel_value: 'the rel value'}]->(e:TempNode2)");
-        db.executeTransactionally("CREATE FULLTEXT INDEX MyCoolRelFulltextIndex FOR ()-[rel:REL]-() ON EACH [rel.rel_value]");
+        db.executeTransactionally(
+                "CREATE FULLTEXT INDEX MyCoolRelFulltextIndex FOR ()-[rel:REL]-() ON EACH [rel.rel_value]");
     }
 
     private void createFullTextNodeAndRelIndex() {
         createFullTextRelIndex();
-        db.executeTransactionally("CREATE FULLTEXT INDEX MyCoolNodeFulltextIndex FOR (n:TempNode) ON EACH [n.rel_value]");
+        db.executeTransactionally(
+                "CREATE FULLTEXT INDEX MyCoolNodeFulltextIndex FOR (n:TempNode) ON EACH [n.rel_value]");
     }
 
     @Test
@@ -1306,21 +1316,32 @@ public class ExportCypherTest {
         // check that `apoc.export.cypher.data`, `apoc.export.cypher.graph` and `apoc.export.cypher.query`
         // return consistent results
         Map<String, Object> config = Map.of("format", "neo4j-shell");
-        assertExportWithRangeIndex(EXPECTED_SCHEMA_WITH_RELS_OPTIMIZED,
+        assertExportWithRangeIndex(
+                EXPECTED_SCHEMA_WITH_RELS_OPTIMIZED,
                 exportQuery,
-                map("query", "MATCH (start:Foo)-[rel:KNOWS]->(end:Bar) RETURN start, rel, end",
-                        "file", null,
-                        "config", config));
+                map(
+                        "query",
+                        "MATCH (start:Foo)-[rel:KNOWS]->(end:Bar) RETURN start, rel, end",
+                        "file",
+                        null,
+                        "config",
+                        config));
 
-        assertExportWithRangeIndex(EXPECTED_SCHEMA_WITH_RELS_OPTIMIZED, """
+        assertExportWithRangeIndex(
+                EXPECTED_SCHEMA_WITH_RELS_OPTIMIZED,
+                """
                 MATCH (start:Foo)-[rel:KNOWS]->(end:Bar)
                 CALL apoc.export.cypher.data([start, end], [rel], null, $config)
                 YIELD cypherStatements RETURN *
-                """, map("config", config));
-        assertExportWithRangeIndex(EXPECTED_SCHEMA_WITH_RELS_OPTIMIZED, """
+                """,
+                map("config", config));
+        assertExportWithRangeIndex(
+                EXPECTED_SCHEMA_WITH_RELS_OPTIMIZED,
+                """
                 MATCH (start:Foo)-[rel:KNOWS]->(end:Bar)
                 CALL apoc.export.cypher.data([start, end], [rel], null, $config)
-                YIELD cypherStatements RETURN *""", map("config", config));
+                YIELD cypherStatements RETURN *""",
+                map("config", config));
 
         db.executeTransactionally("DROP INDEX rel_index_name");
     }
@@ -1332,24 +1353,38 @@ public class ExportCypherTest {
         // check that `apoc.export.cypher.data`, `apoc.export.cypher.graph` and `apoc.export.cypher.query`
         // return consistent results
         Map<String, Object> config = Map.of("format", "neo4j-shell", "saveIndexNames", true);
-        assertExportWithRangeIndex(EXPECTED_SCHEMA_WITH_RELS_AND_NAME_OPTIMIZED, exportQuery, map("query", "MATCH (start:Foo)-[rel:KNOWS]->(end:Bar) RETURN start, rel, end",
-                "file", null,
-                "config", config));
-        assertExportWithRangeIndex(EXPECTED_SCHEMA_WITH_RELS_AND_NAME_OPTIMIZED, """
+        assertExportWithRangeIndex(
+                EXPECTED_SCHEMA_WITH_RELS_AND_NAME_OPTIMIZED,
+                exportQuery,
+                map(
+                        "query",
+                        "MATCH (start:Foo)-[rel:KNOWS]->(end:Bar) RETURN start, rel, end",
+                        "file",
+                        null,
+                        "config",
+                        config));
+        assertExportWithRangeIndex(
+                EXPECTED_SCHEMA_WITH_RELS_AND_NAME_OPTIMIZED,
+                """
                 MATCH (start:Foo)-[rel:KNOWS]->(end:Bar)
                 CALL apoc.export.cypher.data([start, end], [rel], null, $config)
                 YIELD cypherStatements RETURN *
-                """, map("config", config));
-        assertExportWithRangeIndex(EXPECTED_SCHEMA_WITH_RELS_AND_NAME_OPTIMIZED, """
+                """,
+                map("config", config));
+        assertExportWithRangeIndex(
+                EXPECTED_SCHEMA_WITH_RELS_AND_NAME_OPTIMIZED,
+                """
                 MATCH (start:Foo)-[rel:KNOWS]->(end:Bar)
                 CALL apoc.export.cypher.data([start, end], [rel], null, $config)
-                YIELD cypherStatements RETURN *""", map("config", config));
+                YIELD cypherStatements RETURN *""",
+                map("config", config));
 
         db.executeTransactionally("DROP INDEX rel_index_name");
     }
 
     private void assertExportWithRangeIndex(String expectedSchema, String query, Map<String, Object> params) {
-        String expectedNodesAndRels = """
+        String expectedNodesAndRels =
+                """
                 BEGIN
                 UNWIND [{_id:0, properties:{born:date('2018-10-31'), name:"foo"}}] AS row
                 CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;
@@ -1365,8 +1400,7 @@ public class ExportCypherTest {
                 """;
         String expected = expectedSchema + expectedNodesAndRels + EXPECTED_CLEAN_UP;
 
-        TestUtil.testCall(db, query, params,
-                r -> assertEquals(expected, r.get("cypherStatements")));
+        TestUtil.testCall(db, query, params, r -> assertEquals(expected, r.get("cypherStatements")));
     }
 
     @Test
@@ -1748,51 +1782,57 @@ public class ExportCypherTest {
     }
 
     public static class ExportCypherResults {
-        static final String EXPECTED_TEMPNODE_AND_REL = String.format(":begin%n" +
-                "CREATE FULLTEXT INDEX MyCoolNodeFulltextIndex FOR (n:TempNode) ON EACH [n.`rel_value`];%n" +
-                "CREATE FULLTEXT INDEX MyCoolRelFulltextIndex FOR ()-[rel:REL]-() ON EACH [rel.`rel_value`];%n" +
-                "CREATE CONSTRAINT UNIQUE_IMPORT_NAME FOR (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
-                ":commit%n" +
-                "CALL db.awaitIndexes(3000);%n" +
-                ":begin%n" +
-                "UNWIND [{_id:3, properties:{}}] AS row%n" +
-                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:TempNode;%n" +
-                "UNWIND [{_id:4, properties:{}}] AS row\n" +
-                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:TempNode2;%n" +
-                ":commit%n" +
-                ":begin%n" +
-                "UNWIND [{start: {_id:3}, end: {_id:4}, properties:{rel_value:\"the rel value\"}}] AS row%n" +
-                "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})%n" +
-                "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})%n" +
-                "CREATE (start)-[r:REL]->(end) SET r += row.properties;%n" +
-                ":commit%n" +
-                ":begin%n" +
-                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
-                ":commit%n" +
-                ":begin%n" +
-                "DROP CONSTRAINT UNIQUE_IMPORT_NAME;%n" +
-                ":commit%n");
-        static final String EXPECTED_TEMPNODE = String.format(":begin%n" +
-                "CREATE FULLTEXT INDEX MyCoolRelFulltextIndex FOR ()-[rel:REL]-() ON EACH [rel.`rel_value`];%n" +
-                "CREATE CONSTRAINT UNIQUE_IMPORT_NAME FOR (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
-                ":commit%n" +
-                "CALL db.awaitIndexes(3000);%n" +
-                ":begin%n" +
-                "UNWIND [{_id:3, properties:{}}] AS row%n" +
-                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:TempNode;%n" +
-                ":commit%n" +
-                ":begin%n" +
-                "UNWIND [{start: {_id:3}, end: {_id:4}, properties:{rel_value:\"the rel value\"}}] AS row%n" +
-                "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})%n" +
-                "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})%n" +
-                "CREATE (start)-[r:REL]->(end) SET r += row.properties;%n" +
-                ":commit%n" +
-                ":begin%n" +
-                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
-                ":commit%n" +
-                ":begin%n" +
-                "DROP CONSTRAINT UNIQUE_IMPORT_NAME;%n" +
-                ":commit%n");
+        static final String EXPECTED_TEMPNODE_AND_REL =
+                """
+                :begin
+                CREATE FULLTEXT INDEX MyCoolNodeFulltextIndex FOR (n:TempNode) ON EACH [n.`rel_value`];
+                CREATE FULLTEXT INDEX MyCoolRelFulltextIndex FOR ()-[rel:REL]-() ON EACH [rel.`rel_value`];
+                CREATE CONSTRAINT UNIQUE_IMPORT_NAME FOR (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;
+                :commit
+                CALL db.awaitIndexes(3000);
+                :begin
+                UNWIND [{_id:3, properties:{}}] AS row
+                CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:TempNode;
+                UNWIND [{_id:4, properties:{}}] AS row
+                CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:TempNode2;
+                :commit
+                :begin
+                UNWIND [{start: {_id:3}, end: {_id:4}, properties:{rel_value:"the rel value"}}] AS row
+                MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})
+                MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})
+                CREATE (start)-[r:REL]->(end) SET r += row.properties;
+                :commit
+                :begin
+                MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;
+                :commit
+                :begin
+                DROP CONSTRAINT UNIQUE_IMPORT_NAME;
+                :commit
+                """;
+        static final String EXPECTED_TEMPNODE =
+                """
+                :begin
+                CREATE FULLTEXT INDEX MyCoolRelFulltextIndex FOR ()-[rel:REL]-() ON EACH [rel.`rel_value`];
+                CREATE CONSTRAINT UNIQUE_IMPORT_NAME FOR (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;
+                :commit
+                CALL db.awaitIndexes(3000);
+                :begin
+                UNWIND [{_id:3, properties:{}}] AS row
+                CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:TempNode;
+                :commit
+                :begin
+                UNWIND [{start: {_id:3}, end: {_id:4}, properties:{rel_value:"the rel value"}}] AS row
+                MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})
+                MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})
+                CREATE (start)-[r:REL]->(end) SET r += row.properties;
+                :commit
+                :begin
+                MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;
+                :commit
+                :begin
+                DROP CONSTRAINT UNIQUE_IMPORT_NAME;
+                :commit
+                """;
 
         static final String EXPECTED_ISOLATED_NODE =
                 "CREATE (:Bar:`UNIQUE IMPORT LABEL` {age:12, `UNIQUE IMPORT ID`:2});\n";
@@ -1803,11 +1843,14 @@ public class ExportCypherTest {
         public static final String EXPECTED_NODES =
                 String.format(EXPECTED_BEGIN_AND_FOO + EXPECTED_BAR_END_NODE + EXPECTED_ISOLATED_NODE + "COMMIT%n");
 
-        private static final String EXPECTED_NODES_MERGE = String.format("BEGIN%n"
-                + "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}) SET n.name=\"foo\", n.born=date('2018-10-31'), n:Foo;%n"
-                + "MERGE (n:Bar{name:\"bar\"}) SET n.age=42;%n"
-                + "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:2}) SET n.age=12, n:Bar;%n"
-                + "COMMIT%n");
+        private static final String EXPECTED_NODES_MERGE =
+                """
+                BEGIN
+                MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}) SET n.name="foo", n.born=date('2018-10-31'), n:Foo;
+                MERGE (n:Bar{name:"bar"}) SET n.age=42;
+                MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:2}) SET n.age=12, n:Bar;
+                COMMIT
+                """;
 
         public static final String EXPECTED_NODES_MERGE_ON_CREATE_SET =
                 EXPECTED_NODES_MERGE.replaceAll(" SET ", " ON CREATE SET ");
@@ -2278,17 +2321,16 @@ public class ExportCypherTest {
                 convertToCypherShellFormat(EXPECTED_ONLY_SCHEMA_NEO4J_SHELL);
 
         public static final List<String> EXPECTED_CONSTRAINTS = List.of(
-             "CREATE CONSTRAINT SingleUnique FOR (node:Label) REQUIRE (node.prop) IS UNIQUE;",
-             "CREATE CONSTRAINT SingleUniqueRel FOR ()-[rel:TYPE]-() REQUIRE (rel.prop) IS UNIQUE;",
-             "CREATE CONSTRAINT CompositeUnique FOR (node:Label) REQUIRE (node.prop1, node.prop2) IS UNIQUE;",
-             "CREATE CONSTRAINT CompositeUniqueRel FOR ()-[rel:TYPE]-() REQUIRE (rel.prop1, rel.prop2) IS UNIQUE;",
-             "CREATE CONSTRAINT SingleExists FOR (node:Label2) REQUIRE (node.prop) IS NOT NULL;",
-             "CREATE CONSTRAINT SingleExistsRel FOR ()-[rel:TYPE2]-() REQUIRE (rel.prop) IS NOT NULL;",
-             "CREATE CONSTRAINT SingleNodeKey FOR (node:Label3) REQUIRE (node.prop) IS NODE KEY;",
-             "CREATE CONSTRAINT PersonRequiresNamesConstraint FOR (node:Person) REQUIRE (node.name, node.surname) IS NODE KEY;",
-             "CREATE CONSTRAINT KnowsConsNotNull FOR ()-[rel:KNOWS]-() REQUIRE (rel.foo) IS NOT NULL;",
-             "CREATE CONSTRAINT KnowsConsUnique FOR ()-[rel:KNOWS]-() REQUIRE (rel.two) IS UNIQUE;"
-        );
+                "CREATE CONSTRAINT SingleUnique FOR (node:Label) REQUIRE (node.prop) IS UNIQUE;",
+                "CREATE CONSTRAINT SingleUniqueRel FOR ()-[rel:TYPE]-() REQUIRE (rel.prop) IS UNIQUE;",
+                "CREATE CONSTRAINT CompositeUnique FOR (node:Label) REQUIRE (node.prop1, node.prop2) IS UNIQUE;",
+                "CREATE CONSTRAINT CompositeUniqueRel FOR ()-[rel:TYPE]-() REQUIRE (rel.prop1, rel.prop2) IS UNIQUE;",
+                "CREATE CONSTRAINT SingleExists FOR (node:Label2) REQUIRE (node.prop) IS NOT NULL;",
+                "CREATE CONSTRAINT SingleExistsRel FOR ()-[rel:TYPE2]-() REQUIRE (rel.prop) IS NOT NULL;",
+                "CREATE CONSTRAINT SingleNodeKey FOR (node:Label3) REQUIRE (node.prop) IS NODE KEY;",
+                "CREATE CONSTRAINT PersonRequiresNamesConstraint FOR (node:Person) REQUIRE (node.name, node.surname) IS NODE KEY;",
+                "CREATE CONSTRAINT KnowsConsNotNull FOR ()-[rel:KNOWS]-() REQUIRE (rel.foo) IS NOT NULL;",
+                "CREATE CONSTRAINT KnowsConsUnique FOR ()-[rel:KNOWS]-() REQUIRE (rel.two) IS UNIQUE;");
 
         public static final String EXPECTED_NEO4J_SHELL_WITH_COMPOUND_CONSTRAINT =
                 String.format("COMMIT%n" + "SCHEMA AWAIT%n"

--- a/it/src/test/java/apoc/it/core/ExportCypherEnterpriseFeaturesTest.java
+++ b/it/src/test/java/apoc/it/core/ExportCypherEnterpriseFeaturesTest.java
@@ -70,7 +70,7 @@ public class ExportCypherEnterpriseFeaturesTest {
         session.writeTransaction(tx -> {
             tx.run("CREATE (a:Person:Base {name: 'Phil', surname: 'Meyer', tenantId: 'neo4j', id: 'waBfk3z'}) "
                     + "CREATE (b:Person:Base {name: 'Silvia', surname: 'Jones', tenantId: 'random', id: 'waBfk3z'}) "
-                    + "CREATE (a)-[:KNOWS]->(b)");
+                    + "CREATE (a)-[:KNOWS {foo:2}]->(b)");
             tx.commit();
             return null;
         });
@@ -98,6 +98,92 @@ public class ExportCypherEnterpriseFeaturesTest {
                 map("file", fileName, "config", Util.map("format", "cypher-shell")),
                 (r) -> assertExportStatement(
                         ExportCypherResults.EXPECTED_CYPHER_SHELL_WITH_COMPOUND_CONSTRAINT, fileName));
+    }
+
+    @Test
+    public void testExportDataWithCompoundConstraintCypherShell() {
+        testCall(session, """
+                MATCH (start:Person)-[rel:KNOWS]->(end)
+                CALL apoc.export.cypher.data([start, end], [rel], null, $config)
+                YIELD nodeStatements, schemaStatements, relationshipStatements RETURN *""",
+                map("config", Util.map("format", "cypher-shell", "separateFiles", true)),
+                this::assertExportNodesAndRels);
+    }
+
+    @Test
+    public void testExportGraphWithCompoundConstraintCypherShell() {
+        String fileName = "testGraphCypherShellWithCompoundConstraint.cypher";
+        testCall(session, """
+                MATCH (start:Person)-[rel:KNOWS]->(end)
+                WITH {nodes: [start, end], relationships: [rel]} AS graph
+                CALL apoc.export.cypher.graph(graph, null, $config)
+                YIELD nodeStatements, schemaStatements, relationshipStatements RETURN *""",
+                map("file", fileName, "config", Util.map("format", "cypher-shell", "separateFiles", true)),
+                this::assertExportNodesAndRels);
+    }
+
+    @Test
+    public void testExportQueryWithCompoundConstraintCypherShell() {
+        String fileName = "testQueryCypherShellWithCompoundConstraint.cypher";
+        testCall(session, "CALL apoc.export.cypher.query($query, null, {separateFiles: true})",
+                map("query", "MATCH (start:Person)-[rel:KNOWS]->(end) RETURN start, rel, end", "file", fileName),
+                this::assertExportNodesAndRels);
+    }
+
+    private void assertExportNodesAndRels(Map<String, Object> r) {
+        List<String> possibleNodeStatements = List.of("UNWIND [{surname:\"Jackson\", name:\"Matt\", properties:{}}, {surname:\"Snow\", name:\"John\", properties:{}}] AS row\n" +
+                        "CREATE (n:Person{surname: row.surname, name: row.name}) SET n += row.properties;",
+                "UNWIND [{surname:\"Snow\", name:\"John\", properties:{}}, {surname:\"Jackson\", name:\"Matt\", properties:{}}] AS row\n" +
+                        "CREATE (n:Person{surname: row.surname, name: row.name}) SET n += row.properties;");
+        String actual = (String) r.get("nodeStatements");
+        assertTrue(possibleNodeStatements.stream().anyMatch(actual::contains));
+        String schemaStatements = (String) r.get("schemaStatements");
+        List.of("CREATE CONSTRAINT KnowsConsNotNull FOR ()-[rel:KNOWS]-() REQUIRE (rel.foo) IS NOT NULL;",
+                "CREATE CONSTRAINT PersonRequiresNamesConstraint FOR (node:Person) REQUIRE (node.name, node.surname) IS NODE KEY;",
+                "CREATE CONSTRAINT KnowsConsUnique FOR ()-[rel:KNOWS]-() REQUIRE (rel.two) IS UNIQUE;")
+                        .forEach(constraint -> assertTrue(String.format("Constraint '%s' not in result", constraint), schemaStatements.contains(constraint) ));
+        assertEquals("""
+                            :begin
+                            UNWIND [{start: {name:"John", surname:"Snow"}, end: {name:"Matt", surname:"Jackson"}, properties:{foo:1}}] AS row
+                            MATCH (start:Person{surname: row.start.surname, name: row.start.name})
+                            MATCH (end:Person{surname: row.end.surname, name: row.end.name})
+                            CREATE (start)-[r:KNOWS]->(end) SET r += row.properties;
+                            :commit
+                            """,  r.get("relationshipStatements"));
+    }
+
+    @Test
+    public void testExportDataOnlyRelWithCompoundConstraintCypherShell() {
+        String fileName = "testDataCypherShellWithCompoundConstraint.cypher";
+        testCall(session, """
+                MATCH (start:Person)-[rel:KNOWS]->(end)
+                CALL apoc.export.cypher.data([], [rel], $file, $config)
+                YIELD nodes, relationships, properties RETURN *""",
+                map("file", fileName, "config", Util.map("format", "cypher-shell")), (r) -> {
+                    assertExportOnlyRels(fileName);
+                });
+    }
+
+    @Test
+    public void testExportGraphOnlyRelWithCompoundConstraintCypherShell() {
+        String fileName = "testGraphCypherShellWithCompoundConstraint.cypher";
+        testCall(session, """
+                MATCH (start:Person)-[rel:KNOWS]->(end)
+                WITH {nodes: [], relationships: [rel]} AS graph
+                CALL apoc.export.cypher.graph(graph, $file, $config)
+                YIELD nodes, relationships, properties RETURN *""",
+                map("file", fileName, "config", Util.map("format", "cypher-shell")), (r) -> {
+                    assertExportOnlyRels(fileName);
+                });
+    }
+
+    @Test
+    public void testExportQueryOnlyRelWithCompoundConstraintCypherShell() {
+        String fileName = "testQueryCypherShellWithCompoundConstraint.cypher";
+        testCall(session, "CALL apoc.export.cypher.query($query, $file)",
+                map("query", "MATCH (start:Person)-[rel:KNOWS]->(end) RETURN rel", "file", fileName), (r) -> {
+                    assertExportOnlyRels(fileName);
+                });
     }
 
     @Test
@@ -133,7 +219,7 @@ public class ExportCypherEnterpriseFeaturesTest {
         */
         final String expected =
                 """
-                UNWIND [{start: {name:"Phil", surname:"Meyer"}, end: {name:"Silvia", surname:"Jones"}, properties:{}}] AS row
+                UNWIND [{start: {name:"Phil", surname:"Meyer"}, end: {name:"Silvia", surname:"Jones"}, properties:{foo:2}}] AS row
                 MATCH (start:Person{surname: row.start.surname, name: row.start.name})
                 MATCH (end:Person{surname: row.end.surname, name: row.end.name})
                 CREATE (start)-[r:KNOWS]->(end) SET r += row.properties""";
@@ -158,6 +244,24 @@ public class ExportCypherEnterpriseFeaturesTest {
         } finally {
             afterTwoLabelsWithOneCompoundConstraintEach();
         }
+    }
+
+    private void assertExportOnlyRels(String fileName) {
+        String actual = readFileToString(new File(directory, fileName));
+        final String expected = """
+            :begin
+            CREATE CONSTRAINT KnowsConsNotNull FOR ()-[rel:KNOWS]-() REQUIRE (rel.foo) IS NOT NULL;
+            CREATE CONSTRAINT KnowsConsUnique FOR ()-[rel:KNOWS]-() REQUIRE (rel.two) IS UNIQUE;
+            :commit
+            CALL db.awaitIndexes(300);
+            :begin
+            UNWIND [{start: {_id:0}, end: {_id:1}, properties:{foo:1}}] AS row
+            MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})
+            MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})
+            CREATE (start)-[r:KNOWS]->(end) SET r += row.properties;
+            :commit
+            """;
+        assertEquals(expected, actual);
     }
 
     private void assertExportStatement(String expectedStatement, String fileName) {


### PR DESCRIPTION
- Increased `apoc.export.cypher.data/graph` test coverage with indexes and constraints
- Added schema relationship support to `apoc.export.cypher.data/graph` procedures