### PR TITLE
[NOID] Revert docker gradle change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage' : project.hasProperty("neo4jDockerVersionOverride") ? 'neo4j:' + project.getProperty("neo4jDockerVersionOverride") + '-enterprise' : 'neo4j:5.10.0-enterprise',
-                'neo4jCommunityDockerImage': project.hasProperty("neo4jDockerVersionOverride") ? 'neo4j:' + project.getProperty("neo4jDockerVersionOverride") : 'neo4j:5.10.0',
+                'neo4jDockerImage' : project.hasProperty("neo4jVersionOverride") ? 'neo4j:' + project.getProperty("neo4jVersionOverride") + '-enterprise' : 'neo4j:5.10.0-enterprise',
+                'neo4jCommunityDockerImage': project.hasProperty("neo4jVersionOverride") ? 'neo4j:' + project.getProperty("neo4jVersionOverride") : 'neo4j:5.10.0',
                 'coreDir': 'core'
 
         maxHeapSize = "5G"


### PR DESCRIPTION
The builds are running for 3.5h instead of 25mins, reverting the most likely culprit.

Revert: https://github.com/neo4j/apoc/pull/426