### PR TITLE
Annotate unsafe procedures with @NotThreadSafe

### DIFF
--- a/core/src/main/java/apoc/algo/PathFinding.java
+++ b/core/src/main/java/apoc/algo/PathFinding.java
@@ -26,6 +26,7 @@ import org.neo4j.graphdb.*;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.NotThreadSafe;
 import org.neo4j.procedure.Procedure;
 
 import java.util.Collections;
@@ -109,6 +110,7 @@ public class PathFinding {
         return WeightedPathResult.streamWeightedPathResult(startNode, endNode, algo);
     }
 
+    @NotThreadSafe
     @Procedure("apoc.algo.allSimplePaths")
     @Description("Runs a search algorithm to find all of the simple paths between the given relationships, " +
             "up to a max depth described by maxNodes.")

--- a/core/src/main/java/apoc/coll/Coll.java
+++ b/core/src/main/java/apoc/coll/Coll.java
@@ -59,7 +59,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
+import org.neo4j.procedure.NotThreadSafe;
 import static apoc.util.Util.containsValueEquals;
 import static apoc.util.Util.toAnyValues;
 import static java.util.Arrays.asList;
@@ -149,6 +149,7 @@ public class Coll {
         }
         return (avg/(double)list.size());
     }
+    @NotThreadSafe
     @UserFunction("apoc.coll.min")
     @Description("Returns the minimum of all values in the given list.")
     public Object min(@Name("values") List<Object> list) {
@@ -160,8 +161,9 @@ public class Coll {
         }
     }
 
-    @UserFunction("apoc.coll.max")
-    @Description("Returns the maximum of all values in the given list.")
+    @NotThreadSafe
+    @UserFunction( "apoc.coll.max" )
+    @Description( "Returns the maximum of all values in the given list." )
     public Object max(@Name("values") List<Object> list) {
         if (list == null || list.isEmpty()) return null;
         if (list.size() == 1) return list.get(0);

--- a/core/src/main/java/apoc/cypher/Cypher.java
+++ b/core/src/main/java/apoc/cypher/Cypher.java
@@ -31,6 +31,7 @@ import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Mode;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.NotThreadSafe;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.TerminationGuard;
 
@@ -74,6 +75,7 @@ public class Cypher {
     @Context
     public Pools pools;
 
+    @NotThreadSafe
     @Procedure("apoc.cypher.run")
     @Description("Runs a dynamically constructed read-only string with the given parameters.")
     public Stream<MapResult> run(@Name("statement") String statement, @Name("params") Map<String, Object> params) {
@@ -162,6 +164,7 @@ public class Cypher {
         return runManyStatements(stringReader ,params, false, addStatistics, queueCapacity);
     }
 
+    @NotThreadSafe
     @Procedure(name = "apoc.cypher.runManyReadOnly", mode = READ)
     @Description("Runs each semicolon separated read-only statement and returns a summary of the statement outcomes.")
     public Stream<RowResult> runManyReadOnly(@Name("statement") String cypher, @Name("params") Map<String,Object> params, @Name(value = "config",defaultValue = "{}") Map<String,Object> config) {

--- a/core/src/main/java/apoc/cypher/CypherFunctions.java
+++ b/core/src/main/java/apoc/cypher/CypherFunctions.java
@@ -24,6 +24,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.NotThreadSafe;
 import org.neo4j.procedure.UserFunction;
 
 import java.util.Collections;
@@ -54,11 +55,14 @@ public class CypherFunctions {
       }
     }
 
+    @NotThreadSafe
     @UserFunction("apoc.cypher.runFirstColumnMany")
     @Description("Runs the given statement with the given parameters and returns the first column collected into a list.")
     public List<Object> runFirstColumnMany(@Name("statement") String statement, @Name("params") Map<String, Object> params) {
         return (List)runFirstColumn(statement, params, true);
     }
+
+    @NotThreadSafe
     @UserFunction("apoc.cypher.runFirstColumnSingle")
     @Description("Runs the given statement with the given parameters and returns the first element of the first column.")
     public Object runFirstColumnSingle(@Name("statement") String statement, @Name("params") Map<String, Object> params) {

--- a/core/src/main/java/apoc/cypher/Timeboxed.java
+++ b/core/src/main/java/apoc/cypher/Timeboxed.java
@@ -29,6 +29,7 @@ import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.NotThreadSafe;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.TerminationGuard;
 
@@ -61,6 +62,8 @@ public class Timeboxed {
 
     private final static Map<String,Object> POISON = Collections.singletonMap("__magic", "POISON");
 
+
+    @NotThreadSafe
     @Procedure("apoc.cypher.runTimeboxed")
     @Description("Terminates a Cypher statement if it has not finished before the set timeout (ms).")
     public Stream<MapResult> runTimeboxed(@Name("statement") String cypher, @Name("params") Map<String, Object> params, @Name("timeout") long timeout) {

--- a/core/src/main/java/apoc/example/Examples.java
+++ b/core/src/main/java/apoc/example/Examples.java
@@ -26,6 +26,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Mode;
+import org.neo4j.procedure.NotThreadSafe;
 import org.neo4j.procedure.Procedure;
 
 import java.util.stream.Stream;
@@ -39,6 +40,7 @@ public class Examples {
     @Context
     public Transaction tx;
 
+    @NotThreadSafe
     @Procedure(name = "apoc.example.movies", mode = Mode.WRITE)
     @Description("Seeds the database with the Neo4j movie dataset.")
     public Stream<ProgressInfo> movies() {

--- a/core/src/main/java/apoc/export/arrow/ExportArrow.java
+++ b/core/src/main/java/apoc/export/arrow/ExportArrow.java
@@ -34,6 +34,7 @@ import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.NotThreadSafe;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.TerminationGuard;
 
@@ -59,12 +60,14 @@ public class ExportArrow {
     @Context
     public TerminationGuard terminationGuard;
 
+    @NotThreadSafe
     @Procedure("apoc.export.arrow.stream.all")
     @Description("Exports the full database as an arrow byte array.")
     public Stream<ByteArrayResult> all(@Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
         return new ExportArrowService(db, pools, terminationGuard, logger).stream(new DatabaseSubGraph(tx), new ArrowConfig(config));
     }
 
+    @NotThreadSafe
     @Procedure("apoc.export.arrow.stream.graph")
     @Description("Exports the given graph as an arrow byte array.")
     public Stream<ByteArrayResult> graph(@Name("graph") Object graph, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
@@ -85,6 +88,7 @@ public class ExportArrow {
         return new ExportArrowService(db, pools, terminationGuard, logger).stream(subGraph, new ArrowConfig(config));
     }
 
+    @NotThreadSafe
     @Procedure("apoc.export.arrow.stream.query")
     @Description("Exports the given Cypher query as an arrow byte array.")
     public Stream<ByteArrayResult> query(@Name("query") String query, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
@@ -93,12 +97,14 @@ public class ExportArrow {
         return new ExportArrowService(db, pools, terminationGuard, logger).stream(result, new ArrowConfig(config));
     }
 
+    @NotThreadSafe
     @Procedure("apoc.export.arrow.all")
     @Description("Exports the full database as an arrow file.")
     public Stream<ProgressInfo> all(@Name("file") String fileName, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
         return new ExportArrowService(db, pools, terminationGuard, logger).file(fileName, new DatabaseSubGraph(tx), new ArrowConfig(config));
     }
 
+    @NotThreadSafe
     @Procedure("apoc.export.arrow.graph")
     @Description("Exports the given graph as an arrow file.")
     public Stream<ProgressInfo> graph(@Name("file") String fileName, @Name("graph") Object graph, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
@@ -119,6 +125,7 @@ public class ExportArrow {
         return new ExportArrowService(db, pools, terminationGuard, logger).file(fileName, subGraph, new ArrowConfig(config));
     }
 
+    @NotThreadSafe
     @Procedure("apoc.export.arrow.query")
     @Description("Exports the results from the given Cypher query as an arrow file.")
     public Stream<ProgressInfo> query(@Name("file") String fileName, @Name("query") String query, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {

--- a/core/src/main/java/apoc/export/csv/ExportCSV.java
+++ b/core/src/main/java/apoc/export/csv/ExportCSV.java
@@ -39,6 +39,7 @@ import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.NotThreadSafe;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.TerminationGuard;
 
@@ -71,6 +72,7 @@ public class ExportCSV {
     public ExportCSV() {
     }
 
+    @NotThreadSafe
     @Procedure("apoc.export.csv.all")
     @Description("Exports the full database to the provided CSV file.")
     public Stream<ProgressInfo> all(@Name("file") String fileName, @Name("config") Map<String, Object> config) {
@@ -78,6 +80,7 @@ public class ExportCSV {
         return exportCsv(fileName, source, new DatabaseSubGraph(tx), new ExportConfig(config));
     }
 
+    @NotThreadSafe
     @Procedure("apoc.export.csv.data")
     @Description("Exports the given nodes and relationships to the provided CSV file.")
     public Stream<ProgressInfo> data(@Name("nodes") List<Node> nodes, @Name("rels") List<Relationship> rels, @Name("file") String fileName, @Name("config") Map<String, Object> config) {
@@ -86,6 +89,8 @@ public class ExportCSV {
         String source = String.format("data: nodes(%d), rels(%d)", nodes.size(), rels.size());
         return exportCsv(fileName, source, new NodesAndRelsSubGraph(tx, nodes, rels), exportConfig);
     }
+
+    @NotThreadSafe
     @Procedure("apoc.export.csv.graph")
     @Description("Exports the given graph to the provided CSV file.")
     public Stream<ProgressInfo> graph(@Name("graph") Map<String,Object> graph, @Name("file") String fileName, @Name("config") Map<String, Object> config) {
@@ -95,6 +100,7 @@ public class ExportCSV {
         return exportCsv(fileName, source, new NodesAndRelsSubGraph(tx, nodes, rels), new ExportConfig(config));
     }
 
+    @NotThreadSafe
     @Procedure("apoc.export.csv.query")
     @Description("Exports the results from running the given Cypher query to the provided CSV file.")
     public Stream<ProgressInfo> query(@Name("query") String query, @Name("file") String fileName, @Name("config") Map<String, Object> config) {

--- a/core/src/main/java/apoc/export/cypher/ExportCypher.java
+++ b/core/src/main/java/apoc/export/cypher/ExportCypher.java
@@ -39,6 +39,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.NotThreadSafe;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.TerminationGuard;
 
@@ -71,6 +72,7 @@ public class ExportCypher {
     @Context
     public Pools pools;
 
+    @NotThreadSafe
     @Procedure("apoc.export.cypher.all")
     @Description("Exports the full database (incl. indexes) as Cypher statements to the provided file (default: Cypher Shell).")
     public Stream<DataProgressInfo> all(@Name(value = "file",defaultValue = "") String fileName, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
@@ -79,6 +81,7 @@ public class ExportCypher {
         return exportCypher(fileName, source, new DatabaseSubGraph(tx), new ExportConfig(config), false);
     }
 
+    @NotThreadSafe
     @Procedure("apoc.export.cypher.data")
     @Description("Exports the given nodes and relationships (incl. indexes) as Cypher statements to the provided file (default: Cypher Shell).")
     public Stream<DataProgressInfo> data(@Name("nodes") List<Node> nodes, @Name("rels") List<Relationship> rels, @Name(value = "file",defaultValue = "") String fileName, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
@@ -87,6 +90,7 @@ public class ExportCypher {
         return exportCypher(fileName, source, new NodesAndRelsSubGraph(tx, nodes, rels), new ExportConfig(config), false);
     }
 
+    @NotThreadSafe
     @Procedure("apoc.export.cypher.graph")
     @Description("Exports the given graph (incl. indexes) as Cypher statements to the provided file (default: Cypher Shell).")
     public Stream<DataProgressInfo> graph(@Name("graph") Map<String, Object> graph, @Name(value = "file",defaultValue = "") String fileName, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
@@ -98,6 +102,7 @@ public class ExportCypher {
         return exportCypher(fileName, source, new NodesAndRelsSubGraph(tx, nodes, rels), new ExportConfig(config), false);
     }
 
+    @NotThreadSafe
     @Procedure("apoc.export.cypher.query")
     @Description("Exports the nodes and relationships from the given Cypher query (incl. indexes) as Cypher statements to the provided file (default: Cypher Shell).")
     public Stream<DataProgressInfo> query(@Name("statement") String query, @Name(value = "file",defaultValue = "") String fileName, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
@@ -111,6 +116,7 @@ public class ExportCypher {
         return exportCypher(fileName, source, graph, c, false);
     }
 
+    @NotThreadSafe
     @Procedure("apoc.export.cypher.schema")
     @Description("Exports all schema indexes and constraints to Cypher statements.")
     public Stream<DataProgressInfo> schema(@Name(value = "file",defaultValue = "") String fileName, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {

--- a/core/src/main/java/apoc/export/graphml/ExportGraphML.java
+++ b/core/src/main/java/apoc/export/graphml/ExportGraphML.java
@@ -42,6 +42,7 @@ import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Mode;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.NotThreadSafe;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.TerminationGuard;
 
@@ -98,6 +99,8 @@ public class ExportGraphML {
         });
         return Stream.of(result);
     }
+
+    @NotThreadSafe
     @Procedure("apoc.export.graphml.all")
     @Description("Exports the full database to the provided GraphML file.")
     public Stream<ProgressInfo> all(@Name("file") String fileName, @Name("config") Map<String, Object> config) throws Exception {
@@ -123,6 +126,7 @@ public class ExportGraphML {
         return exportGraphML(fileName, source, new NodesAndRelsSubGraph(tx, nodes, rels), new ExportConfig(config));
     }
 
+    @NotThreadSafe
     @Procedure("apoc.export.graphml.query")
     @Description("Exports the given nodes and relationships from the Cypher statement to the provided GraphML file.")
     public Stream<ProgressInfo> query(@Name("statement") String query, @Name("file") String fileName, @Name("config") Map<String, Object> config) throws Exception {

--- a/core/src/main/java/apoc/export/json/ExportJson.java
+++ b/core/src/main/java/apoc/export/json/ExportJson.java
@@ -38,6 +38,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.NotThreadSafe;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.TerminationGuard;
 
@@ -63,6 +64,7 @@ public class ExportJson {
     @Context
     public TerminationGuard terminationGuard;
 
+    @NotThreadSafe
     @Procedure("apoc.export.json.all")
     @Description("Exports the full database to the provided JSON file.")
     public Stream<ProgressInfo> all(@Name("file") String fileName, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
@@ -71,6 +73,7 @@ public class ExportJson {
         return exportJson(fileName, source, new DatabaseSubGraph(tx), config);
     }
 
+    @NotThreadSafe
     @Procedure("apoc.export.json.data")
     @Description("Exports the given nodes and relationships to the provided JSON file.")
     public Stream<ProgressInfo> data(@Name("nodes") List<Node> nodes, @Name("rels") List<Relationship> rels, @Name("file") String fileName, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
@@ -81,6 +84,8 @@ public class ExportJson {
         String source = String.format("data: nodes(%d), rels(%d)", nodes.size(), rels.size());
         return exportJson(fileName, source, new NodesAndRelsSubGraph(tx, nodes, rels), config);
     }
+
+    @NotThreadSafe
     @Procedure("apoc.export.json.graph")
     @Description("Exports the given graph to the provided JSON file.")
     public Stream<ProgressInfo> graph(@Name("graph") Map<String,Object> graph, @Name("file") String fileName, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
@@ -91,6 +96,7 @@ public class ExportJson {
         return exportJson(fileName, source, new NodesAndRelsSubGraph(tx, nodes, rels), config);
     }
 
+    @NotThreadSafe
     @Procedure("apoc.export.json.query")
     @Description("Exports the results from the Cypher statement to the provided JSON file.")
     public Stream<ProgressInfo> query(@Name("statement") String query, @Name("file") String fileName, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {

--- a/core/src/main/java/apoc/graph/Graphs.java
+++ b/core/src/main/java/apoc/graph/Graphs.java
@@ -84,6 +84,7 @@ public class Graphs {
         return Stream.of(new VirtualGraph(name,tx.getAllNodes(),tx.getAllRelationships(),properties));
     }
 
+    @NotThreadSafe
     @Procedure("apoc.graph.fromCypher")
     @Description("Generates a virtual sub-graph by extracting all of the nodes and relationships from the data returned by the given Cypher statement.")
     public Stream<VirtualGraph> fromCypher(@Name("statement") String statement,  @Name("params") Map<String,Object> params,@Name("name") String name,  @Name("props") Map<String,Object> properties) {

--- a/core/src/main/java/apoc/help/Help.java
+++ b/core/src/main/java/apoc/help/Help.java
@@ -31,6 +31,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.NotThreadSafe;
 import org.neo4j.procedure.Procedure;
 
 import static apoc.util.Util.map;
@@ -57,6 +58,7 @@ public class Help {
         }
     }
 
+    @NotThreadSafe
     @Procedure("apoc.help")
     @Description("Returns descriptions of the available APOC procedures and functions.")
     public Stream<HelpResult> info(@Name("proc") String name) {

--- a/core/src/main/java/apoc/index/SchemaIndex.java
+++ b/core/src/main/java/apoc/index/SchemaIndex.java
@@ -48,6 +48,7 @@ import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.NotThreadSafe;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.TerminationGuard;
 
@@ -79,7 +80,7 @@ public class SchemaIndex {
     @Context
     public TerminationGuard terminationGuard;
 
-
+    @NotThreadSafe
     @Procedure("apoc.schema.properties.distinct")
     @Description("Returns all distinct node property values for the given key.")
     public Stream<ListResult> distinct(@Name("label") String label, @Name("key")  String key) {
@@ -87,6 +88,7 @@ public class SchemaIndex {
         return Stream.of(new ListResult(values));
     }
 
+    @NotThreadSafe
     @Procedure("apoc.schema.properties.distinctCount")
     @Description("Returns all distinct property values and counts for the given key.")
     public Stream<PropertyValueCount> distinctCount(@Name(value = "label", defaultValue = "") String labelName, @Name(value = "key", defaultValue = "") String keyName) {

--- a/core/src/main/java/apoc/lock/Lock.java
+++ b/core/src/main/java/apoc/lock/Lock.java
@@ -30,6 +30,7 @@ public class Lock {
     @Context
     public Transaction tx;
 
+    @NotThreadSafe
     @Procedure(name = "apoc.lock.all", mode = Mode.WRITE)
     @Description("Acquires a write lock on the given nodes and relationships.")
     public void all(@Name("nodes") List<Node> nodes, @Name("rels") List<Relationship> rels) {
@@ -41,6 +42,7 @@ public class Lock {
         }
     }
 
+    @NotThreadSafe
     @Procedure(name = "apoc.lock.nodes", mode = Mode.WRITE)
     @Description("Acquires a write lock on the given nodes.")
     public void nodes(@Name("nodes") List<Node> nodes) {
@@ -49,6 +51,7 @@ public class Lock {
         }
     }
 
+    @NotThreadSafe
     @Procedure(name = "apoc.lock.read.nodes", mode = Mode.READ)
     @Description("Acquires a read lock on the given nodes.")
     public void readLockOnNodes(@Name("nodes") List<Node> nodes) {
@@ -57,6 +60,7 @@ public class Lock {
         }
     }
 
+    @NotThreadSafe
     @Procedure(name = "apoc.lock.rels", mode = Mode.WRITE)
     @Description("Acquires a write lock on the given relationships.")
     public void rels(@Name("rels") List<Relationship> rels) {
@@ -65,6 +69,7 @@ public class Lock {
         }
     }
 
+    @NotThreadSafe
     @Procedure(name = "apoc.lock.read.rels", mode = Mode.READ)
     @Description("Acquires a read lock on the given relationships.")
     public void readLocksOnRels(@Name("rels") List<Relationship> rels) {

--- a/core/src/main/java/apoc/nodes/Grouping.java
+++ b/core/src/main/java/apoc/nodes/Grouping.java
@@ -28,6 +28,7 @@ import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.NotThreadSafe;
 import org.neo4j.procedure.Procedure;
 
 import java.util.*;
@@ -84,6 +85,7 @@ public class Grouping {
         }
     }
 
+    @NotThreadSafe
     @Procedure("apoc.nodes.group")
     @Description("Allows for the aggregation of nodes based on the given properties.\n" +
             "This procedure returns virtual nodes.")

--- a/core/src/main/java/apoc/nodes/Nodes.java
+++ b/core/src/main/java/apoc/nodes/Nodes.java
@@ -56,6 +56,7 @@ import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Mode;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.NotThreadSafe;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.UserFunction;
 import org.neo4j.storageengine.api.RelationshipSelection;
@@ -597,6 +598,7 @@ public class Nodes {
         }
     }
 
+    @NotThreadSafe
     @UserFunction("apoc.any.isDeleted")
     @Description("Returns true if the given node or relationship no longer exists.")
     public boolean isDeleted(@Name("object") Object object) {

--- a/core/src/main/java/apoc/path/PathExplorer.java
+++ b/core/src/main/java/apoc/path/PathExplorer.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.NotThreadSafe;
 import org.neo4j.procedure.Procedure;
 
 import java.util.*;
@@ -49,6 +50,7 @@ public class PathExplorer {
 	@Context
     public Transaction tx;
 
+	@NotThreadSafe
 	@Procedure("apoc.path.expand")
 	@Description("Returns paths expanded from the start node following the given relationship types from min-depth to max-depth.")
 	public Stream<PathResult> explorePath(@Name("startNode") Object start
@@ -61,12 +63,14 @@ public class PathExplorer {
 	}
 
 	//
+	@NotThreadSafe
 	@Procedure("apoc.path.expandConfig")
 	@Description("Returns paths expanded from the start node the given relationship types from min-depth to max-depth.")
 	public Stream<PathResult> expandConfig(@Name("startNode") Object start, @Name("config") Map<String,Object> config) throws Exception {
 		return expandConfigPrivate(start, config).map( PathResult::new );
 	}
 
+	@NotThreadSafe
 	@Procedure("apoc.path.subgraphNodes")
 	@Description("Returns the nodes in the sub-graph reachable from the start node following the given relationship types to max-depth.")
 	public Stream<NodeResult> subgraphNodes(@Name("startNode") Object start, @Name("config") Map<String,Object> config) throws Exception {
@@ -80,6 +84,7 @@ public class PathExplorer {
 		return expandConfigPrivate(start, configMap).map( path -> path == null ? new NodeResult(null) : new NodeResult(path.endNode()) );
 	}
 
+	@NotThreadSafe
 	@Procedure("apoc.path.subgraphAll")
 	@Description("Returns the sub-graph reachable from the start node following the given relationship types to max-depth.")
 	public Stream<GraphResult> subgraphAll(@Name("startNode") Object start, @Name("config") Map<String,Object> config) throws Exception {
@@ -97,6 +102,7 @@ public class PathExplorer {
 		return Stream.of(new GraphResult(subgraphNodes, subgraphRels));
 	}
 
+	@NotThreadSafe
 	@Procedure("apoc.path.spanningTree")
 	@Description("Returns spanning tree paths expanded from the start node following the given relationship types to max-depth.")
 	public Stream<PathResult> spanningTree(@Name("startNode") Object start, @Name("config") Map<String,Object> config) throws Exception {

--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -47,6 +47,7 @@ import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Mode;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.NotThreadSafe;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.UserFunction;
 import org.neo4j.token.api.TokenConstants;
@@ -82,6 +83,7 @@ public class Schemas {
     @Context
     public KernelTransaction ktx;
 
+    @NotThreadSafe
     @Procedure(name = "apoc.schema.assert", mode = Mode.SCHEMA)
     @Description("Drops all other existing indexes and constraints when `dropExisting` is `true` (default is `true`).\n" +
             "Asserts at the end of the operation that the given indexes and unique constraints are there.")
@@ -91,6 +93,7 @@ public class Schemas {
                 assertConstraints(constraints, dropExisting).stream());
     }
 
+    @NotThreadSafe
     @Procedure(name = "apoc.schema.nodes", mode = Mode.SCHEMA)
     @Description("Returns all indexes and constraints information for all node labels in the database.\n" +
             "It is possible to define a set of labels to include or exclude in the config parameters.")
@@ -98,6 +101,7 @@ public class Schemas {
         return indexesAndConstraintsForNode(config);
     }
 
+    @NotThreadSafe
     @Procedure(name = "apoc.schema.relationships", mode = Mode.SCHEMA)
     @Description("Returns the indexes and constraints information for all the relationship types in the database.\n" +
             "It is possible to define a set of relationship types to include or exclude in the config parameters.")
@@ -105,24 +109,28 @@ public class Schemas {
         return indexesAndConstraintsForRelationships(config);
     }
 
+    @NotThreadSafe
     @UserFunction(name = "apoc.schema.node.indexExists")
     @Description("Returns a boolean depending on whether or not an index exists for the given node label with the given property names.")
     public Boolean indexExistsOnNode(@Name("labelName") String labelName, @Name("propertyName") List<String> propertyNames) {
         return indexExists(labelName, propertyNames);
     }
 
+    @NotThreadSafe
     @UserFunction(value = "apoc.schema.relationship.indexExists")
     @Description("Returns a boolean depending on whether or not an index exists for the given relationship type with the given property names.")
     public Boolean indexExistsOnRelationship(@Name("type") String relName, @Name("propertyName") List<String> propertyNames) {
         return indexExistsForRelationship(relName, propertyNames);
     }
 
+    @NotThreadSafe
     @UserFunction(name = "apoc.schema.node.constraintExists")
     @Description("Returns a boolean depending on whether or not a constraint exists for the given node label with the given property names.")
     public Boolean constraintExistsOnNode(@Name("labelName") String labelName, @Name("propertyName") List<String> propertyNames) {
         return constraintsExists(labelName, propertyNames);
     }
 
+    @NotThreadSafe
     @UserFunction(name = "apoc.schema.relationship.constraintExists")
     @Description("Returns a boolean depending on whether or not a constraint exists for the given relationship type with the given property names.")
     public Boolean constraintExistsOnRelationship(@Name("type") String type, @Name("propertyName") List<String> propertyNames) {

--- a/core/src/main/java/apoc/search/ParallelNodeSearch.java
+++ b/core/src/main/java/apoc/search/ParallelNodeSearch.java
@@ -27,6 +27,7 @@ import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.NotThreadSafe;
 import org.neo4j.procedure.Procedure;
 
 import java.util.*;
@@ -54,6 +55,7 @@ public class ParallelNodeSearch {
     @Context
     public Transaction tx;
 
+    @NotThreadSafe
     @Procedure("apoc.search.nodeAllReduced")
     @Description("Returns a reduced representation of the nodes found after a parallel search over multiple indexes.\n" +
             "The reduced node representation includes: node id, node labels and the searched properties.")
@@ -70,6 +72,7 @@ public class ParallelNodeSearch {
         return a;
     }
 
+    @NotThreadSafe
     @Procedure("apoc.search.nodeReduced")
     @Description("Returns a reduced representation of the distinct nodes found after a parallel search over multiple indexes.\n" +
             "The reduced node representation includes: node id, node labels and the searched properties.")
@@ -80,6 +83,7 @@ public class ParallelNodeSearch {
                     .values().stream().filter(Optional::isPresent).map(Optional::get);
     }
 
+    @NotThreadSafe
     @Procedure("apoc.search.multiSearchReduced")
     @Description("Returns a reduced representation of the nodes found after a parallel search over multiple indexes.\n" +
             "The reduced node representation includes: node id, node labels and the searched properties.")
@@ -91,6 +95,7 @@ public class ParallelNodeSearch {
                     .filter(Optional::isPresent).map(Optional::get);
     }
 
+    @NotThreadSafe
     @Procedure("apoc.search.nodeAll")
     @Description("Returns all the nodes found after a parallel search over multiple indexes.")
     public Stream<NodeResult> multiSearchNodeAll(@Name("labelPropertyMap") final Object labelProperties, @Name("operator") final String operator, @Name("value") final String value) throws Exception {
@@ -98,6 +103,7 @@ public class ParallelNodeSearch {
     }
 
 
+    @NotThreadSafe
     @Procedure("apoc.search.node")
     @Description("Returns all the distinct nodes found after a parallel search over multiple indexes.")
     public Stream<NodeResult> multiSearchNode(@Name("labelPropertyMap") final Object labelProperties, @Name("operator") final String operator, @Name("value") final String value) throws Exception {

--- a/core/src/main/java/apoc/stats/DegreeDistribution.java
+++ b/core/src/main/java/apoc/stats/DegreeDistribution.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.NotThreadSafe;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.token.api.NamedToken;
 
@@ -111,6 +112,7 @@ public class DegreeDistribution {
     @Context
     public Pools pools;
 
+    @NotThreadSafe
     @Procedure("apoc.stats.degrees")
     @Description("Returns the percentile groupings of the degrees on the nodes connected by the given relationship types.")
     public Stream<DegreeStats.Result> degrees(@Name(value = "relTypes", defaultValue = "") String types) {

--- a/core/src/main/java/apoc/warmup/Warmup.java
+++ b/core/src/main/java/apoc/warmup/Warmup.java
@@ -78,6 +78,7 @@ public class Warmup {
         return sb.toString();
     }
 
+    @NotThreadSafe
     @Deprecated
     @Procedure(name = "apoc.warmup.run", deprecatedBy = "Firstly, the procedure duplicates functionality of page cache warm up which is a part of the DBMS. " +
             "Secondly, the API of this procedure is very specific to Record storage engine." )


### PR DESCRIPTION
Annotate unsafe procedures with @NotThreadSafe

## Proposed Changes

When run with parallel runtime not all operations on injected instances of `Transaction` and `GraphDatabaseService` are supported. By annotating these with `@NotThreadSafe` we can avoid runtime failures and we detect already at planning that we cannot run these procedures with parallel runtime.
