### PR TITLE
[2kuFEKOe] Fix flaky integration test

### DIFF
--- a/test-utils/src/main/java/apoc/util/TestContainerUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestContainerUtil.java
@@ -138,7 +138,6 @@ public class TestContainerUtil {
         System.out.println("neo4jDockerImageVersion = " + dockerImage);
         Neo4jContainerExtension neo4jContainer = new Neo4jContainerExtension(dockerImage)
                 .withPlugins(MountableFile.forHostPath(pluginsFolder.toPath()))
-                .withTmpFs(Map.of("/logs", "rw", "/data", "rw", pluginsFolder.toPath().toAbsolutePath().toString(), "rw"))
                 .withAdminPassword(password)
                 .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
                 .withEnv("apoc.export.file.enabled", "true")


### PR DESCRIPTION
Tmpfs has been causing flaky tests on team city.

[Green builds on TC](https://live.neo4j-build.io/buildConfiguration/CypherSurface_Apoc_Dev_BuildAndCreateArtifacts?branch=%2Fflaky-test-from-hell-mem-files&mode=builds#all-projects), historically they have 50% success rate.