### PR TITLE
[NOID] Bump commoms lang3 from 3.12.0 to 3.13.0

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     // We need to force this dependency's verion due to a vulnerability https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/3048
     api group: 'org.apache.commons', name: 'commons-lang3', {
         version {
-            strictly '3.12.0'
+            strictly '3.13.0'
         }
     }
     api group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'


### PR DESCRIPTION
Bump commons version to align the new version with the coming version of commons in core db: https://github.com/neo-technology/neo4j/pull/21746