### PR TITLE
[UNKBKte1] Redacts passwords in CypherInitializer

### DIFF
--- a/common/src/main/java/apoc/util/LogsUtil.java
+++ b/common/src/main/java/apoc/util/LogsUtil.java
@@ -1,0 +1,30 @@
+package apoc.util;
+
+import org.neo4j.cypher.internal.ast.Statement;
+import org.neo4j.cypher.internal.ast.factory.neo4j.JavaCCParser;
+import org.neo4j.cypher.internal.ast.prettifier.DefaultExpressionStringifier;
+import org.neo4j.cypher.internal.ast.prettifier.ExpressionStringifier;
+import org.neo4j.cypher.internal.ast.prettifier.ExpressionStringifier$;
+import org.neo4j.cypher.internal.util.OpenCypherExceptionFactory;
+import org.neo4j.cypher.internal.ast.prettifier.Prettifier;
+import org.neo4j.cypher.internal.rewriting.rewriters.sensitiveLiteralReplacement;
+
+public class LogsUtil {
+    private static OpenCypherExceptionFactory exceptionFactory = new OpenCypherExceptionFactory(scala.Option.empty());
+    private static ExpressionStringifier.Extension extension = ExpressionStringifier.Extension$.MODULE$.simple((ExpressionStringifier$.MODULE$.failingExtender()));
+    private static ExpressionStringifier stringifier = new DefaultExpressionStringifier(extension, false, false, false, false);
+    private static Prettifier prettifier = new Prettifier(stringifier, Prettifier.EmptyExtension$.MODULE$, true);
+
+
+    public static String sanitizeQuery(String query) {
+        try {
+            var statement = JavaCCParser.parse(query, exceptionFactory);
+            var rewriter = sensitiveLiteralReplacement.apply(statement)._1;
+            var res = (Statement) rewriter.apply(statement);
+
+            return prettifier.asString(res);
+        } catch (Exception e) {
+            return query;
+        }
+    }
+}

--- a/common/src/main/java/apoc/util/QueryUtil.java
+++ b/common/src/main/java/apoc/util/QueryUtil.java
@@ -1,0 +1,17 @@
+package apoc.util;
+
+import org.neo4j.cypher.internal.ast.factory.neo4j.JavaCCParser;
+import org.neo4j.cypher.internal.util.OpenCypherExceptionFactory;
+
+public class QueryUtil {
+    private static OpenCypherExceptionFactory exceptionFactory = new OpenCypherExceptionFactory(scala.Option.empty());
+
+    public static boolean isValidQuery(String query) {
+        try {
+            JavaCCParser.parse(query, exceptionFactory);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/core/src/main/java/apoc/cypher/CypherInitializer.java
+++ b/core/src/main/java/apoc/cypher/CypherInitializer.java
@@ -20,6 +20,8 @@ package apoc.cypher;
 
 import apoc.ApocConfig;
 import apoc.SystemLabels;
+import apoc.util.LogsUtil;
+import apoc.util.QueryUtil;
 import apoc.util.Util;
 import apoc.util.collection.Iterators;
 import apoc.version.Version;
@@ -101,13 +103,18 @@ public class CypherInitializer implements AvailabilityListener {
 
                 Configuration config = dependencyResolver.resolveDependency(ApocConfig.class).getConfig();
                 for (String query : collectInitializers(config)) {
-                    try {
-                        // we need to apply a retry strategy here since in systemdb we potentially conflict with
-                        // creating constraints which could cause our query to fail with a transient error.
-                        Util.retryInTx(userLog, db, tx -> Iterators.count(tx.execute(query)), 0, 5, retries -> { });
-                        userLog.info("successfully initialized: " + query);
-                    } catch (Exception e) {
-                        userLog.error("error upon initialization, running: " + query, e);
+                    if (QueryUtil.isValidQuery(query)) {
+                        String sanitizedQuery = LogsUtil.sanitizeQuery(query);
+                        try {
+                            // we need to apply a retry strategy here since in systemdb we potentially conflict with
+                            // creating constraints which could cause our query to fail with a transient error.
+                            Util.retryInTx(userLog, db, tx -> Iterators.count(tx.execute(query)), 0, 5, retries -> { });
+                            userLog.info("successfully initialized: " + sanitizedQuery);
+                        } catch (Exception e) {
+                            userLog.error("error upon initialization, running: " + sanitizedQuery, e);
+                        }
+                    } else {
+                        userLog.error("error upon initialization, invalid query: " + query);
                     }
                 }
             } finally {

--- a/core/src/test/java/apoc/util/LogsUtilTest.java
+++ b/core/src/test/java/apoc/util/LogsUtilTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package apoc.util;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class LogsUtilTest {
+
+    @Test
+    public void shouldRedactPasswords() {
+        String sanitized = LogsUtil.sanitizeQuery("CREATE USER dummy IF NOT EXISTS SET PASSWORD 'pass12345' CHANGE NOT REQUIRED");
+        assertEquals(sanitized, "CREATE USER dummy IF NOT EXISTS SET PASSWORD '******' CHANGE NOT REQUIRED");
+    }
+
+    @Test
+    public void shouldReturnInputIfInvalidQuery() {
+        String invalidQuery = "MATCH USER dummy IF NOT EXISTS SET PASSWORD 'pass12345' CHANGE NOT REQUIRED";
+        String sanitized = LogsUtil.sanitizeQuery(invalidQuery);
+
+        assertEquals(sanitized, invalidQuery);
+    }
+}

--- a/core/src/test/java/apoc/util/QueryUtilTest.java
+++ b/core/src/test/java/apoc/util/QueryUtilTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package apoc.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class QueryUtilTest
+{
+
+    @Test
+    public void shouldReturnTrueForValidQueries() {
+        assertTrue(QueryUtil.isValidQuery("CREATE USER dummy IF NOT EXISTS SET PASSWORD 'pass12345' CHANGE NOT REQUIRED"));
+    }
+
+    @Test
+    public void shouldReturnFalseForInvalidQueries() {
+        assertFalse(QueryUtil.isValidQuery("MATCH USER dummy IF NOT EXISTS SET PASSWORD 'pass12345' CHANGE NOT REQUIRED"));
+    }
+}

--- a/it/src/test/java/apoc/it/core/StartupTest.java
+++ b/it/src/test/java/apoc/it/core/StartupTest.java
@@ -100,6 +100,11 @@ public class StartupTest {
                 );
             }
 
+            String logs = neo4jContainer.getLogs();
+            assertTrue(logs.contains("successfully initialized: CREATE USER dummy IF NOT EXISTS SET PASSWORD '******' CHANGE NOT REQUIRED"));
+            assertTrue(logs.contains("successfully initialized: GRANT ROLE reader TO dummy"));
+            // The password should have been redacted
+            assertFalse(logs.contains("pass12345"));
             neo4jContainer.close();
         } catch (Exception ex) {
              if (TestContainerUtil.isDockerImageAvailable(ex)) {


### PR DESCRIPTION
Cherry-picked from https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3572

## What
We should obfuscate passwords when logging information in CypherInitializer

## Why

Because if we used:

```
apoc.initializer.system.1=CREATE USER dummy IF NOT EXISTS SET PASSWORD pass12345
```

we were getting an entry in neo4j.log with the password in plaintext:

```
INFO  [system/00000000] successfully initialized: alter user neo4j SET PASSWORD "pass12345" CHANGE NOT REQUIRED
```

## Expected behaviour

We should get a redacted password instead:

```
INFO  [system/00000000] successfully initialized: alter user neo4j SET PASSWORD "*****" CHANGE NOT REQUIRED
```
