### PR TITLE
[NOID] Remove overrideImplementation argument

### DIFF
--- a/core/src/test/java/apoc/export/BigGraphTest.java
+++ b/core/src/test/java/apoc/export/BigGraphTest.java
@@ -66,7 +66,7 @@ public class BigGraphTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        TestUtil.registerProcedure(db, Rename.class, ExportCSV.class, ExportJson.class, ExportCypher.class, ExportGraphML.class, Graphs.class, Meta.class, ImportCsv.class, GraphRefactoring.class,
+        TestUtil.registerProcedure(db, Rename.class, ExportCSV.class, ExportJson.class, ExportCypher.class, ExportGraphML.class, Graphs.class, Meta.class, GraphRefactoring.class,
                 ImportCsv.class, ImportJson.class);
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);

--- a/core/src/test/java/apoc/trigger/TriggerNewProceduresTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerNewProceduresTest.java
@@ -86,9 +86,9 @@ public class TriggerNewProceduresTest {
         db = databaseManagementService.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
         sysDb = databaseManagementService.database(GraphDatabaseSettings.SYSTEM_DATABASE_NAME);
         waitDbsAvailable(db, sysDb);
-        TestUtil.registerProcedure(sysDb, TriggerNewProcedures.class, Nodes.class);
-        TestUtil.registerProcedure(db, Trigger.class, Nodes.class);
-        
+        // Procedures are global for the DBMS, so it is sufficient to register them via one DB.
+        TestUtil.registerProcedure(db, TriggerNewProcedures.class, Nodes.class, Trigger.class);
+
     }
 
     @AfterClass

--- a/test-utils/src/main/java/apoc/util/TestUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestUtil.java
@@ -172,9 +172,9 @@ public class TestUtil {
         GlobalProcedures globalProcedures = ((GraphDatabaseAPI) db).getDependencyResolver().resolveDependency(GlobalProcedures.class);
         for (Class<?> procedure : procedures) {
             try {
-                globalProcedures.registerProcedure(procedure, true);
-                globalProcedures.registerFunction(procedure, true);
-                globalProcedures.registerAggregationFunction(procedure, true);
+                globalProcedures.registerProcedure(procedure);
+                globalProcedures.registerFunction(procedure);
+                globalProcedures.registerAggregationFunction(procedure);
             } catch (KernelException e) {
                 throw new RuntimeException("while registering " + procedure, e);
             }


### PR DESCRIPTION
.. that will be removed from Neo4j. This has hidden two errors:

* BigGraphTest registered the ImportCSV methods twice.
* TriggeredNewProcedures registered the Nodes methods twice, but also
  attempted to register things on different databases (which is not
  possible at the time of writing).