### PR TITLE
[NOID] Cleans up resources after the tests

### DIFF
--- a/core/src/test/java/apoc/export/BigGraphTest.java
+++ b/core/src/test/java/apoc/export/BigGraphTest.java
@@ -30,6 +30,7 @@ import apoc.refactor.GraphRefactoring;
 import apoc.refactor.rename.Rename;
 import apoc.util.TestUtil;
 import apoc.util.Util;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -73,6 +74,11 @@ public class BigGraphTest {
 
         final String query = Util.readResourceFile("moviesMod.cypher");
         IntStream.range(0, 10000).forEach(__-> db.executeTransactionally(query));
+    }
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
+++ b/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
@@ -27,6 +27,7 @@ import apoc.util.FileUtils;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import com.nimbusds.jose.util.Pair;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -89,6 +90,11 @@ public class ExportCoreSecurityTest {
         logger.setLevel(Level.SEVERE);
 
         TestUtil.registerProcedure(db, ExportCSV.class, ExportJson.class, ExportGraphML.class, ExportCypher.class);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
     }
 
     public static void setFileExport(boolean allowed) {

--- a/core/src/test/java/apoc/export/ImportAndLoadCoreSecurityTest.java
+++ b/core/src/test/java/apoc/export/ImportAndLoadCoreSecurityTest.java
@@ -31,6 +31,7 @@ import com.nimbusds.jose.util.Pair;
 import inet.ipaddr.IPAddressString;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.assertj.core.api.Assertions;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -149,7 +150,11 @@ public class ImportAndLoadCoreSecurityTest {
                 // load procedures (Xml contains both `apoc.load.xml` and `apoc.import.xml` procedures)
                 LoadJson.class, LoadArrow.class);
     }
-    
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
+    }
 
     @Test
     public void testIllegalFSAccessWithDifferentApocConfs() {

--- a/core/src/test/java/apoc/export/arrow/ArrowTest.java
+++ b/core/src/test/java/apoc/export/arrow/ArrowTest.java
@@ -24,6 +24,7 @@ import apoc.meta.Meta;
 import apoc.util.JsonUtil;
 import apoc.util.TestUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -114,6 +115,11 @@ public class ArrowTest {
     public static void beforeClass() {
         db.executeTransactionally("CREATE (f:User {name:'Adam',age:42,male:true,kids:['Sam','Anna','Grace'], born:localdatetime('2015-05-18T19:32:24.000'), place:point({latitude: 13.1, longitude: 33.46789, height: 100.0})})-[:KNOWS {since: 1993, bffSince: duration('P5M1.5D')}]->(b:User {name:'Jim',age:42})");
         TestUtil.registerProcedure(db, ExportArrow.class, LoadArrow.class, Graphs.class, Meta.class);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
     }
 
     @Before

--- a/core/src/test/java/apoc/export/arrow/ExportArrowSecurityTest.java
+++ b/core/src/test/java/apoc/export/arrow/ExportArrowSecurityTest.java
@@ -24,6 +24,7 @@ import apoc.meta.Meta;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import com.nimbusds.jose.util.Pair;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -91,6 +92,11 @@ public class ExportArrowSecurityTest {
         logger.setLevel(Level.SEVERE);
 
         TestUtil.registerProcedure(db, ExportArrow.class, Meta.class);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
     }
 
     private static Collection<Object[]> getParameterData(List<Pair<String, Consumer<Map>>> fileAndErrors) {

--- a/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
@@ -25,6 +25,7 @@ import apoc.util.TestUtil;
 import apoc.util.Util;
 import apoc.util.collection.Iterators;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -113,6 +114,11 @@ public class ExportCsvNeo4jAdminTest {
         db.executeTransactionally("CREATE (f:User1:User {name:'foo',age:42,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})");
         db.executeTransactionally("CREATE (f:Address1:Address {name:'Andrea', city: 'Milano', street:'Via Garibaldi, 7'})-[:NEXT_DELIVERY]->(a:Address {name: 'Bar Sport'}), (b:Address {street: 'via Benni'})");
         db.executeTransactionally("CREATE (a:Types {date: date('2018-10-30'), localDateTime: localdatetime('20181030T19:32:24'), dateTime: datetime('2018-10-30T12:50:35.556+0100'), localtime: localtime('12:50:35.556'), duration: duration('P5M1DT12H'), time: time('125035.556+0100'), born_2D: point({ x: 2.3, y: 4.5 }), born_3D:point({ longitude: 56.7, latitude: 12.78, height: 100 })})");
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -27,6 +27,7 @@ import apoc.util.CompressionConfig;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import apoc.util.collection.Iterators;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -156,6 +157,11 @@ public class ExportCsvTest {
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
         db.executeTransactionally("CREATE (f:User1:User {name:'foo',age:42,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})");
         db.executeTransactionally("CREATE (f:Address1:Address {name:'Andrea', city: 'Milano', street:'Via Garibaldi, 7'})-[:NEXT_DELIVERY]->(a:Address {name: 'Bar Sport'}), (b:Address {street: 'via Benni'})");
+    }
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
     }
 
     private String readFile(String fileName) {

--- a/core/src/test/java/apoc/export/csv/ImportCsvLdbcTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvLdbcTest.java
@@ -20,6 +20,7 @@ package apoc.export.csv;
 
 import apoc.csv.CsvTestUtil;
 import apoc.util.TestUtil;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -144,6 +145,11 @@ public class ImportCsvLdbcTest {
         TestUtil.registerProcedure(db, ImportCsv.class);
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -22,6 +22,7 @@ import apoc.csv.CsvTestUtil;
 import apoc.util.CompressionAlgo;
 import apoc.util.TestUtil;
 import org.apache.commons.io.FileUtils;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -253,6 +254,11 @@ public class ImportCsvTest {
 
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
     
     @Test

--- a/core/src/test/java/apoc/export/cypher/ExportCypherMultiRelTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherMultiRelTest.java
@@ -21,6 +21,7 @@ package apoc.export.cypher;
 import apoc.cypher.Cypher;
 import apoc.util.TestUtil;
 import apoc.util.collection.Iterators;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -80,7 +81,12 @@ public class ExportCypherMultiRelTest {
                 "(pers)-[:IS_TEAM_MEMBER_OF {name: 'eee'}]->(:Team {name: 'two'})");
         
     }
-    
+
+    @After
+    public void teardown() {
+        db.shutdown();
+    }
+
     @Test
     public void updateAllOptimizationNone() {
         String expectedCypherStatement = NODES_MULTI_RELS + SCHEMA_WITH_UNIQUE_IMPORT_ID + RELS_MULTI_RELS + CLEANUP_SMALL_BATCH;

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -24,6 +24,7 @@ import apoc.util.CompressionAlgo;
 import apoc.util.MapUtil;
 import apoc.util.TestUtil;
 import apoc.util.Util;
+import org.junit.After;
 import org.junit.Assert;
 
 import java.util.ArrayList;
@@ -103,6 +104,11 @@ public class ExportCypherTest {
     @Before
     public void setUp() {
         ExportCypherTestUtils.setUp(db, testName);
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -27,6 +27,7 @@ import apoc.util.collection.Iterables;
 import junit.framework.TestCase;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -107,6 +108,11 @@ public class ExportGraphMLTest {
     @Before
     public void setUp() {
         setUpGraphMl(db, testName);
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/export/json/ExportJsonTest.java
+++ b/core/src/test/java/apoc/export/json/ExportJsonTest.java
@@ -24,6 +24,7 @@ import apoc.util.CompressionAlgo;
 import apoc.util.FileTestUtil;
 import apoc.util.TestUtil;
 import apoc.util.Util;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -97,6 +98,11 @@ public class ExportJsonTest {
                         ]->(b:User {name:'Jim',age:42}),
                         (c:User {age:12})
                         """);
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/export/json/ImportJsonTest.java
+++ b/core/src/test/java/apoc/export/json/ImportJsonTest.java
@@ -28,6 +28,7 @@ import apoc.util.collection.Iterables;
 import junit.framework.TestCase;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import apoc.util.Utils;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -88,7 +89,12 @@ public class ImportJsonTest {
         TestUtil.registerProcedure(db, ImportJson.class, Schemas.class, Utils.class);
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
     }
-    
+
+    @After
+    public void teardown() {
+        db.shutdown();
+    }
+
     @Test
     public void shouldImportAllJsonWithoutImportId() {
         shouldImportAllCommon(map("cleanup", true), 8, 0L);

--- a/core/src/test/java/apoc/graph/GraphsTest.java
+++ b/core/src/test/java/apoc/graph/GraphsTest.java
@@ -25,6 +25,7 @@ import apoc.util.Util;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -91,6 +92,11 @@ public class GraphsTest {
                     result.stream().forEach(graph::putAll);
                     return null;
                 });
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/hashing/FingerprintingTest.java
+++ b/core/src/test/java/apoc/hashing/FingerprintingTest.java
@@ -23,6 +23,7 @@ import apoc.graph.Graphs;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,6 +54,11 @@ public class FingerprintingTest  {
     @Before
     public void setup() {
         TestUtil.registerProcedure(db, Fingerprinting.class, Graphs.class, Coll.class);
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/help/HelpTest.java
+++ b/core/src/test/java/apoc/help/HelpTest.java
@@ -23,6 +23,7 @@ import apoc.coll.Coll;
 import apoc.create.Create;
 import apoc.diff.Diff;
 import apoc.util.TestUtil;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,6 +47,11 @@ public class HelpTest {
     @Before
     public void setUp() {
         TestUtil.registerProcedure(db, Help.class, BitwiseOperations.class, Coll.class, Diff.class, Create.class);
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/index/SchemaIndexTest.java
+++ b/core/src/test/java/apoc/index/SchemaIndexTest.java
@@ -19,6 +19,7 @@
 package apoc.index;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -106,6 +107,11 @@ SchemaIndexTest {
             tx.schema().awaitIndexesOnline(2,TimeUnit.SECONDS);
             tx.commit();
         }
+    }
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/label/LabelTest.java
+++ b/core/src/test/java/apoc/label/LabelTest.java
@@ -19,6 +19,7 @@
 package apoc.label;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -36,6 +37,11 @@ public class LabelTest {
     @BeforeClass
     public static void setUp() {
         TestUtil.registerProcedure(db, Label.class);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/load/LoadJsonTest.java
+++ b/core/src/test/java/apoc/load/LoadJsonTest.java
@@ -105,6 +105,7 @@ public class LoadJsonTest {
     @After
     public void cleanup() {
         server.stop(0);
+        db.shutdown();
     }
 
     @Test public void testLoadJson() {

--- a/core/src/test/java/apoc/load/XmlTest.java
+++ b/core/src/test/java/apoc/load/XmlTest.java
@@ -84,6 +84,7 @@ public class XmlTest {
     @After
     public void cleanup() {
         server.stop(0);
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/load/relative/LoadRelativePathTest.java
+++ b/core/src/test/java/apoc/load/relative/LoadRelativePathTest.java
@@ -21,6 +21,7 @@ package apoc.load.relative;
 import apoc.load.LoadJson;
 import apoc.load.Xml;
 import apoc.util.TestUtil;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -56,6 +57,11 @@ public class LoadRelativePathTest {
     public void setUp() {
         TestUtil.registerProcedure(db, LoadJson.class, Xml.class);
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
 
     //JSON

--- a/core/src/test/java/apoc/lock/LockTest.java
+++ b/core/src/test/java/apoc/lock/LockTest.java
@@ -20,6 +20,7 @@ package apoc.lock;
 
 import apoc.util.TestUtil;
 import apoc.util.collection.Iterators;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -46,6 +47,11 @@ public class LockTest {
     @BeforeClass
     public static void setUp() {
         TestUtil.registerProcedure(db, Lock.class);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/log/Neo4jLogStreamTest.java
+++ b/core/src/test/java/apoc/log/Neo4jLogStreamTest.java
@@ -20,6 +20,7 @@ package apoc.log;
 
 import apoc.util.TestUtil;
 import apoc.util.collection.Iterators;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
@@ -36,18 +37,24 @@ import static apoc.util.TestUtil.testResult;
 import static org.junit.Assert.assertTrue;
 
 public class Neo4jLogStreamTest {
-    
+
     private GraphDatabaseService db;
+    private DatabaseManagementService dbManagementService;
 
     @Before
     public void setUp() {
-        DatabaseManagementService dbManagementService = new TestDatabaseManagementServiceBuilder(
+        dbManagementService = new TestDatabaseManagementServiceBuilder(
                 Paths.get("target", UUID.randomUUID().toString()).toAbsolutePath()).build();
         apocConfig().setProperty("server.directories.logs", "");
         db = dbManagementService.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
         TestUtil.registerProcedure(db, Neo4jLogStream.class);
     }
-    
+
+    @After
+    public void teardown() {
+        dbManagementService.shutdown();
+    }
+
     @Test
     public void testLogStream() {
         testResult(db, "CALL apoc.log.stream('debug.log')", res -> {

--- a/core/src/test/java/apoc/map/MapsTest.java
+++ b/core/src/test/java/apoc/map/MapsTest.java
@@ -19,6 +19,7 @@
 package apoc.map;
 
 import apoc.util.TestUtil;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,6 +49,11 @@ public class MapsTest {
     @Before
     public void setUp() {
         TestUtil.registerProcedure(db,Maps.class);
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/math/MathsTest.java
+++ b/core/src/test/java/apoc/math/MathsTest.java
@@ -19,6 +19,7 @@
 package apoc.math;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -37,6 +38,11 @@ public class MathsTest {
 
     @BeforeClass public static void setUp() {
         TestUtil.registerProcedure(db,Maths.class);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
     }
 
     @Test public void testMaxLong(){

--- a/core/src/test/java/apoc/math/RegressionTest.java
+++ b/core/src/test/java/apoc/math/RegressionTest.java
@@ -20,6 +20,7 @@ package apoc.math;
 
 import apoc.util.TestUtil;
 import org.apache.commons.math3.stat.regression.SimpleRegression;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -39,6 +40,11 @@ public class RegressionTest {
     @BeforeClass
     public static void setUp() {
         TestUtil.registerProcedure(db, Regression.class);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/merge/MergeTest.java
+++ b/core/src/test/java/apoc/merge/MergeTest.java
@@ -21,6 +21,7 @@ package apoc.merge;
 import apoc.util.MapUtil;
 import apoc.util.TestUtil;
 import apoc.util.collection.Iterators;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,6 +46,11 @@ public class MergeTest {
         TestUtil.registerProcedure(db, Merge.class);
     }
 
+    @After
+    public void teardown() {
+        db.shutdown();
+    }
+    
     @Test
     public void testMergeNode() {
         testMergeNodeCommon(false);

--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -25,6 +25,7 @@ import apoc.util.Util;
 import apoc.util.collection.Iterables;
 import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.Assertions;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -80,6 +81,11 @@ public class MetaTest {
     @Before
     public void setUp() {
         TestUtil.registerProcedure(db, Meta.class, Graphs.class);
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
 
     public static boolean hasRecordMatching(List<Map<String,Object>> records, Map<String,Object> record) {

--- a/core/src/test/java/apoc/neighbors/NeighborsTest.java
+++ b/core/src/test/java/apoc/neighbors/NeighborsTest.java
@@ -19,6 +19,7 @@
 package apoc.neighbors;
 
 import apoc.util.TestUtil;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,6 +49,11 @@ public class NeighborsTest {
                 "(b)-[:KNOWS]->(a), " +
                 "(b)-[:KNOWS]->(c), " +
                 "(c)-[:KNOWS]->(d) ");
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/nodes/GroupingTest.java
+++ b/core/src/test/java/apoc/nodes/GroupingTest.java
@@ -20,6 +20,7 @@ package apoc.nodes;
 
 import apoc.util.TestUtil;
 import apoc.util.collection.Iterators;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,6 +49,11 @@ public class GroupingTest {
     @Before
     public void setUp() {
         TestUtil.registerProcedure(db, Grouping.class);
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
 
     public void createGraph() {

--- a/core/src/test/java/apoc/nodes/NodesTest.java
+++ b/core/src/test/java/apoc/nodes/NodesTest.java
@@ -25,6 +25,7 @@ import apoc.util.TestUtil;
 import apoc.util.Util;
 import apoc.util.collection.Iterables;
 import apoc.util.collection.Iterators;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -77,6 +78,11 @@ public class NodesTest {
     @Before
     public void setUp() {
         TestUtil.registerProcedure(db, Nodes.class, Create.class);
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/number/ArabicRomanTest.java
+++ b/core/src/test/java/apoc/number/ArabicRomanTest.java
@@ -19,6 +19,7 @@
 package apoc.number;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -38,6 +39,11 @@ public class ArabicRomanTest {
     @BeforeClass
     public static void setUp() {
         TestUtil.registerProcedure(db, ArabicRoman.class);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/number/NumbersTest.java
+++ b/core/src/test/java/apoc/number/NumbersTest.java
@@ -19,6 +19,7 @@
 package apoc.number;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -46,6 +47,11 @@ public class NumbersTest {
     @BeforeClass
     public static void sUp() {
         TestUtil.registerProcedure(db, Numbers.class);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/number/exact/ExactTest.java
+++ b/core/src/test/java/apoc/number/exact/ExactTest.java
@@ -19,6 +19,7 @@
 package apoc.number.exact;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -46,6 +47,11 @@ public class ExactTest {
 
 	@BeforeClass public static void sUp() {
 		TestUtil.registerProcedure(db, Exact.class);
+	}
+
+	@AfterClass
+	public static void teardown() {
+		db.shutdown();
 	}
 
 	@Test

--- a/core/src/test/java/apoc/path/ExpandPathTest.java
+++ b/core/src/test/java/apoc/path/ExpandPathTest.java
@@ -25,6 +25,7 @@ import apoc.util.collection.Iterators;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -63,7 +64,12 @@ public class ExpandPathTest {
 		 }
     }
 
-    @After
+	@AfterClass
+	public static void teardown() {
+		db.shutdown();
+	}
+
+	@After
     public void removeOtherLabels() {
 		db.executeTransactionally("OPTIONAL MATCH (c:Western) REMOVE c:Western WITH DISTINCT 1 as ignore OPTIONAL MATCH (c:Denylist) REMOVE c:Denylist");
 	}

--- a/core/src/test/java/apoc/path/LabelSequenceTest.java
+++ b/core/src/test/java/apoc/path/LabelSequenceTest.java
@@ -19,6 +19,7 @@
 package apoc.path;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -44,6 +45,11 @@ public class LabelSequenceTest {
     public static void setUp() {
         TestUtil.registerProcedure(db, PathExplorer.class);
         db.executeTransactionally("create (s:Start{name:'start'})-[:REL]->(:A{name:'a'})-[:REL]->(:B{name:'b'})-[:REL]->(:A:C{name:'ac'})-[:REL]->(:B:A{name:'ba'})-[:REL]->(:D:A{name:'da'})");
+    }
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/path/NodeFilterTest.java
+++ b/core/src/test/java/apoc/path/NodeFilterTest.java
@@ -22,6 +22,7 @@ import apoc.util.TestUtil;
 import apoc.util.Util;
 import apoc.util.collection.Iterators;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -51,6 +52,11 @@ public class NodeFilterTest {
             tx.execute(movies);
             tx.commit();
         }
+    }
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
     }
 
     @After

--- a/core/src/test/java/apoc/path/PathsTest.java
+++ b/core/src/test/java/apoc/path/PathsTest.java
@@ -19,6 +19,7 @@
 package apoc.path;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -44,6 +45,11 @@ public class PathsTest {
     public static void setUp() {
         TestUtil.registerProcedure(db, Paths.class);
         db.executeTransactionally("CREATE (a:A)-[:NEXT]->(b:B)-[:NEXT]->(c:C)-[:NEXT]->(d:D)");
+    }
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/path/RelSequenceTest.java
+++ b/core/src/test/java/apoc/path/RelSequenceTest.java
@@ -21,6 +21,7 @@ package apoc.path;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import apoc.util.collection.Iterators;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -52,6 +53,11 @@ public class RelSequenceTest {
             tx.execute(additionalLink);
             tx.commit();
         }
+    }
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/path/SequenceTest.java
+++ b/core/src/test/java/apoc/path/SequenceTest.java
@@ -20,6 +20,7 @@ package apoc.path;
 
 import apoc.util.TestUtil;
 import apoc.util.Util;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -49,6 +50,11 @@ public class SequenceTest {
             tx.execute(additionalLink);
             tx.commit();
         }
+    }
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/path/SubgraphTest.java
+++ b/core/src/test/java/apoc/path/SubgraphTest.java
@@ -26,6 +26,7 @@ import apoc.util.Util;
 import apoc.util.collection.Iterators;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -72,6 +73,11 @@ public class SubgraphTest {
 			Map<String, Object> row = result.next();
 			fullGraphCount = (Long) row.get("graphCount");
 		}
+	}
+
+	@AfterClass
+	public static void teardown() {
+		db.shutdown();
 	}
 
 	@Rule

--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -26,6 +26,7 @@ import apoc.util.Utils;
 import apoc.util.collection.Iterators;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hamcrest.MatcherAssert;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -99,6 +100,11 @@ public class PeriodicTest {
     public void initDb() {
         TestUtil.registerProcedure(db, Periodic.class, Schemas.class, Cypher.class, Utils.class, MockLogger.class);
         db.executeTransactionally("call apoc.periodic.list() yield name call apoc.periodic.cancel(name) yield name as name2 return count(*)");
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/refactor/util/PropertiesManagerTest.java
+++ b/core/src/test/java/apoc/refactor/util/PropertiesManagerTest.java
@@ -22,6 +22,7 @@ import apoc.refactor.GraphRefactoring;
 import apoc.util.ArrayBackedList;
 import apoc.util.TestUtil;
 import apoc.util.Util;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -54,6 +55,11 @@ public class PropertiesManagerTest {
 	@Before
 	public void setUp() {
 		TestUtil.registerProcedure(db, GraphRefactoring.class);
+	}
+
+	@After
+	public void teardown() {
+		db.shutdown();
 	}
 
 	@Test

--- a/it/src/test/java/apoc/it/core/ApocSplitTest.java
+++ b/it/src/test/java/apoc/it/core/ApocSplitTest.java
@@ -486,6 +486,7 @@ public class ApocSplitTest {
 
         Assert.assertEquals(CORE_PROCEDURES, procedureNames);
         Assert.assertEquals(CORE_FUNCTIONS, functionNames);
+        session.close();
         neo4jContainer.close();
     }
 }

--- a/it/src/test/java/apoc/it/core/ExportCsvIT.java
+++ b/it/src/test/java/apoc/it/core/ExportCsvIT.java
@@ -51,6 +51,7 @@ public class ExportCsvIT {
 
     @AfterClass
     public static void afterAll() {
+        session.close();
         neo4jContainer.close();
     }
 

--- a/it/src/test/java/apoc/it/core/ExportCsvS3Test.java
+++ b/it/src/test/java/apoc/it/core/ExportCsvS3Test.java
@@ -22,6 +22,7 @@ import apoc.export.csv.ExportCSV;
 import apoc.graph.Graphs;
 import apoc.util.TestUtil;
 import apoc.util.s3.S3BaseTest;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -50,6 +51,11 @@ public class ExportCsvS3Test extends S3BaseTest {
         TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class);
         db.executeTransactionally("CREATE (f:User1:User {name:'foo',age:42,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})");
         db.executeTransactionally("CREATE (f:Address1:Address {name:'Andrea', city: 'Milano', street:'Via Garibaldi, 7'})-[:NEXT_DELIVERY]->(a:Address {name: 'Bar Sport'}), (b:Address {street: 'via Benni'})");
+    }
+
+    @AfterClass
+    public static void teardown() {
+        db.shutdown();
     }
 
     private static final String EXPECTED_QUERY_NODES = String.format("\"u\"%n" +

--- a/it/src/test/java/apoc/it/core/ExportCypherS3Test.java
+++ b/it/src/test/java/apoc/it/core/ExportCypherS3Test.java
@@ -22,6 +22,7 @@ import apoc.export.cypher.ExportCypherTestUtils;
 import apoc.util.TestUtil;
 import apoc.util.s3.S3BaseTest;
 import apoc.util.s3.S3TestUtil;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,6 +50,11 @@ public class ExportCypherS3Test extends S3BaseTest {
     @Before
     public void setUp() {
         ExportCypherTestUtils.setUp(db, testName);
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
 
     // -- Whole file test -- //

--- a/it/src/test/java/apoc/it/core/ExportGraphMLS3Test.java
+++ b/it/src/test/java/apoc/it/core/ExportGraphMLS3Test.java
@@ -20,6 +20,7 @@ package apoc.it.core;
 
 import apoc.util.TestUtil;
 import apoc.util.s3.S3BaseTest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,6 +53,11 @@ public class ExportGraphMLS3Test extends S3BaseTest {
     @Before
     public void setUp() {
         setUpGraphMl(db, testName);
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/it/src/test/java/apoc/it/core/ExportJsonS3Test.java
+++ b/it/src/test/java/apoc/it/core/ExportJsonS3Test.java
@@ -22,6 +22,7 @@ import apoc.export.json.ExportJson;
 import apoc.graph.Graphs;
 import apoc.util.TestUtil;
 import apoc.util.s3.S3BaseTest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,6 +54,11 @@ public class ExportJsonS3Test extends S3BaseTest {
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
         TestUtil.registerProcedure(db, ExportJson.class, Graphs.class);
         db.executeTransactionally("CREATE (f:User {name:'Adam',age:42,male:true,kids:['Sam','Anna','Grace'], born:localdatetime('2015185T19:32:24'), place:point({latitude: 13.1, longitude: 33.46789})})-[:KNOWS {since: 1993, bffSince: duration('P5M1.5D')}]->(b:User {name:'Jim',age:42}),(c:User {age:12})");
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
     }
 
     @Test

--- a/it/src/test/java/apoc/it/core/StartupTest.java
+++ b/it/src/test/java/apoc/it/core/StartupTest.java
@@ -70,6 +70,7 @@ public class StartupTest {
                 assertFalse(startupLog.contains("SLF4J: Failed to load class \"org.slf4j.impl.StaticLoggerBinder\""));
                 assertFalse(startupLog.contains("SLF4J: Class path contains multiple SLF4J providers"));
 
+                session.close();
                 neo4jContainer.close();
             } catch (Exception ex) {
                 // if Testcontainers wasn't able to retrieve the docker image we ignore the test


### PR DESCRIPTION
Cherry-picks https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3714

## Why
Because most of the tests are leaving dbms opened and that can make the CI slow or even provoke it to run out of memory or available threads.

Needed for https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3699
