### PR TITLE
[47wOlqLp] Adds option to customize decompression ratio

### DIFF
--- a/common/src/main/java/apoc/ApocConfig.java
+++ b/common/src/main/java/apoc/ApocConfig.java
@@ -79,6 +79,8 @@ public class ApocConfig extends LifecycleAdapter {
     public static final String APOC_CONFIG_JOBS_QUEUE_SIZE = "apoc.jobs.queue.size";
     public static final String APOC_CONFIG_INITIALIZER = "apoc.initializer";
     public static final String LOAD_FROM_FILE_ERROR = "Import from files not enabled, please set apoc.import.file.enabled=true in your apoc.conf";
+    public static final String APOC_MAX_DECOMPRESSION_RATIO = "apoc.max.decompression.ratio";
+    public static final Integer DEFAULT_MAX_DECOMPRESSION_RATIO = 200;
     private static final WebURLAccessRule webAccessRule = new WebURLAccessRule();
 
     // These were earlier added via the Neo4j config using the ApocSettings.java class
@@ -89,7 +91,6 @@ public class ApocConfig extends LifecycleAdapter {
                     APOC_IMPORT_FILE_USE_NEO4J_CONFIG, true,
                     APOC_TRIGGER_ENABLED, false
             );
-
     private static final List<Setting> NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES = new ArrayList<>(Arrays.asList(
             data_directory,
             load_csv_file_url_root,
@@ -238,6 +239,13 @@ public class ApocConfig extends LifecycleAdapter {
                 if (value!=null) {
                     config.setProperty(s.name(), value.toString());
                 }
+            }
+
+            if (!config.containsKey(APOC_MAX_DECOMPRESSION_RATIO)) {
+                config.setProperty(APOC_MAX_DECOMPRESSION_RATIO, DEFAULT_MAX_DECOMPRESSION_RATIO);
+            }
+            if (config.getInt(APOC_MAX_DECOMPRESSION_RATIO) == 0) {
+                throw new IllegalArgumentException(format("value 0 is not allowed for the config option %s", APOC_MAX_DECOMPRESSION_RATIO));
             }
 
             boolean allowFileUrls = neo4jConfig.get(GraphDatabaseSettings.allow_file_urls);

--- a/common/src/main/java/apoc/export/util/LimitedSizeInputStream.java
+++ b/common/src/main/java/apoc/export/util/LimitedSizeInputStream.java
@@ -18,8 +18,13 @@
  */
 package apoc.export.util;
 
+
 import java.io.IOException;
 import java.io.InputStream;
+
+import static apoc.ApocConfig.APOC_MAX_DECOMPRESSION_RATIO;
+import static apoc.ApocConfig.DEFAULT_MAX_DECOMPRESSION_RATIO;
+import static apoc.ApocConfig.apocConfig;
 
 public class LimitedSizeInputStream extends InputStream {
     public static final String SIZE_EXCEEDED_ERROR = """
@@ -27,7 +32,7 @@ public class LimitedSizeInputStream extends InputStream {
             which is %s times the width of the original file.
             The InputStream has been blocked because the file could be a compression bomb attack.""";
 
-    public static final int SIZE_MULTIPLIER = 100;
+    public static final int SIZE_MULTIPLIER = apocConfig().getInt(APOC_MAX_DECOMPRESSION_RATIO, DEFAULT_MAX_DECOMPRESSION_RATIO);
 
     private final InputStream stream;
     private final long maxSize;

--- a/it/src/test/java/apoc/it/core/LoadCoreEnterpriseTest.java
+++ b/it/src/test/java/apoc/it/core/LoadCoreEnterpriseTest.java
@@ -41,10 +41,12 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.LongStream;
 
+import static apoc.ApocConfig.APOC_MAX_DECOMPRESSION_RATIO;
+import static apoc.ApocConfig.DEFAULT_MAX_DECOMPRESSION_RATIO;
 import static apoc.export.util.LimitedSizeInputStream.SIZE_EXCEEDED_ERROR;
-import static apoc.export.util.LimitedSizeInputStream.SIZE_MULTIPLIER;
 import static apoc.util.TestContainerUtil.createEnterpriseDB;
 import static apoc.util.TestContainerUtil.testCall;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -62,13 +64,21 @@ public class LoadCoreEnterpriseTest {
         directory.mkdirs();
     }
 
+    private static Neo4jContainerExtension createNeo4jWithMaxCompressionRatio(int ratio) {
+        Neo4jContainerExtension container = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.CORE), true)
+                .withNeo4jConfig("dbms.memory.heap.max_size", "1GB")
+                .withEnv(APOC_MAX_DECOMPRESSION_RATIO, String.valueOf(ratio));
+        container.start();
+
+        assertTrue(container.isRunning());
+
+        return container;
+    }
+
     @BeforeClass
     public static void beforeClass() {
-        neo4jContainer = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.CORE), true)
-                .withNeo4jConfig("server.memory.heap.max_size", "1GB");
-        neo4jContainer.start();
-
-        assertTrue(neo4jContainer.isRunning());
+        neo4jContainer = createNeo4jWithMaxCompressionRatio(DEFAULT_MAX_DECOMPRESSION_RATIO);
+        session = neo4jContainer.getSession();
 
         loopAllCompressionAlgos(algo -> {
             writeCompressedFile(COMPRESSED_JSON_FILE + algo.name(), algo, writer -> {
@@ -78,7 +88,6 @@ public class LoadCoreEnterpriseTest {
                 writer.write("\"}");
             });
         });
-
         loopAllCompressionAlgos(algo -> {
             writeCompressedFile(COMPRESSED_XML_FILE + algo.name(), algo, writer -> {
                 writer.write("<?xml version=\"1.0\"?><catalog>");
@@ -87,8 +96,6 @@ public class LoadCoreEnterpriseTest {
                 writer.write("</catalog>");
             });
         });
-
-        session = neo4jContainer.getSession();
     }
 
     private static void writeCompressedFile(String fileName, CompressionAlgo algo, Consumer<PrintWriter> supplier) {
@@ -148,9 +155,11 @@ public class LoadCoreEnterpriseTest {
         loopAllCompressionAlgos(algo -> {
             String algoName = algo.name();
             String fileName = COMPRESSED_JSON_FILE + algoName;
-            testMaxSizeExceeded("CALL apoc.load.json($file, '', {compression: $compression})",
-                    Map.of("file", fileName, "compression", algoName),
-                    new File(directory, fileName).length());
+            testMaxSizeExceeded( session,
+                                 "CALL apoc.load.json($file, '', {compression: $compression})",
+                                 Map.of("file", fileName, "compression", algoName),
+                                 new File(directory, fileName).length(),
+                                 DEFAULT_MAX_DECOMPRESSION_RATIO );
         });
     }
 
@@ -161,8 +170,11 @@ public class LoadCoreEnterpriseTest {
                 String algoName = algo.name();
                 byte[] bytes = bytesFromFile(COMPRESSED_XML_FILE, algoName);
 
-                testMaxSizeExceeded("CALL apoc.load.xml($file, null, {compression: $compression})",
-                        Map.of("file", bytes, "compression", algoName), bytes.length);
+                testMaxSizeExceeded( session,
+                                     "CALL apoc.load.xml($file, null, {compression: $compression})",
+                                     Map.of("file", bytes, "compression", algoName),
+                                     bytes.length,
+                                     DEFAULT_MAX_DECOMPRESSION_RATIO );
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -176,8 +188,11 @@ public class LoadCoreEnterpriseTest {
                 String algoName = algo.name();
                 byte[] bytes = bytesFromFile(COMPRESSED_JSON_FILE, algoName);
 
-                testMaxSizeExceeded("CALL apoc.load.json($file, '', {compression: $compression})",
-                        Map.of("file", bytes, "compression", algoName), bytes.length);
+                testMaxSizeExceeded( session,
+                                     "CALL apoc.load.json($file, '', {compression: $compression})",
+                                     Map.of("file", bytes, "compression", algoName),
+                                     bytes.length,
+                                     DEFAULT_MAX_DECOMPRESSION_RATIO );
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -189,9 +204,10 @@ public class LoadCoreEnterpriseTest {
         loopAllCompressionAlgos(algo -> {
             String algoName = algo.name();
             String fileName = COMPRESSED_XML_FILE + algoName;
-            testMaxSizeExceeded("CALL apoc.load.xml($file, null, {compression: $compression})",
-                    Map.of("file", fileName, "compression", algoName),
-                    new File(directory, fileName).length());
+            testMaxSizeExceeded( session,
+                                 "CALL apoc.load.xml($file, null, {compression: $compression})",
+                                 Map.of("file", fileName, "compression", algoName),
+                                 new File(directory, fileName).length(), DEFAULT_MAX_DECOMPRESSION_RATIO );
         });
     }
 
@@ -202,12 +218,66 @@ public class LoadCoreEnterpriseTest {
                 String algoName = algo.name();
                 byte[] bytes = bytesFromFile(COMPRESSED_JSON_FILE, algoName);
 
-                testMaxSizeExceeded("RETURN apoc.util.decompress($file, {compression: $algo})",
-                        Map.of("file", bytes, "algo", algoName), bytes.length);
+                testMaxSizeExceeded( session,
+                                     "RETURN apoc.util.decompress($file, {compression: $algo})",
+                                     Map.of("file", bytes, "algo", algoName), bytes.length, DEFAULT_MAX_DECOMPRESSION_RATIO );
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
         });
+    }
+
+    @Test
+    public void testLoadWorksWithIncreasedCompressionRatio() {
+        Neo4jContainerExtension neo4jContainer = createNeo4jWithMaxCompressionRatio(100000);
+        Session session = neo4jContainer.getSession();
+
+        loopAllCompressionAlgos(algo -> {
+            String algoName = algo.name();
+            String fileName = COMPRESSED_JSON_FILE + algoName;
+            testCall( session, "CALL apoc.load.json($file, '', {compression: $compression})",
+                      Map.of("file", fileName, "compression", algoName),
+                      r -> assertFalse(r.isEmpty()));
+        });
+
+        neo4jContainer.close();
+        session.close();
+    }
+
+    @Test
+    public void testNegativeValueDisablesZipBombProtection() {
+        Neo4jContainerExtension neo4jContainer = createNeo4jWithMaxCompressionRatio(-1);
+        Session session = neo4jContainer.getSession();
+
+        var compressionAlgorithm = CompressionAlgo.GZIP;
+        String algoName = compressionAlgorithm.name();
+        String fileName = COMPRESSED_JSON_FILE + algoName;
+
+        testCall( session, "CALL apoc.load.json($file, '', {compression: $compression})",
+                  Map.of("file", fileName, "compression", algoName),
+                  r -> assertFalse(r.isEmpty()));
+
+        neo4jContainer.close();
+        session.close();
+    }
+
+    @Test
+    public void testLoadZipBombFailsWithNonDefaultRatio() {
+        int compressionRatio = 101;
+        Neo4jContainerExtension neo4jContainer = createNeo4jWithMaxCompressionRatio(compressionRatio);
+        Session session = neo4jContainer.getSession();
+
+        var compressionAlgorithm = CompressionAlgo.GZIP;
+        String algoName = compressionAlgorithm.name();
+        String fileName = COMPRESSED_JSON_FILE + algoName;
+        testMaxSizeExceeded( session,
+                            "CALL apoc.load.json($file, '', {compression: $compression})",
+                             Map.of("file", fileName, "compression", algoName),
+                             new File(directory, fileName).length(),
+                             compressionRatio);
+
+        neo4jContainer.close();
+        session.close();
     }
 
     private static void loopAllCompressionAlgos(Consumer<CompressionAlgo> compressionAlgoConsumer) {
@@ -223,13 +293,13 @@ public class LoadCoreEnterpriseTest {
         return Files.readAllBytes(path);
     }
 
-    private void testMaxSizeExceeded(String query, Map<String, Object> params, long fileSize) {
+    private void testMaxSizeExceeded(Session session, String query, Map<String, Object> params, long fileSize, int compressionRatio) {
         RuntimeException e = assertThrows(RuntimeException.class,
                 () -> testCall( session, query, params, r -> {} )
         );
 
         String sizeExceededError = String.format(SIZE_EXCEEDED_ERROR,
-                fileSize * SIZE_MULTIPLIER, SIZE_MULTIPLIER);
+                fileSize * compressionRatio, compressionRatio);
         Assertions.assertThat(e.getMessage()).contains(sizeExceededError);
     }
 }


### PR DESCRIPTION
Cherry picks https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3710

## Why
To allow for customers to tweak exactly how big the uncompressed files can be.
