### PR TITLE
[dITjfMpu] apoc.coll.indexOf unexpectedly treats collections differently than the same hardcoded list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,6 @@ apply from: "licenses-source-header.gradle"
 
 ext {
     publicDir =  "${project.rootDir}"
-    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : "5.8.0"
+    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : "5.9.0"
     testContainersVersion = '1.17.6'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,6 @@ apply from: "licenses-source-header.gradle"
 
 ext {
     publicDir =  "${project.rootDir}"
-    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : "5.9.0"
+    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : "5.8.0"
     testContainersVersion = '1.17.6'
 }

--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -26,6 +26,7 @@ import apoc.export.util.ExportConfig;
 import apoc.result.VirtualNode;
 import apoc.result.VirtualRelationship;
 import apoc.util.collection.Iterators;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.io.IOUtils;
@@ -86,7 +87,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -1113,34 +1113,20 @@ public class Util {
                 .equals(ValueUtils.of(other));
     }
 
-    // todo - parameterized???
-    public static <T> List<T> removeAll(Collection<T> remove, List<T> second) {
-        return gettStream(remove, second)
-                .collect(Collectors.toList());
+    public static boolean containsValueEquals(Collection<Object> collection, Object value) {
+        return collection.stream()
+                .anyMatch(i -> Util.valueEquals(value, i));
     }
 
-    public static <T> Set<T> removeAll(Collection<T> remove, Set<T> second) {
-        return gettStream(remove, second)
-                .collect(Collectors.toSet());
-    }
-
-
-    public static boolean isaBoolean(Collection<Object> second, Object i) {
-        return second.stream().anyMatch(i2 -> Util.valueEquals(i, i2));
-    }
-
-    private static <T> Stream<T> gettStream(Collection<T> remove, Collection<T> second) {
-        return remove.stream()
-                .filter(i -> isNoneMatch(second, i));
-    }
-
-    private static <T> boolean isNoneMatch(Collection<T> second, T i) {
-        return second.stream().noneMatch(i2 -> Util.valueEquals(i, i2));
-    }
-
-    public static <T> List<AnyValue> toAnyValues(List<T> second) {
-        return second.stream()
+    public static <T> List<AnyValue> toAnyValues(List<T> list) {
+        return list.stream()
                 .map(ValueUtils::of)
                 .collect(Collectors.toList());
+    }
+
+    public static int indexOf(List<Object> list, Object value) {
+        return ListUtils.indexOf(list,
+                (i) -> Util.valueEquals(i, value)
+        );
     }
 }

--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -36,8 +36,10 @@ import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.schema.ConstraintType;
 import org.neo4j.internal.schema.ConstraintDescriptor;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
+import org.neo4j.kernel.impl.util.ValueUtils;
 import org.neo4j.logging.NullLog;
 import org.neo4j.procedure.Mode;
+import org.neo4j.values.AnyValue;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
 import org.neo4j.values.storable.PointValue;
 import org.neo4j.values.storable.Values;
@@ -84,6 +86,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -1100,5 +1103,44 @@ public class Util {
         return System.getProperty("os.name")
                 .toLowerCase()
                 .contains("win");
+    }
+
+    public static <T> boolean valueEquals(T one, T other) {
+        if (one == null || other == null) {
+            return false;
+        }
+        return ValueUtils.of(one)
+                .equals(ValueUtils.of(other));
+    }
+
+    // todo - parameterized???
+    public static <T> List<T> removeAll(Collection<T> remove, List<T> second) {
+        return gettStream(remove, second)
+                .collect(Collectors.toList());
+    }
+
+    public static <T> Set<T> removeAll(Collection<T> remove, Set<T> second) {
+        return gettStream(remove, second)
+                .collect(Collectors.toSet());
+    }
+
+
+    public static boolean isaBoolean(Collection<Object> second, Object i) {
+        return second.stream().anyMatch(i2 -> Util.valueEquals(i, i2));
+    }
+
+    private static <T> Stream<T> gettStream(Collection<T> remove, Collection<T> second) {
+        return remove.stream()
+                .filter(i -> isNoneMatch(second, i));
+    }
+
+    private static <T> boolean isNoneMatch(Collection<T> second, T i) {
+        return second.stream().noneMatch(i2 -> Util.valueEquals(i, i2));
+    }
+
+    public static <T> List<AnyValue> toAnyValues(List<T> second) {
+        return second.stream()
+                .map(ValueUtils::of)
+                .collect(Collectors.toList());
     }
 }

--- a/core/src/main/java/apoc/coll/Coll.java
+++ b/core/src/main/java/apoc/coll/Coll.java
@@ -19,7 +19,9 @@
 package apoc.coll;
 
 import apoc.result.ListResult;
+import apoc.util.Util;
 import com.google.common.util.concurrent.AtomicDouble;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
@@ -29,28 +31,17 @@ import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.impl.util.ValueUtils;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.UserFunction;
+import org.neo4j.values.AnyValue;
 
 import java.lang.reflect.Array;
 import java.text.Collator;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Random;
-import java.util.RandomAccess;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -58,6 +49,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static apoc.util.Util.isaBoolean;
+import static apoc.util.Util.toAnyValues;
 import static java.util.Arrays.asList;
 
 public class Coll {
@@ -389,12 +382,12 @@ public class Coll {
 	    if (list==null || list.isEmpty()) return Stream.empty();
         List<Object> l = new ArrayList<>(list);
         List<List<Object>> result = new ArrayList<>(10);
-        int idx = l.indexOf(value);
+        int idx = extracted(l, value);
         while (idx != -1) {
             List<Object> subList = l.subList(0, idx);
             if (!subList.isEmpty()) result.add(subList);
             l = l.subList(idx+1,l.size());
-            idx = l.indexOf(value);
+            idx = extracted(l, value);// l.indexOf(value);
         }
         if (!l.isEmpty()) result.add(l);
         return result.stream().map(ListResult::new);
@@ -471,14 +464,35 @@ public class Coll {
     public long indexOf(@Name("coll") List<Object> coll, @Name("value") Object value) {
         // return reduce(res=[0,-1], x in $list | CASE WHEN x=$value AND res[1]=-1 THEN [res[0], res[0]+1] ELSE [res[0]+1, res[1]] END)[1] as value
         if (coll == null || coll.isEmpty()) return -1;
-        return  new ArrayList<>(coll).indexOf(value);
+        return new ArrayList<>(toAnyValues(coll)).indexOf(ValueUtils.of(value));
+    }
+//    @UserFunction("apoc.coll.indexOf")
+//    @Description("Returns the index for the first occurrence of the specified value in the list.")
+//    public long indexOf(@Name("coll") List<Object> coll, @Name("value") Object value) {
+//        // return reduce(res=[0,-1], x in $list | CASE WHEN x=$value AND res[1]=-1 THEN [res[0], res[0]+1] ELSE [res[0]+1, res[1]] END)[1] as value
+//        return extracted(coll, value);
+//    }
+
+    private int extracted(List<Object> coll, Object value) {
+        return ListUtils.indexOf(coll,
+                (i) -> Util.valueEquals(i, value)// ValueUtils.of(i).equals(ValueUtils.of(value))
+        );
     }
 
     @UserFunction("apoc.coll.containsAll")
     @Description("Returns whether or not all of the given values exist in the given collection (using a HashSet).")
     public boolean containsAll(@Name("coll1") List<Object> coll, @Name("coll2") List<Object> values) {
         if (coll == null || coll.isEmpty() || values == null) return false;
-        return new HashSet<>(coll).containsAll(values);
+        // todo - forse anche questo??
+//        CollectionUtils.containsAll(coll, values, null)
+        Set<Object> objects = new HashSet<>(coll);
+//        values.stream().allMatch(i -> objects.removeIf(i1 -> i1.equals()))
+
+        return values.stream()
+                .allMatch( i -> isaBoolean(objects, i));
+//                .allMatch( i -> isaBoolean(objects, i) objects.stream().anyMatch(i1 -> Util.valueEquals(i, i1)/* i1.equals(i)*/) );
+//                .containsAll(values);
+//        return new HashSet<>(coll).containsAll(values);
     }
 
     @UserFunction("apoc.coll.containsSorted")
@@ -522,7 +536,8 @@ public class Coll {
     @Description("Returns a unique list from the given list.")
     public List<Object> toSet(@Name("coll") List<Object> list) {
 	    if (list == null) return null;
-        return new SetBackedList(new LinkedHashSet(list));
+        List<AnyValue> anyValues = toAnyValues(list);
+        return new SetBackedList(new LinkedHashSet(anyValues));
     }
 
     @UserFunction("apoc.coll.sumLongs")
@@ -602,11 +617,19 @@ public class Coll {
     @UserFunction("apoc.coll.removeAll")
     @Description("Returns the first list with all elements of the second list removed.")
     public List<Object> removeAll(@Name("list1") List<Object> first, @Name("list2") List<Object> second) {
-		if (first == null) return null;
-        List<Object> list = new ArrayList<>(first);
-        if (second!=null) list.removeAll(second);
+        if (first == null) return null;
+        List<Object> list = new ArrayList<>(toAnyValues(first));
+        if (second!=null) list.removeAll(toAnyValues(second));
         return list;
     }
+//    @UserFunction("apoc.coll.removeAll")
+//    @Description("Returns the first list with all elements of the second list removed.")
+//    public List<Object> removeAll(@Name("list1") List<Object> first, @Name("list2") List<Object> second) {
+//		if (first == null) return null;
+//        List<Object> list = new ArrayList<>(first);
+//        if (second!=null) list = Util.removeAll(list, second);
+//        return list;
+//    }
     @UserFunction("apoc.coll.subtract")
     @Description("Returns the first list as a set with all the elements of the second list removed.")
     public List<Object> subtract(@Name("list1") List<Object> first, @Name("list2") List<Object> second) {
@@ -620,8 +643,8 @@ public class Coll {
     @Description("Returns the distinct intersection of two lists.")
     public List<Object> intersection(@Name("list1") List<Object> first, @Name("list2") List<Object> second) {
         if (first == null || second == null) return Collections.emptyList();
-        Set<Object> set = new HashSet<>(first);
-        set.retainAll(second);
+        Set<Object> set =first.stream().filter(i -> isaBoolean(second, i))
+                .collect(Collectors.toSet());
         return new SetBackedList(set);
     }
 

--- a/core/src/test/java/apoc/coll/CollTest.java
+++ b/core/src/test/java/apoc/coll/CollTest.java
@@ -43,9 +43,12 @@ import static org.junit.Assert.*;
 public class CollTest {
     // query that procedures a list,
     // with both entity types, via collect(..), and hardcoded one
-    private static final String QUERY_WITH_MIXED_TYPES = "MATCH (n:Test) " +
-            "WITH n ORDER BY n.a " +
-            "WITH COLLECT({something: n.something}) + { something: [] } + {something: 'alpha'} + {something: [1,2,3]} AS collection \n";
+    private static final String QUERY_WITH_MIXED_TYPES = """
+            WITH COLLECT {
+            MATCH (n:Test)
+            RETURN {something: n.something}
+            ORDER BY n.a} + { something: [] } + {something: 'alpha'} + {something: [1,2,3]} AS collection
+            """;
 
     private static final String QUERY_WITH_ARRAY = "CREATE (:Test {a: 1, something: 'alpha' }), " +
             "(:Test { a: 2, something: [] }), " +
@@ -226,11 +229,8 @@ public class CollTest {
     public void testIndexOfWithCollections() {
         db.executeTransactionally(QUERY_WITH_ARRAY);
         testCall(db, QUERY_WITH_MIXED_TYPES + "RETURN apoc.coll.indexOf(collection, { something: [] }) AS index",
-                r -> {
-                    long index = (long) r.get("index");
-                    assertTrue("Actual index is " + index,
-                            index == 1L || index == 2L);
-                });
+                r -> assertEquals(1L, r.get("index"))
+        );
     }
 
     @Test


### PR DESCRIPTION
Potentially this behaviour can affect a lot of procedures/functions, both `apoc.coll` and elsewhere.
I changed some of them, just to discuss about a possible solution that can be good for each procedure/fun that may have the problem.
For the other cases I created a follow-up card (id: `v8imq7eo`)

I think the possible solution are:
- Util.toAnyValues(..), as done in `apoc.coll.toSet`, which transform every object in `AnyValue`
  - pros: less code to change, just wrap the lists with that method
  - cons: tranform Object in AnyValue, so e.g an hardcoded `[1,2,3]` is converted from ArrayList<Long> to long[], so it could be considered a breaking change
  - 
- Create Util method that leverage `ValueUtils.of()`, as done in `apoc.coll.indexOf` and `apoc.coll.containsAll` 
  - pros: no need to loop through lists to transform to AnyValue
  - cons: e.g with an `apoc.coll.toSet(<NodePropValue>, ... <HardcodedValue>)`, if the two `..Value` are equal, the function will return the nodeProp or the hardcoded based on which one finds first.
