### PR TITLE
[dLZ2xYwQ] Multiple CypherInitializer's per single DatabaseAvailabilityGuard

### DIFF
--- a/common/src/main/java/apoc/ApocExtensionFactory.java
+++ b/common/src/main/java/apoc/ApocExtensionFactory.java
@@ -147,6 +147,10 @@ public class ApocExtensionFactory extends ExtensionFactory<ApocExtensionFactory.
                     }
                 });
             });
+
+            AvailabilityGuard availabilityGuard = dependencies.availabilityGuard();
+            registeredListeners.forEach(availabilityGuard::removeListener);
+            registeredListeners.clear();
         }
 
         public Collection<AvailabilityListener> getRegisteredListeners()


### PR DESCRIPTION
Removed `AvailabilityGuard`s when the database is stopped.

Other listeners:
- The `TransactionEventListener` is
 