### PR TITLE
[NOID] Uses debian images in the TeamCity CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage' : project.hasProperty("neo4jDockerVersionOverride") ? 'neo4j:' + project.getProperty("neo4jDockerVersionOverride") + '-enterprise' : 'neo4j:5.10.0-enterprise',
-                'neo4jCommunityDockerImage': project.hasProperty("neo4jDockerVersionOverride") ? 'neo4j:' + project.getProperty("neo4jDockerVersionOverride") : 'neo4j:5.10.0',
+                'neo4jDockerImage' : project.hasProperty("neo4jDockerVersionOverride") ? 'neo4j:' + project.getProperty("neo4jDockerVersionOverride") + '-enterprise-debian' : 'neo4j:5.10.0-enterprise-debian',
+                'neo4jCommunityDockerImage': project.hasProperty("neo4jDockerVersionOverride") ? 'neo4j:' + project.getProperty("neo4jDockerVersionOverride") + '-debian': 'neo4j:5.10.0-debian',
                 'coreDir': 'core'
 
         maxHeapSize = "5G"


### PR DESCRIPTION
## Why
The images have changed internally to have the `-debian` tag
