### PR TITLE
[DranV6rq] Add IndexType.VECTOR to recognised index types

### DIFF
--- a/common/src/test/java/apoc/util/UtilTest.java
+++ b/common/src/test/java/apoc/util/UtilTest.java
@@ -40,6 +40,7 @@ import static org.neo4j.graphdb.schema.IndexType.LOOKUP;
 import static org.neo4j.graphdb.schema.IndexType.POINT;
 import static org.neo4j.graphdb.schema.IndexType.RANGE;
 import static org.neo4j.graphdb.schema.IndexType.TEXT;
+import static org.neo4j.graphdb.schema.IndexType.VECTOR;
 
 public class UtilTest {
 
@@ -69,7 +70,8 @@ public class UtilTest {
                 LOOKUP,
                 TEXT,
                 RANGE,
-                POINT
+                POINT,
+                VECTOR
         ));
     }
 }


### PR DESCRIPTION
Adding the EAP Vector Indexes into Neo4j adds a new enum value to `IndexType`.
This particular test does a runtime check that it is explicitly aware of each `IndexType`, and thus fails when reaching `VECTOR`.