### PR TITLE
[W9VglL9c] Bump APOC and Neo versions to 5.13

### DIFF
--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -21,9 +21,9 @@ Apache-2.0
   aws-java-sdk-core-1.12.425.jar
   aws-java-sdk-kms-1.12.425.jar
   aws-java-sdk-s3-1.12.425.jar
-  byte-buddy-1.14.5.jar
-  byte-buddy-agent-1.14.5.jar
-  caffeine-3.1.7.jar
+  byte-buddy-1.14.6.jar
+  byte-buddy-agent-1.14.6.jar
+  caffeine-3.1.8.jar
   cassandra-driver-core-3.10.0.jar
   commons-beanutils-1.9.4.jar
   commons-cli-1.2.jar
@@ -171,11 +171,11 @@ Apache-2.0
   metrics-core-3.2.4.jar
   netty-3.10.6.Final.jar
   netty-all-4.1.89.Final.jar
-  netty-buffer-4.1.96.Final.jar
-  netty-codec-4.1.96.Final.jar
+  netty-buffer-4.1.97.Final.jar
+  netty-codec-4.1.97.Final.jar
   netty-codec-dns-4.1.89.Final.jar
   netty-codec-haproxy-4.1.89.Final.jar
-  netty-codec-http-4.1.96.Final.jar
+  netty-codec-http-4.1.97.Final.jar
   netty-codec-http2-4.1.89.Final.jar
   netty-codec-memcache-4.1.89.Final.jar
   netty-codec-mqtt-4.1.89.Final.jar
@@ -184,24 +184,24 @@ Apache-2.0
   netty-codec-socks-4.1.89.Final.jar
   netty-codec-stomp-4.1.89.Final.jar
   netty-codec-xml-4.1.89.Final.jar
-  netty-common-4.1.96.Final.jar
-  netty-handler-4.1.96.Final.jar
+  netty-common-4.1.97.Final.jar
+  netty-handler-4.1.97.Final.jar
   netty-handler-proxy-4.1.89.Final.jar
   netty-handler-ssl-ocsp-4.1.89.Final.jar
-  netty-resolver-4.1.96.Final.jar
+  netty-resolver-4.1.97.Final.jar
   netty-resolver-dns-4.1.89.Final.jar
   netty-resolver-dns-classes-macos-4.1.89.Final.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-aarch_64.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-x86_64.jar
-  netty-transport-4.1.96.Final.jar
-  netty-transport-classes-epoll-4.1.96.Final.jar
-  netty-transport-classes-kqueue-4.1.96.Final.jar
-  netty-transport-native-epoll-4.1.96.Final-linux-aarch_64.jar
-  netty-transport-native-epoll-4.1.96.Final-linux-x86_64.jar
-  netty-transport-native-epoll-4.1.96.Final.jar
-  netty-transport-native-kqueue-4.1.96.Final-osx-aarch_64.jar
-  netty-transport-native-kqueue-4.1.96.Final-osx-x86_64.jar
-  netty-transport-native-unix-common-4.1.96.Final.jar
+  netty-transport-4.1.97.Final.jar
+  netty-transport-classes-epoll-4.1.97.Final.jar
+  netty-transport-classes-kqueue-4.1.97.Final.jar
+  netty-transport-native-epoll-4.1.97.Final-linux-aarch_64.jar
+  netty-transport-native-epoll-4.1.97.Final-linux-x86_64.jar
+  netty-transport-native-epoll-4.1.97.Final.jar
+  netty-transport-native-kqueue-4.1.97.Final-osx-aarch_64.jar
+  netty-transport-native-kqueue-4.1.97.Final-osx-x86_64.jar
+  netty-transport-native-unix-common-4.1.97.Final.jar
   netty-transport-rxtx-4.1.89.Final.jar
   netty-transport-sctp-4.1.89.Final.jar
   netty-transport-udt-4.1.89.Final.jar
@@ -211,8 +211,8 @@ Apache-2.0
   okio-jvm-2.8.0.jar
   opencsv-5.7.1.jar
   opentest4j-1.3.0.jar
-  picocli-4.7.4.jar
-  reactor-core-3.5.8.jar
+  picocli-4.7.5.jar
+  reactor-core-3.5.9.jar
   reload4j-1.2.22.jar
   scala-collection-contrib_2.13-0.3.0.jar
   scala-library-2.13.11.jar
@@ -2574,7 +2574,7 @@ MIT
   jersey-hk2-2.34.jar
   jnr-x86asm-1.0.2.jar
   localstack-1.18.3.jar
-  mockito-core-5.4.0.jar
+  mockito-core-5.5.0.jar
   mssql-jdbc-6.2.1.jre7.jar
   mysql-1.18.3.jar
   neo4j-1.18.3.jar

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -51,9 +51,9 @@ Apache-2.0
   aws-java-sdk-core-1.12.425.jar
   aws-java-sdk-kms-1.12.425.jar
   aws-java-sdk-s3-1.12.425.jar
-  byte-buddy-1.14.5.jar
-  byte-buddy-agent-1.14.5.jar
-  caffeine-3.1.7.jar
+  byte-buddy-1.14.6.jar
+  byte-buddy-agent-1.14.6.jar
+  caffeine-3.1.8.jar
   cassandra-driver-core-3.10.0.jar
   commons-beanutils-1.9.4.jar
   commons-cli-1.2.jar
@@ -201,11 +201,11 @@ Apache-2.0
   metrics-core-3.2.4.jar
   netty-3.10.6.Final.jar
   netty-all-4.1.89.Final.jar
-  netty-buffer-4.1.96.Final.jar
-  netty-codec-4.1.96.Final.jar
+  netty-buffer-4.1.97.Final.jar
+  netty-codec-4.1.97.Final.jar
   netty-codec-dns-4.1.89.Final.jar
   netty-codec-haproxy-4.1.89.Final.jar
-  netty-codec-http-4.1.96.Final.jar
+  netty-codec-http-4.1.97.Final.jar
   netty-codec-http2-4.1.89.Final.jar
   netty-codec-memcache-4.1.89.Final.jar
   netty-codec-mqtt-4.1.89.Final.jar
@@ -214,24 +214,24 @@ Apache-2.0
   netty-codec-socks-4.1.89.Final.jar
   netty-codec-stomp-4.1.89.Final.jar
   netty-codec-xml-4.1.89.Final.jar
-  netty-common-4.1.96.Final.jar
-  netty-handler-4.1.96.Final.jar
+  netty-common-4.1.97.Final.jar
+  netty-handler-4.1.97.Final.jar
   netty-handler-proxy-4.1.89.Final.jar
   netty-handler-ssl-ocsp-4.1.89.Final.jar
-  netty-resolver-4.1.96.Final.jar
+  netty-resolver-4.1.97.Final.jar
   netty-resolver-dns-4.1.89.Final.jar
   netty-resolver-dns-classes-macos-4.1.89.Final.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-aarch_64.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-x86_64.jar
-  netty-transport-4.1.96.Final.jar
-  netty-transport-classes-epoll-4.1.96.Final.jar
-  netty-transport-classes-kqueue-4.1.96.Final.jar
-  netty-transport-native-epoll-4.1.96.Final-linux-aarch_64.jar
-  netty-transport-native-epoll-4.1.96.Final-linux-x86_64.jar
-  netty-transport-native-epoll-4.1.96.Final.jar
-  netty-transport-native-kqueue-4.1.96.Final-osx-aarch_64.jar
-  netty-transport-native-kqueue-4.1.96.Final-osx-x86_64.jar
-  netty-transport-native-unix-common-4.1.96.Final.jar
+  netty-transport-4.1.97.Final.jar
+  netty-transport-classes-epoll-4.1.97.Final.jar
+  netty-transport-classes-kqueue-4.1.97.Final.jar
+  netty-transport-native-epoll-4.1.97.Final-linux-aarch_64.jar
+  netty-transport-native-epoll-4.1.97.Final-linux-x86_64.jar
+  netty-transport-native-epoll-4.1.97.Final.jar
+  netty-transport-native-kqueue-4.1.97.Final-osx-aarch_64.jar
+  netty-transport-native-kqueue-4.1.97.Final-osx-x86_64.jar
+  netty-transport-native-unix-common-4.1.97.Final.jar
   netty-transport-rxtx-4.1.89.Final.jar
   netty-transport-sctp-4.1.89.Final.jar
   netty-transport-udt-4.1.89.Final.jar
@@ -241,8 +241,8 @@ Apache-2.0
   okio-jvm-2.8.0.jar
   opencsv-5.7.1.jar
   opentest4j-1.3.0.jar
-  picocli-4.7.4.jar
-  reactor-core-3.5.8.jar
+  picocli-4.7.5.jar
+  reactor-core-3.5.9.jar
   reload4j-1.2.22.jar
   scala-collection-contrib_2.13-0.3.0.jar
   scala-library-2.13.11.jar
@@ -437,7 +437,7 @@ MIT
   jersey-hk2-2.34.jar
   jnr-x86asm-1.0.2.jar
   localstack-1.18.3.jar
-  mockito-core-5.4.0.jar
+  mockito-core-5.5.0.jar
   mssql-jdbc-6.2.1.jre7.jar
   mysql-1.18.3.jar
   neo4j-1.18.3.jar

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ downloadLicenses {
 
 allprojects {
     group = 'org.neo4j.procedure'
-    version = '5.12.0'
+    version = '5.13.0'
     archivesBaseName = 'apoc'
     description = """neo4j-apoc-procedures"""
 }
@@ -70,8 +70,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage' : project.hasProperty("neo4jDockerVersionOverride") ? 'neo4j:' + project.getProperty("neo4jDockerVersionOverride") + '-enterprise-debian' : 'neo4j:5.12.0-enterprise-debian',
-                'neo4jCommunityDockerImage': project.hasProperty("neo4jDockerVersionOverride") ? 'neo4j:' + project.getProperty("neo4jDockerVersionOverride") + '-debian': 'neo4j:5.12.0-debian',
+                'neo4jDockerImage' : project.hasProperty("neo4jDockerVersionOverride") ? 'neo4j:' + project.getProperty("neo4jDockerVersionOverride") + '-enterprise-debian' : 'neo4j:5.13.0-enterprise-debian',
+                'neo4jCommunityDockerImage': project.hasProperty("neo4jDockerVersionOverride") ? 'neo4j:' + project.getProperty("neo4jDockerVersionOverride") + '-debian': 'neo4j:5.13.0-debian',
                 'coreDir': 'core'
 
         maxHeapSize = "5G"
@@ -131,6 +131,6 @@ apply from: "licenses-source-header.gradle"
 
 ext {
     publicDir =  "${project.rootDir}"
-    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : "5.12.0"
+    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : "5.13.0"
     testContainersVersion = '1.18.3'
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     implementation group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '13.0.0', arrowExclusions
     implementation group: 'io.netty', name: 'netty-buffer', {
         version {
-            strictly '4.1.96.Final'
+            strictly '4.1.97.Final'
         }
     }
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,8 +1,8 @@
 :readme:
-:branch: 5.10
+:branch: 5.13
 :docs: https://neo4j.com/docs/apoc/current
-:apoc-release: 5.12.0
-:neo4j-version: 5.12.0
+:apoc-release: 5.13.0
+:neo4j-version: 5.13.0
 :img: https://raw.githubusercontent.com/neo4j/apoc/dev/images
 
 https://community.neo4j.com[image:https://img.shields.io/discourse/users?logo=discourse&server=https%3A%2F%2Fcommunity.neo4j.com[Discourse users]]
@@ -159,7 +159,7 @@ h| Output Return Columns |
 Since APOC relies on Neo4j's internal APIs you need to use the *matching APOC version* for your Neo4j installation.
 Make sure that the *first two version numbers match between Neo4j and APOC*.
 
-Go to https://github.com/neo4j/apoc/releases/{apoc-release}[the latest release] for *Neo4j version {branch}* and download the binary jar to place into your `$NEO4J_HOME/plugins` folder.
+Go to https://github.com/neo4j/apoc/releases/latest[the latest release] for the matching *Neo4j version* and download the binary jar to place into your `$NEO4J_HOME/plugins` folder.
 
 You can find https://github.com/neo4j/apoc/releases/[all releases here].
 


### PR DESCRIPTION
Bump to 5.13 and update Readme a little bit so it is sightly more useful. 