### PR TITLE
[1F4aew1T] Uses slf4j-api 2.x api instead of slf4j-simple 1.x

### DIFF
--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -2580,9 +2580,7 @@ MIT
   neo4j-1.18.3.jar
   postgresql-1.18.3.jar
   reactive-streams-1.0.4.jar
-  slf4j-api-1.7.36.jar
   slf4j-api-2.0.7.jar
-  slf4j-simple-1.7.36.jar
   testcontainers-1.18.3.jar
 ------------------------------------------------------------------------------
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -443,9 +443,7 @@ MIT
   neo4j-1.18.3.jar
   postgresql-1.18.3.jar
   reactive-streams-1.0.4.jar
-  slf4j-api-1.7.36.jar
   slf4j-api-2.0.7.jar
-  slf4j-simple-1.7.36.jar
   testcontainers-1.18.3.jar
 
 MPL 1.1

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     api group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
     api group: 'org.apache.commons', name: 'commons-collections4', version: '4.2'
     // We need this to avoid seeing SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder" on startup
-    api group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.36'
+    api group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 
     // We need to force this dependency's verion due to a vulnerability https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/3048
     api group: 'org.apache.commons', name: 'commons-lang3', {

--- a/it/src/test/java/apoc/it/core/StartupTest.java
+++ b/it/src/test/java/apoc/it/core/StartupTest.java
@@ -64,6 +64,8 @@ public class StartupTest {
                 assertTrue(functionCount > 0);
                 assertTrue(coreCount > 0);
                 // Check there's one and only one logger for apoc inside the container
+                // and it doesn't override the one inside the database
+                assertFalse(startupLog.contains("[main] INFO org.eclipse.jetty.server.Server"));
                 assertFalse(startupLog.contains("SLF4J: No SLF4J providers were found"));
                 assertFalse(startupLog.contains("SLF4J: Failed to load class \"org.slf4j.impl.StaticLoggerBinder\""));
                 assertFalse(startupLog.contains("SLF4J: Class path contains multiple SLF4J providers"));


### PR DESCRIPTION
## Why
Because the logger was colliding with the jetty one included in coredb, showing output like:

```
[main] INFO org.eclipse.jetty.server.Server - jetty-10.0.15; built: 2023-04-11T17:25:14.480Z; git: 68017dbd00236bb7e187330d7585a059610f661d; jvm 17.0.8+7
[main] INFO org.eclipse.jetty.server.handler.ContextHandler - Started o.e.j.s.h.MovedContextHandler@eae9533{/,null,AVAILABLE}
[main] INFO org.eclipse.jetty.server.session.DefaultSessionIdManager - Session workerName=node0
[main] INFO org.eclipse.jetty.server.handler.ContextHandler - Started o.e.j.s.ServletContextHandler@77dae14e{/dbms,null,AVAILABLE}
``` 
