### PR TITLE
[x2fDvuKu] extend timeout for flaky BigGraphTest

### DIFF
--- a/core/src/test/java/apoc/export/BigGraphTest.java
+++ b/core/src/test/java/apoc/export/BigGraphTest.java
@@ -108,7 +108,7 @@ public class BigGraphTest {
 
     @Test
     public void testTerminateRenameType() {
-        checkTerminationGuard(db, "CALL apoc.refactor.rename.type('DIRECTED', 'DIRECTED_TWO')");
+        checkTerminationGuard(db,  50L, "CALL apoc.refactor.rename.type('DIRECTED', 'DIRECTED_TWO')");
     }
 
     @Test

--- a/test-utils/src/main/java/apoc/util/TransactionTestUtil.java
+++ b/test-utils/src/main/java/apoc/util/TransactionTestUtil.java
@@ -80,9 +80,11 @@ public class TransactionTestUtil {
     }
 
     public static void checkTransactionTime(long timeout, long timePassed) {
-        timePassed = (System.currentTimeMillis() - timePassed) / 1000;
-        assertTrue("The transaction hasn't been terminated before the timeout time, but after " + timePassed + " seconds",
-                timePassed <= timeout);
+        double timePassedDouble = (System.currentTimeMillis() - timePassed) / 1000.0;
+
+        assertTrue("The transaction hasn't been terminated before the given timeout time (" + timeout
+                + "), but after " + timePassedDouble + " seconds",
+                timePassedDouble <= timeout);
     }
 
     public static void checkTransactionNotInList(GraphDatabaseService db, String query) {


### PR DESCRIPTION
apoc.refactor.rename.type reuses functionality from periodic iterate, which uses a termination guard. However, there is no concrete guarantee on when we will catch it. I propose we extended the timemout to encompass the outlier in the build. The default value was 10L seconds.

When running the test locally, timepassed was 0. Doubles could be a bit more precise.