### PR TITLE
[NOID] Bump commoms lang3 from 3.12.0 to 3.13.0

### DIFF
--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -23,7 +23,7 @@ Apache-2.0
   aws-java-sdk-s3-1.12.425.jar
   byte-buddy-1.14.5.jar
   byte-buddy-agent-1.14.5.jar
-  caffeine-3.1.6.jar
+  caffeine-3.1.7.jar
   cassandra-driver-core-3.10.0.jar
   commons-beanutils-1.9.4.jar
   commons-cli-1.2.jar
@@ -37,7 +37,7 @@ Apache-2.0
   commons-csv-1.9.0.jar
   commons-daemon-1.0.13.jar
   commons-io-2.13.0.jar
-  commons-lang3-3.12.0.jar
+  commons-lang3-3.13.0.jar
   commons-logging-1.2.jar
   commons-math3-3.6.1.jar
   commons-net-3.9.0.jar
@@ -172,10 +172,11 @@ Apache-2.0
   netty-3.10.6.Final.jar
   netty-all-4.1.89.Final.jar
   netty-buffer-4.1.94.Final.jar
-  netty-codec-4.1.94.Final.jar
+  netty-buffer-4.1.96.Final.jar
+  netty-codec-4.1.96.Final.jar
   netty-codec-dns-4.1.89.Final.jar
   netty-codec-haproxy-4.1.89.Final.jar
-  netty-codec-http-4.1.94.Final.jar
+  netty-codec-http-4.1.96.Final.jar
   netty-codec-http2-4.1.89.Final.jar
   netty-codec-memcache-4.1.89.Final.jar
   netty-codec-mqtt-4.1.89.Final.jar
@@ -185,23 +186,24 @@ Apache-2.0
   netty-codec-stomp-4.1.89.Final.jar
   netty-codec-xml-4.1.89.Final.jar
   netty-common-4.1.94.Final.jar
-  netty-handler-4.1.94.Final.jar
+  netty-common-4.1.96.Final.jar
+  netty-handler-4.1.96.Final.jar
   netty-handler-proxy-4.1.89.Final.jar
   netty-handler-ssl-ocsp-4.1.89.Final.jar
-  netty-resolver-4.1.94.Final.jar
+  netty-resolver-4.1.96.Final.jar
   netty-resolver-dns-4.1.89.Final.jar
   netty-resolver-dns-classes-macos-4.1.89.Final.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-aarch_64.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-x86_64.jar
-  netty-transport-4.1.94.Final.jar
-  netty-transport-classes-epoll-4.1.94.Final.jar
-  netty-transport-classes-kqueue-4.1.94.Final.jar
-  netty-transport-native-epoll-4.1.94.Final-linux-aarch_64.jar
-  netty-transport-native-epoll-4.1.94.Final-linux-x86_64.jar
-  netty-transport-native-epoll-4.1.94.Final.jar
-  netty-transport-native-kqueue-4.1.94.Final-osx-aarch_64.jar
-  netty-transport-native-kqueue-4.1.94.Final-osx-x86_64.jar
-  netty-transport-native-unix-common-4.1.94.Final.jar
+  netty-transport-4.1.96.Final.jar
+  netty-transport-classes-epoll-4.1.96.Final.jar
+  netty-transport-classes-kqueue-4.1.96.Final.jar
+  netty-transport-native-epoll-4.1.96.Final-linux-aarch_64.jar
+  netty-transport-native-epoll-4.1.96.Final-linux-x86_64.jar
+  netty-transport-native-epoll-4.1.96.Final.jar
+  netty-transport-native-kqueue-4.1.96.Final-osx-aarch_64.jar
+  netty-transport-native-kqueue-4.1.96.Final-osx-x86_64.jar
+  netty-transport-native-unix-common-4.1.96.Final.jar
   netty-transport-rxtx-4.1.89.Final.jar
   netty-transport-sctp-4.1.89.Final.jar
   netty-transport-udt-4.1.89.Final.jar
@@ -210,7 +212,7 @@ Apache-2.0
   okhttp-4.9.3.jar
   okio-jvm-2.8.0.jar
   opencsv-5.7.1.jar
-  opentest4j-1.2.0.jar
+  opentest4j-1.3.0.jar
   picocli-4.7.4.jar
   reactor-core-3.5.8.jar
   reload4j-1.2.22.jar
@@ -446,7 +448,7 @@ BSD-2-Clause
   jline-3.9.0.jar
   jsch-0.1.55.jar
   stax2-api-4.2.1.jar
-  zstd-jni-1.5.5-4.jar
+  zstd-jni-1.5.5-5.jar
 ------------------------------------------------------------------------------
 
 Copyright <year> <copyright holder>
@@ -1867,14 +1869,14 @@ Eclipse Public License - v 2.0
   jersey-container-servlet-core-2.34.jar
   jersey-hk2-2.34.jar
   jersey-server-2.34.jar
-  junit-jupiter-5.9.3.jar
-  junit-jupiter-api-5.9.3.jar
-  junit-jupiter-engine-5.9.3.jar
-  junit-jupiter-params-5.9.3.jar
-  junit-platform-commons-1.9.3.jar
-  junit-platform-engine-1.9.3.jar
-  junit-platform-launcher-1.9.3.jar
-  junit-platform-testkit-1.9.3.jar
+  junit-jupiter-5.10.0.jar
+  junit-jupiter-api-5.10.0.jar
+  junit-jupiter-engine-5.10.0.jar
+  junit-jupiter-params-5.10.0.jar
+  junit-platform-commons-1.10.0.jar
+  junit-platform-engine-1.10.0.jar
+  junit-platform-launcher-1.10.0.jar
+  junit-platform-testkit-1.10.0.jar
   osgi-resource-locator-1.0.3.jar
 ------------------------------------------------------------------------------
 
@@ -2556,10 +2558,10 @@ and/or involve the use of third party software.
 MIT
   animal-sniffer-annotations-1.17.jar
   bcpkix-jdk15on-1.68.jar
-  bcpkix-jdk18on-1.75.jar
+  bcpkix-jdk18on-1.76.jar
   bcprov-jdk15on-1.68.jar
-  bcprov-jdk18on-1.75.jar
-  bcutil-jdk18on-1.75.jar
+  bcprov-jdk18on-1.76.jar
+  bcutil-jdk18on-1.76.jar
   cassandra-1.18.3.jar
   checker-qual-2.5.2.jar
   checker-qual-3.33.0.jar
@@ -2610,7 +2612,7 @@ THE SOFTWARE.
 
 ------------------------------------------------------------------------------
 MPL-2.0
-  kiama_2.13-2.5.0.jar
+  kiama_2.13-2.5.1.jar
 ------------------------------------------------------------------------------
 
 Mozilla Public License Version 2.0

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -53,7 +53,7 @@ Apache-2.0
   aws-java-sdk-s3-1.12.425.jar
   byte-buddy-1.14.5.jar
   byte-buddy-agent-1.14.5.jar
-  caffeine-3.1.6.jar
+  caffeine-3.1.7.jar
   cassandra-driver-core-3.10.0.jar
   commons-beanutils-1.9.4.jar
   commons-cli-1.2.jar
@@ -67,7 +67,7 @@ Apache-2.0
   commons-csv-1.9.0.jar
   commons-daemon-1.0.13.jar
   commons-io-2.13.0.jar
-  commons-lang3-3.12.0.jar
+  commons-lang3-3.13.0.jar
   commons-logging-1.2.jar
   commons-math3-3.6.1.jar
   commons-net-3.9.0.jar
@@ -202,10 +202,11 @@ Apache-2.0
   netty-3.10.6.Final.jar
   netty-all-4.1.89.Final.jar
   netty-buffer-4.1.94.Final.jar
-  netty-codec-4.1.94.Final.jar
+  netty-buffer-4.1.96.Final.jar
+  netty-codec-4.1.96.Final.jar
   netty-codec-dns-4.1.89.Final.jar
   netty-codec-haproxy-4.1.89.Final.jar
-  netty-codec-http-4.1.94.Final.jar
+  netty-codec-http-4.1.96.Final.jar
   netty-codec-http2-4.1.89.Final.jar
   netty-codec-memcache-4.1.89.Final.jar
   netty-codec-mqtt-4.1.89.Final.jar
@@ -215,23 +216,24 @@ Apache-2.0
   netty-codec-stomp-4.1.89.Final.jar
   netty-codec-xml-4.1.89.Final.jar
   netty-common-4.1.94.Final.jar
-  netty-handler-4.1.94.Final.jar
+  netty-common-4.1.96.Final.jar
+  netty-handler-4.1.96.Final.jar
   netty-handler-proxy-4.1.89.Final.jar
   netty-handler-ssl-ocsp-4.1.89.Final.jar
-  netty-resolver-4.1.94.Final.jar
+  netty-resolver-4.1.96.Final.jar
   netty-resolver-dns-4.1.89.Final.jar
   netty-resolver-dns-classes-macos-4.1.89.Final.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-aarch_64.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-x86_64.jar
-  netty-transport-4.1.94.Final.jar
-  netty-transport-classes-epoll-4.1.94.Final.jar
-  netty-transport-classes-kqueue-4.1.94.Final.jar
-  netty-transport-native-epoll-4.1.94.Final-linux-aarch_64.jar
-  netty-transport-native-epoll-4.1.94.Final-linux-x86_64.jar
-  netty-transport-native-epoll-4.1.94.Final.jar
-  netty-transport-native-kqueue-4.1.94.Final-osx-aarch_64.jar
-  netty-transport-native-kqueue-4.1.94.Final-osx-x86_64.jar
-  netty-transport-native-unix-common-4.1.94.Final.jar
+  netty-transport-4.1.96.Final.jar
+  netty-transport-classes-epoll-4.1.96.Final.jar
+  netty-transport-classes-kqueue-4.1.96.Final.jar
+  netty-transport-native-epoll-4.1.96.Final-linux-aarch_64.jar
+  netty-transport-native-epoll-4.1.96.Final-linux-x86_64.jar
+  netty-transport-native-epoll-4.1.96.Final.jar
+  netty-transport-native-kqueue-4.1.96.Final-osx-aarch_64.jar
+  netty-transport-native-kqueue-4.1.96.Final-osx-x86_64.jar
+  netty-transport-native-unix-common-4.1.96.Final.jar
   netty-transport-rxtx-4.1.89.Final.jar
   netty-transport-sctp-4.1.89.Final.jar
   netty-transport-udt-4.1.89.Final.jar
@@ -240,7 +242,7 @@ Apache-2.0
   okhttp-4.9.3.jar
   okio-jvm-2.8.0.jar
   opencsv-5.7.1.jar
-  opentest4j-1.2.0.jar
+  opentest4j-1.3.0.jar
   picocli-4.7.4.jar
   reactor-core-3.5.8.jar
   reload4j-1.2.22.jar
@@ -278,7 +280,7 @@ BSD-2-Clause
   jline-3.9.0.jar
   jsch-0.1.55.jar
   stax2-api-4.2.1.jar
-  zstd-jni-1.5.5-4.jar
+  zstd-jni-1.5.5-5.jar
 
 BSD-3-Clause
   asm-9.3.jar
@@ -369,14 +371,14 @@ Eclipse Public License - v 2.0
   jersey-container-servlet-core-2.34.jar
   jersey-hk2-2.34.jar
   jersey-server-2.34.jar
-  junit-jupiter-5.9.3.jar
-  junit-jupiter-api-5.9.3.jar
-  junit-jupiter-engine-5.9.3.jar
-  junit-jupiter-params-5.9.3.jar
-  junit-platform-commons-1.9.3.jar
-  junit-platform-engine-1.9.3.jar
-  junit-platform-launcher-1.9.3.jar
-  junit-platform-testkit-1.9.3.jar
+  junit-jupiter-5.10.0.jar
+  junit-jupiter-api-5.10.0.jar
+  junit-jupiter-engine-5.10.0.jar
+  junit-jupiter-params-5.10.0.jar
+  junit-platform-commons-1.10.0.jar
+  junit-platform-engine-1.10.0.jar
+  junit-platform-launcher-1.10.0.jar
+  junit-platform-testkit-1.10.0.jar
   osgi-resource-locator-1.0.3.jar
 
 GNU General Public License (GPL), version 2, with the Classpath exception
@@ -419,10 +421,10 @@ LGPL-2.1-or-later
 MIT
   animal-sniffer-annotations-1.17.jar
   bcpkix-jdk15on-1.68.jar
-  bcpkix-jdk18on-1.75.jar
+  bcpkix-jdk18on-1.76.jar
   bcprov-jdk15on-1.68.jar
-  bcprov-jdk18on-1.75.jar
-  bcutil-jdk18on-1.75.jar
+  bcprov-jdk18on-1.76.jar
+  bcutil-jdk18on-1.76.jar
   cassandra-1.18.3.jar
   checker-qual-2.5.2.jar
   checker-qual-3.33.0.jar
@@ -452,7 +454,7 @@ MPL 1.1
   javassist-3.25.0-GA.jar
 
 MPL-2.0
-  kiama_2.13-2.5.0.jar
+  kiama_2.13-2.5.1.jar
 
 Modified BSD
   jersey-client-2.34.jar

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     // We need to force this dependency's verion due to a vulnerability https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/3048
     api group: 'org.apache.commons', name: 'commons-lang3', {
         version {
-            strictly '3.12.0'
+            strictly '3.13.0'
         }
     }
     api group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'


### PR DESCRIPTION
Bump commons version to align the new version with the coming version of commons in core db: https://github.com/neo-technology/neo4j/pull/21746. Replaces https://github.com/neo4j/apoc/pull/472
