### PR TITLE
[VpC8nqNz] Adds license and notice validation to the CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -65,6 +65,17 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
 
+  license-checks:
+    runs-on: ubuntu-latest
+    needs: compile
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-jdk
+      - uses: ./.github/actions/setup-gradle-cache
+      - name: Check LICENSE and NOTICE files
+        run: ./gradlew validateLicenses generateLicensesFiles
+
   tests:
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Why
`./gradlew check` has this wired, but since the checks are done per project in the CI, the global check is never run 😢, so we need to add this manually.