### PR TITLE
[rGkwaqu1] apoc.path.expand doesn't handle special characters in label name

### DIFF
--- a/core/src/main/java/apoc/path/LabelMatcher.java
+++ b/core/src/main/java/apoc/path/LabelMatcher.java
@@ -64,18 +64,28 @@ public class LabelMatcher {
             label = label.substring(1);
         }
 
-        String[] elements = label.split(":");
+        // split any `:` char not preceded by `\`
+        String[] elements = label.split("(?<!\\\\):");
         if (elements.length == 1) {
+            label = sanitizeLabel(label);
             labels.add(label);
         } else if (elements.length > 1) {
             if (compoundLabels == null) {
                 compoundLabels = new ArrayList<>();
             }
 
-            compoundLabels.add(Arrays.asList(elements));
+            List<String> elementsList = Arrays.stream(elements)
+                    .map(this::sanitizeLabel)
+                    .toList();
+            compoundLabels.add(elementsList);
         }
 
         return this;
+    }
+
+    private String sanitizeLabel(String label) {
+        // from `\:` to `:`
+        return label.replaceAll("\\\\:", ":");
     }
 
     public boolean matchesLabels(Set<String> nodeLabels) {

--- a/core/src/test/java/apoc/path/ExpandPathTest.java
+++ b/core/src/test/java/apoc/path/ExpandPathTest.java
@@ -30,16 +30,20 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static apoc.util.Util.labelStrings;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ExpandPathTest {
@@ -529,25 +533,29 @@ public class ExpandPathTest {
 	@Test
 	public void testLabelWithSpecialChar() {
 		db.executeTransactionally(
-				"CREATE (n:`http://example.com/abc#Object` {one: 'alpha'})-[:REL]->(o:`http://www.w3.org/2002/07/owl#Class`:OwlClass {two: 'beta'})"
+				"""
+						CREATE (n:`http://example.com/abc#Object` {one: 'alpha'}) WITH n
+						CREATE (n)-[:REL]->(:`http://www.w3.org/2002/07/owl#Class`:OwlClass {two: 'beta'}),
+						 (n)-[:REL]->(:foo:bar {two: 'gamma'}),
+						 (n)-[:REL]->(:foo:baz {two: 'delta'})"""
 		);
 
 		String pathFilter = ">|<";
 		// match using a single label (`http://www.w3.org/2002/07/owl#Class`)
-		String labelFilter = "/http\\://www.w3.org/2002/07/owl#Class|foo:bar|another";
+		String labelFilter = "/http\\://www.w3.org/2002/07/owl#Class|/foo:bar|/another";
 
 		Map<String, Object> config = Map.of("pathFilter", pathFilter,
 				"labelFilter", labelFilter);
 
-		TestUtil.testCall(db,
-				"MATCH (node:`http://example.com/abc#Object`) CALL apoc.path.expand(node, '>|<', '/http\\://www.w3.org/2002/07/owl#Class', 0, 2) " +
+		TestUtil.testResult(db,
+				"MATCH (node:`http://example.com/abc#Object`) CALL apoc.path.expand(node, $pathFilter, $labelFilter, 0, 2) " +
 						"YIELD path " +
-						"return distinct nodes(path) AS nodes",
+						"return nodes(path) AS nodes",
 				config,
 				this::specialCharAssertions);
 
 		// with apoc.path.expandConfig
-		TestUtil.testCall(db,
+		TestUtil.testResult(db,
 				"MATCH (node:`http://example.com/abc#Object`) CALL apoc.path.expandConfig(node, $config) " +
 						"YIELD path " +
 						"return distinct nodes(path) AS nodes",
@@ -558,25 +566,27 @@ public class ExpandPathTest {
 	@Test
 	public void testCompoundLabelWithSpecialChar() {
 		db.executeTransactionally(
-				"CREATE (n:`http://compound.example/abc#Object` {one: 'alpha'})-[:REL]->(o:`/http://www.w3.org/2002/07/owl#Class`:OwlClass:`Go:ku` {two: 'beta'})"
+				"""
+						CREATE (n:`http://compound.example/abc#Object` {one: 'alpha'}) WITH n
+						CREATE (n)-[:REL]->(o:`/http://www.w3.org/2002/07/owl#Class`:OwlClass:`Go:ku` {two: 'beta'}),
+						 (n)-[:REL]->(:foo:bar {two: 'gamma'}),
+						 (n)-[:REL]->(:foo:baz {two: 'delta'})"""
 		);
 
-		String pathFilter = ">|<";
 		// match using multiple labels (`http://www.w3.org/2002/07/owl#Class`, `OwlClass` and `Go:ku`)
-		String labelFilter = "//http\\://www.w3.org/2002/07/owl#Class:OwlClass:Go\\:ku|foo:bar|another";
+		String labelFilter = "//http\\://www.w3.org/2002/07/owl#Class:OwlClass:Go\\:ku|/foo:bar|/another";
 
-		Map<String, Object> config = Map.of("pathFilter", pathFilter,
-				"labelFilter", labelFilter);
+		Map<String, Object> config = Map.of("labelFilter", labelFilter);
 
-		TestUtil.testCall(db,
-				"MATCH (node:`http://compound.example/abc#Object`) CALL apoc.path.expand(node, $pathFilter, $labelFilter, 0, 2) " +
+		TestUtil.testResult(db,
+				"MATCH (node:`http://compound.example/abc#Object`) CALL apoc.path.expand(node, null, $labelFilter, 0, 2) " +
 						"YIELD path " +
 						"return distinct nodes(path) AS nodes",
 				config,
 				this::specialCharAssertions);
 
 		// with apoc.path.expandConfig
-		TestUtil.testCall(db,
+		TestUtil.testResult(db,
 				"MATCH (node:`http://compound.example/abc#Object`) " +
 						"CALL apoc.path.expandConfig(node, $config) " +
 						"YIELD path " +
@@ -585,11 +595,48 @@ public class ExpandPathTest {
 				this::specialCharAssertions);
 	}
 
-	private void specialCharAssertions(Map<String, Object> row) {
+	@Test
+	public void testLabelWithTwoDots() {
+		db.executeTransactionally("CREATE (n:Multiple:End)-[:REL]->(o:`foo:bar` {two: 'beta'})");
+
+		String labelFilter = "foo:bar";
+		String labelFilterEscaped = "foo\\:bar";
+		Map<String, Object> config = Map.of("labelFilter", labelFilter);
+		Map<String, Object> configEscaped = Map.of("labelFilter", labelFilterEscaped);
+
+		// this doesn't work because search for compound labels, `foo` and `bar`
+		TestUtil.testCallEmpty(db, "MATCH (n:Multiple:End) CALL apoc.path.expand(n, null, $labelFilter, 1, 2) YIELD path RETURN path", config);
+
+		// this works correctly, because search for `foo:bar` label
+		TestUtil.testCall(db, "MATCH (n:Multiple:End) CALL apoc.path.expand(n, null, $labelFilter, 1, 2) YIELD path RETURN path", configEscaped, r -> {
+			Path path = (Path) r.get("path");
+			Iterator<Node> iterator = path.nodes().iterator();
+
+			Node node = iterator.next();
+			assertEquals(List.of("End", "Multiple"), labelStrings(node));
+
+			node = iterator.next();
+			assertEquals(List.of("foo:bar"), labelStrings(node));
+
+			assertFalse(iterator.hasNext());
+		});
+	}
+
+	private void specialCharAssertions(Result result) {
+		Map<String, Object> row = result.next();
+		assertSinglePath(row);
+		row = result.next();
+		assertSinglePath(row);
+		assertFalse(result.hasNext());
+	}
+
+	private static void assertSinglePath(Map<String, Object> row) {
 		List<Node> nodes = (List<Node>) row.get("nodes");
+		assertEquals(2, nodes.size());
 		Map<String, Object> allProperties = nodes.get(0).getAllProperties();
 		assertEquals(Map.of("one", "alpha"), allProperties);
-		Map<String, Object> allProperties1 = nodes.get(1).getAllProperties();
-		assertEquals(Map.of("two", "beta"), allProperties1);
+		Map<String, Object> allPropertiesEnd = nodes.get(1).getAllProperties();
+		String beta = (String) allPropertiesEnd.get("two");
+		assertTrue("Property `two` has value " + beta, List.of("beta", "gamma").contains(beta));
 	}
 }

--- a/core/src/test/java/apoc/path/ExpandPathTest.java
+++ b/core/src/test/java/apoc/path/ExpandPathTest.java
@@ -525,4 +525,71 @@ public class ExpandPathTest {
 					assertEquals(1, maps.size());
 				});
 	}
+
+	@Test
+	public void testLabelWithSpecialChar() {
+		db.executeTransactionally(
+				"CREATE (n:`http://example.com/abc#Object` {one: 'alpha'})-[:REL]->(o:`http://www.w3.org/2002/07/owl#Class`:OwlClass {two: 'beta'})"
+		);
+
+		String pathFilter = ">|<";
+		// match using a single label (`http://www.w3.org/2002/07/owl#Class`)
+		String labelFilter = "/http\\://www.w3.org/2002/07/owl#Class|foo:bar|another";
+
+		Map<String, Object> config = Map.of("pathFilter", pathFilter,
+				"labelFilter", labelFilter);
+
+		TestUtil.testCall(db,
+				"MATCH (node:`http://example.com/abc#Object`) CALL apoc.path.expand(node, '>|<', '/http\\://www.w3.org/2002/07/owl#Class', 0, 2) " +
+						"YIELD path " +
+						"return distinct nodes(path) AS nodes",
+				config,
+				this::specialCharAssertions);
+
+		// with apoc.path.expandConfig
+		TestUtil.testCall(db,
+				"MATCH (node:`http://example.com/abc#Object`) CALL apoc.path.expandConfig(node, $config) " +
+						"YIELD path " +
+						"return distinct nodes(path) AS nodes",
+				Map.of("config", config),
+				this::specialCharAssertions);
+	}
+
+	@Test
+	public void testCompoundLabelWithSpecialChar() {
+		db.executeTransactionally(
+				"CREATE (n:`http://compound.example/abc#Object` {one: 'alpha'})-[:REL]->(o:`/http://www.w3.org/2002/07/owl#Class`:OwlClass:`Go:ku` {two: 'beta'})"
+		);
+
+		String pathFilter = ">|<";
+		// match using multiple labels (`http://www.w3.org/2002/07/owl#Class`, `OwlClass` and `Go:ku`)
+		String labelFilter = "//http\\://www.w3.org/2002/07/owl#Class:OwlClass:Go\\:ku|foo:bar|another";
+
+		Map<String, Object> config = Map.of("pathFilter", pathFilter,
+				"labelFilter", labelFilter);
+
+		TestUtil.testCall(db,
+				"MATCH (node:`http://compound.example/abc#Object`) CALL apoc.path.expand(node, $pathFilter, $labelFilter, 0, 2) " +
+						"YIELD path " +
+						"return distinct nodes(path) AS nodes",
+				config,
+				this::specialCharAssertions);
+
+		// with apoc.path.expandConfig
+		TestUtil.testCall(db,
+				"MATCH (node:`http://compound.example/abc#Object`) " +
+						"CALL apoc.path.expandConfig(node, $config) " +
+						"YIELD path " +
+						"RETURN distinct nodes(path) AS nodes",
+				Map.of("config", config),
+				this::specialCharAssertions);
+	}
+
+	private void specialCharAssertions(Map<String, Object> row) {
+		List<Node> nodes = (List<Node>) row.get("nodes");
+		Map<String, Object> allProperties = nodes.get(0).getAllProperties();
+		assertEquals(Map.of("one", "alpha"), allProperties);
+		Map<String, Object> allProperties1 = nodes.get(1).getAllProperties();
+		assertEquals(Map.of("two", "beta"), allProperties1);
+	}
 }


### PR DESCRIPTION
Unlike what is written in the card, 
the issue regards the `:` character, which handle compound labels.

---

In this pr I updated the `:` char so that an escape character `\` can be inserted.
In case it's ok, the documentation should be updated.

Otherwise, we could just explain better that the `:` char 
is used to handle multiple labels and that it is not possible to filter labels containing that character.