### PR TITLE
[pLz5YbCW] add checks for node labels and relationship types for apoc.merge procedures

### DIFF
--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -137,10 +137,6 @@ public class Util {
     public static String INVALID_QUERY_MODE_ERROR = "This procedure allows for READ-only, non-schema based queries. " +
             "It is therefore not possible to perform writes or query the database with commands such as SHOW CONSTRAINTS/INDEXES.";
 
-    public static String labelString(List<String> labelNames) {
-        return labelNames.stream().map(Util::quote).collect(Collectors.joining(":"));
-    }
-
     public static String labelString(Node n) {
         return joinLabels(n.getLabels(), ":");
     }

--- a/core/src/test/java/apoc/merge/MergeTest.java
+++ b/core/src/test/java/apoc/merge/MergeTest.java
@@ -61,6 +61,7 @@ public class MergeTest {
         testMergeNodeCommon(true);
     }
 
+    // MERGE NODES
     private void testMergeNodeCommon(boolean isWithStats) {
         String procName = isWithStats ? "nodeWithStats" : "node";
 
@@ -112,33 +113,6 @@ public class MergeTest {
     }
 
     @Test
-    public void testMergeRelationships() {
-        db.executeTransactionally("create (:Person{name:'Foo'}), (:Person{name:'Bar'})");
-
-        testCall(db, "MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e CALL apoc.merge.relationship(s, 'KNOWS', {rid:123}, {since:'Thu'}, e) YIELD rel RETURN rel",
-                (row) -> {
-                    Relationship rel = (Relationship) row.get("rel");
-                    assertEquals("KNOWS", rel.getType().name());
-                    assertEquals(123L, rel.getProperty("rid"));
-                    assertEquals("Thu", rel.getProperty("since"));
-                });
-
-        testCall(db, "MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e CALL apoc.merge.relationship(s, 'KNOWS', {rid:123}, {since:'Fri'}, e) YIELD rel RETURN rel",
-                (row) -> {
-                    Relationship rel = (Relationship) row.get("rel");
-                    assertEquals("KNOWS", rel.getType().name());
-                    assertEquals(123L, rel.getProperty("rid"));
-                    assertEquals("Thu", rel.getProperty("since"));
-                });
-        testCall(db, "MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e CALL apoc.merge.relationship(s, 'OTHER', null, null, e) YIELD rel RETURN rel",
-                (row) -> {
-                    Relationship rel = (Relationship) row.get("rel");
-                    assertEquals("OTHER", rel.getType().name());
-                    assertTrue(rel.getAllProperties().isEmpty());
-                });
-    }
-
-    @Test
     public void testMergeWithEmptyIdentityPropertiesShouldFail() {
         for (String idProps: new String[]{"null", "{}"}) {
             try {
@@ -174,6 +148,68 @@ public class MergeTest {
     }
 
     @Test
+    public void testEscapeIdentityPropertiesWithSpecialCharactersShouldWork() {
+        for (String key: new String[]{"normal", "i:d", "i-d", "i d"}) {
+            Map<String, Object> identProps = MapUtil.map(key, "value");
+            Map<String, Object> params = MapUtil.map("identProps", identProps);
+
+            testCall(db, "CALL apoc.merge.node(['Person'], $identProps) YIELD node RETURN node", params,
+                    (row) -> {
+                        Node node = (Node) row.get("node");
+                        assertNotNull(node);
+                        assertTrue(node.hasProperty(key));
+                        assertEquals("value", node.getProperty(key));
+                    });
+        }
+    }
+
+    @Test
+    public void testLabelsWithSpecialCharactersShouldWork() {
+        for (String label: new String[]{"Label with spaces", ":LabelWithColon", "label-with-dash", "LabelWithUmlautsÄÖÜ"}) {
+            Map<String, Object> params = MapUtil.map("label", label);
+            testCall(db, "CALL apoc.merge.node([$label],{id:1}, {name:'John'}) YIELD node RETURN node", params,
+                    row -> assertTrue(row.get("node") instanceof Node));
+        }
+    }
+
+    // MERGE RELATIONSHIPS
+    @Test
+    public void testMergeRelationships() {
+        db.executeTransactionally("create (:Person{name:'Foo'}), (:Person{name:'Bar'})");
+
+        testCall(db, "MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e CALL apoc.merge.relationship(s, 'KNOWS', {rid:123}, {since:'Thu'}, e) YIELD rel RETURN rel",
+                (row) -> {
+                    Relationship rel = (Relationship) row.get("rel");
+                    assertEquals("KNOWS", rel.getType().name());
+                    assertEquals(123L, rel.getProperty("rid"));
+                    assertEquals("Thu", rel.getProperty("since"));
+                });
+
+        testCall(db, "MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e CALL apoc.merge.relationship(s, 'KNOWS', {rid:123}, {since:'Fri'}, e) YIELD rel RETURN rel",
+                (row) -> {
+                    Relationship rel = (Relationship) row.get("rel");
+                    assertEquals("KNOWS", rel.getType().name());
+                    assertEquals(123L, rel.getProperty("rid"));
+                    assertEquals("Thu", rel.getProperty("since"));
+                });
+        testCall(db, "MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e CALL apoc.merge.relationship(s, 'OTHER', null, null, e) YIELD rel RETURN rel",
+                (row) -> {
+                    Relationship rel = (Relationship) row.get("rel");
+                    assertEquals("OTHER", rel.getType().name());
+                    assertTrue(rel.getAllProperties().isEmpty());
+                });
+    }
+
+    @Test
+    public void testRelationshipTypesWithSpecialCharactersShouldWork() {
+        for (String relType: new String[]{"Reltype with space", ":ReltypeWithCOlon", "rel-type-with-dash"}) {
+            Map<String, Object> params = MapUtil.map("relType", relType);
+            testCall(db, "CREATE (a), (b) WITH a,b CALL apoc.merge.relationship(a, $relType, null, null, b) YIELD rel RETURN rel", params,
+                    row -> assertTrue(row.get("rel") instanceof Relationship));
+        }
+    }
+
+    @Test
     public void testMergeRelWithNullRelTypeShouldFail() {
         try {
             testCall(db, "MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e  CALL apoc.merge.relationship(s, null, null, null, e) YIELD rel RETURN rel",
@@ -195,44 +231,7 @@ public class MergeTest {
         }
     }
 
-    @Test
-    public void testEscapeIdentityPropertiesWithSpecialCharactersShouldWork() {
-        for (String key: new String[]{"normal", "i:d", "i-d", "i d"}) {
-            Map<String, Object> identProps = MapUtil.map(key, "value");
-            Map<String, Object> params = MapUtil.map("identProps", identProps);
-            
-            testCall(db, "CALL apoc.merge.node(['Person'], $identProps) YIELD node RETURN node", params,
-                        (row) -> {
-                            Node node = (Node) row.get("node");
-                            assertNotNull(node);
-                            assertTrue(node.hasProperty(key));
-                            assertEquals("value", node.getProperty(key));
-                        });
-        }
-    }
-    
-    @Test
-    public void testLabelsWithSpecialCharactersShouldWork() {
-        for (String label: new String[]{"Label with spaces", ":LabelWithColon", "label-with-dash", "LabelWithUmlautsÄÖÜ"}) {
-            Map<String, Object> params = MapUtil.map("label", label);
-            testCall(db, "CALL apoc.merge.node([$label],{id:1}, {name:'John'}) YIELD node RETURN node", params,
-                    row -> assertTrue(row.get("node") instanceof Node));
-        }
-    }
-
-    @Test
-    public void testRelationshipTypesWithSpecialCharactersShouldWork() {
-        for (String relType: new String[]{"Reltype with space", ":ReltypeWithCOlon", "rel-type-with-dash"}) {
-            Map<String, Object> params = MapUtil.map("relType", relType);
-            testCall(db, "CREATE (a), (b) WITH a,b CALL apoc.merge.relationship(a, $relType, null, null, b) YIELD rel RETURN rel", params,
-                    row -> assertTrue(row.get("rel") instanceof Relationship));
-        }
-    }
-
-
     // MERGE EAGER TESTS
-
-
     @Test
     public void testMergeEagerNode() {
         testMergeEagerCommon(false);

--- a/core/src/test/java/apoc/merge/MergeTest.java
+++ b/core/src/test/java/apoc/merge/MergeTest.java
@@ -67,8 +67,8 @@ public class MergeTest {
         testCall(db, String.format("CALL apoc.merge.%s(['Person','Bastard'],{ssid:'123'}, {name:'John'})", procName),
                 (row) -> {
                     Node node = (Node) row.get("node");
-                    assertEquals(true, node.hasLabel(Label.label("Person")));
-                    assertEquals(true, node.hasLabel(Label.label("Bastard")));
+                    assertTrue(node.hasLabel(Label.label("Person")));
+                    assertTrue(node.hasLabel(Label.label("Bastard")));
                     assertEquals("John", node.getProperty("name"));
                     assertEquals("123", node.getProperty("ssid"));
 
@@ -87,7 +87,7 @@ public class MergeTest {
         testCall(db, "CALL apoc.merge.node(['Person'],{ssid:'123'}, {name:'John'}) YIELD node RETURN node",
                 (row) -> {
                     Node node = (Node) row.get("node");
-                    assertEquals(true, node.hasLabel(Label.label("Person")));
+                    assertTrue(node.hasLabel(Label.label("Person")));
                     assertEquals("Jim", node.getProperty("name"));
                     assertEquals("123", node.getProperty("ssid"));
                 });
@@ -119,7 +119,7 @@ public class MergeTest {
                 (row) -> {
                     Relationship rel = (Relationship) row.get("rel");
                     assertEquals("KNOWS", rel.getType().name());
-                    assertEquals(123l, rel.getProperty("rid"));
+                    assertEquals(123L, rel.getProperty("rid"));
                     assertEquals("Thu", rel.getProperty("since"));
                 });
 
@@ -127,7 +127,7 @@ public class MergeTest {
                 (row) -> {
                     Relationship rel = (Relationship) row.get("rel");
                     assertEquals("KNOWS", rel.getType().name());
-                    assertEquals(123l, rel.getProperty("rid"));
+                    assertEquals(123L, rel.getProperty("rid"));
                     assertEquals("Thu", rel.getProperty("since"));
                 });
         testCall(db, "MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e CALL apoc.merge.relationship(s, 'OTHER', null, null, e) YIELD rel RETURN rel",
@@ -204,7 +204,7 @@ public class MergeTest {
             testCall(db, "CALL apoc.merge.node(['Person'], $identProps) YIELD node RETURN node", params,
                         (row) -> {
                             Node node = (Node) row.get("node");
-                            assertTrue(node instanceof Node);
+                            assertNotNull(node);
                             assertTrue(node.hasProperty(key));
                             assertEquals("value", node.getProperty(key));
                         });
@@ -248,8 +248,8 @@ public class MergeTest {
         testCall(db, String.format("CALL apoc.merge.%s.eager(['Person','Bastard'],{ssid:'123'}, {name:'John'})", procName),
                 (row) -> {
                     Node node = (Node) row.get("node");
-                    assertEquals(true, node.hasLabel(Label.label("Person")));
-                    assertEquals(true, node.hasLabel(Label.label("Bastard")));
+                    assertTrue(node.hasLabel(Label.label("Person")));
+                    assertTrue(node.hasLabel(Label.label("Bastard")));
                     assertEquals("John", node.getProperty("name"));
                     assertEquals("123", node.getProperty("ssid"));
                     
@@ -267,8 +267,8 @@ public class MergeTest {
         testCall(db, "CALL apoc.merge.node.eager(['Person','Bastard'],{ssid:'123'}, {name:'John'},{occupation:'juggler'}) YIELD node RETURN node",
                 (row) -> {
                     Node node = (Node) row.get("node");
-                    assertEquals(true, node.hasLabel(Label.label("Person")));
-                    assertEquals(true, node.hasLabel(Label.label("Bastard")));
+                    assertTrue(node.hasLabel(Label.label("Person")));
+                    assertTrue(node.hasLabel(Label.label("Bastard")));
                     assertEquals("John", node.getProperty("name"));
                     assertEquals("123", node.getProperty("ssid"));
                     assertFalse(node.hasProperty("occupation"));
@@ -281,8 +281,8 @@ public class MergeTest {
         testCall(db, "CALL apoc.merge.node.eager(['Person','Bastard'],{ssid:'123'}, {name:'John'}, {occupation:'juggler'}) YIELD node RETURN node",
                 (row) -> {
                     Node node = (Node) row.get("node");
-                    assertEquals(true, node.hasLabel(Label.label("Person")));
-                    assertEquals(true, node.hasLabel(Label.label("Bastard")));
+                    assertTrue(node.hasLabel(Label.label("Person")));
+                    assertTrue(node.hasLabel(Label.label("Bastard")));
                     assertEquals("juggler", node.getProperty("occupation"));
                     assertEquals("123", node.getProperty("ssid"));
                     assertFalse(node.hasProperty("name"));
@@ -298,8 +298,8 @@ public class MergeTest {
 
             for (long index = 1; index <= 5; index++) {
                 Node node = (Node) result.next().get("node");
-                assertEquals(true, node.hasLabel(Label.label("Person")));
-                assertEquals(true, node.hasLabel(Label.label("Bastard Man")));
+                assertTrue(node.hasLabel(Label.label("Person")));
+                assertTrue(node.hasLabel(Label.label("Bastard Man")));
                 assertEquals("123", node.getProperty("ssid"));
                 assertEquals(index, node.getProperty("index"));
                 assertEquals("juggler", node.getProperty("occupation"));
@@ -330,7 +330,7 @@ public class MergeTest {
                 (row) -> {
                     Relationship rel = (Relationship) row.get("rel");
                     assertEquals("KNOWS", rel.getType().name());
-                    assertEquals(123l, rel.getProperty("rid"));
+                    assertEquals(123L, rel.getProperty("rid"));
                     assertEquals("Thu", rel.getProperty("since"));
                     
                     if (isWithStats) {
@@ -345,7 +345,7 @@ public class MergeTest {
                 (row) -> {
                     Relationship rel = (Relationship) row.get("rel");
                     assertEquals("KNOWS", rel.getType().name());
-                    assertEquals(123l, rel.getProperty("rid"));
+                    assertEquals(123L, rel.getProperty("rid"));
                     assertEquals("Thu", rel.getProperty("since"));
                     
                     if (isWithStats) {
@@ -378,7 +378,7 @@ public class MergeTest {
                 (row) -> {
                     Relationship rel = (Relationship) row.get("rel");
                     assertEquals("KNOWS", rel.getType().name());
-                    assertEquals(123l, rel.getProperty("rid"));
+                    assertEquals(123L, rel.getProperty("rid"));
                     assertEquals("Thu", rel.getProperty("since"));
                     assertFalse(rel.hasProperty("until"));
                 });
@@ -387,7 +387,7 @@ public class MergeTest {
                 (row) -> {
                     Relationship rel = (Relationship) row.get("rel");
                     assertEquals("KNOWS", rel.getType().name());
-                    assertEquals(123l, rel.getProperty("rid"));
+                    assertEquals(123L, rel.getProperty("rid"));
                     assertEquals("Fri", rel.getProperty("since"));
                 });
     }
@@ -402,7 +402,7 @@ public class MergeTest {
             for (long index = 1; index <= 3; index++) {
                 Relationship rel = (Relationship) result.next().get("rel");
                 assertEquals("KNOWS", rel.getType().name());
-                assertEquals(123l, rel.getProperty("rid"));
+                assertEquals(123L, rel.getProperty("rid"));
                 assertEquals("Fri", rel.getProperty("since"));
             }
         } catch (Exception e) {


### PR DESCRIPTION
apoc.merge.nodes:
- if labelNames null is newly considered as an empty label
- if labelNames contains null values, it is considered as incorrect input
- if labelNames contains among others an empty string, it is considered as incorrect input

apoc.merge.relationships:
- if relationship type is null, it is considered as incorrect input
- if relationship type is empty, it is considered as incorrect input
