### PR TITLE
[q3KTZ83O] Remove strange clean up method

### DIFF
--- a/core/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/core/src/main/java/apoc/export/csv/CsvFormat.java
@@ -196,7 +196,7 @@ public class CsvFormat {
                                 return joinLabels(entrySet.getKey(), config.getArrayDelim());
                             }
                             String prop = s.split(":")[0];
-                            return "".equals(prop) ? String.valueOf(getNodeId(tx, n.getElementId())) : cleanPoint(FormatUtils.toString(n.getProperty(prop, "")));
+                            return prop.isEmpty() ? String.valueOf(getNodeId(tx, n.getElementId())) : FormatUtils.toString(n.getProperty(prop, ""));
                         }).collect(Collectors.toList());
                     })
                     .collect(Collectors.toList());
@@ -224,20 +224,13 @@ public class CsvFormat {
                                     return entrySet.getKey().name();
                                 default:
                                     String prop = s.split(":")[0];
-                                    return "".equals(prop) ? String.valueOf(getRelationshipId(tx, r.getElementId())) : cleanPoint(FormatUtils.toString(r.getProperty(prop, "")));
+                                    return prop.isEmpty() ? String.valueOf(getRelationshipId(tx, r.getElementId())) : FormatUtils.toString(r.getProperty(prop, ""));
                             }
                         }).collect(Collectors.toList());
                     })
                     .collect(Collectors.toList());
             writeRow(config, writer, headerRel, rows, "relationships." + entrySet.getKey().name());
         });
-    }
-
-    private String cleanPoint(String point) {
-        point = point.replace(",\"z\":null", "");
-        point = point.replace(",\"heigth\":null", "");
-        point = point.replace("\"", "");
-        return point;
     }
 
     private Set<String> generateHeaderNodeBulkImport(Map.Entry<Iterable<Label>, List<Node>> entrySet) {

--- a/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
@@ -55,7 +55,7 @@ public class ExportCsvNeo4jAdminTest {
             .format(":ID;born_2D:point;born_3D:point;localtime:localtime;time:time;dateTime:datetime;localDateTime:localdatetime;date:date;duration:duration;:LABEL%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_TYPES_NODE = String
-            .format("6;{crs:cartesian,x:2.3,y:4.5};{crs:wgs-84-3d,latitude:12.78,longitude:56.7,height:100.0};12:50:35.556;12:50:35.556+01:00;2018-10-30T12:50:35.556+01:00;2018-10-30T19:32:24;2018-10-30;P5M1DT12H;Types%n");
+            .format("6;\"{\"\"crs\"\":\"\"cartesian\"\",\"\"x\"\":2.3,\"\"y\"\":4.5,\"\"z\"\":null}\";\"{\"\"crs\"\":\"\"wgs-84-3d\"\",\"\"latitude\"\":12.78,\"\"longitude\"\":56.7,\"\"height\"\":100.0}\";12:50:35.556;12:50:35.556+01:00;2018-10-30T12:50:35.556+01:00;2018-10-30T19:32:24;2018-10-30;P5M1DT12H;Types%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS = String
             .format(":ID;name;street;:LABEL%n");
@@ -87,7 +87,7 @@ public class ExportCsvNeo4jAdminTest {
                     "2;;12;User%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER1 = String
-            .format("0;foo;42;true;[a,b,c];\"User1;User\"%n");
+            .format("0;\"foo \"\"the\"\" bar\";42;true;\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\";\"User1;User\"%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_KNOWS = String
             .format("0;1;KNOWS%n");
@@ -111,7 +111,7 @@ public class ExportCsvNeo4jAdminTest {
     public void before() {
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
         TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class);
-        db.executeTransactionally("CREATE (f:User1:User {name:'foo',age:42,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})");
+        db.executeTransactionally("CREATE (f:User1:User {name:'foo \"the\" bar',age:42,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})");
         db.executeTransactionally("CREATE (f:Address1:Address {name:'Andrea', city: 'Milano', street:'Via Garibaldi, 7'})-[:NEXT_DELIVERY]->(a:Address {name: 'Bar Sport'}), (b:Address {street: 'via Benni'})");
         db.executeTransactionally("CREATE (a:Types {date: date('2018-10-30'), localDateTime: localdatetime('20181030T19:32:24'), dateTime: datetime('2018-10-30T12:50:35.556+0100'), localtime: localtime('12:50:35.556'), duration: duration('P5M1DT12H'), time: time('125035.556+0100'), born_2D: point({ x: 2.3, y: 4.5 }), born_3D:point({ longitude: 56.7, latitude: 12.78, height: 100 })})");
     }


### PR DESCRIPTION
Allow double quotes in node and rel properties with export csv.

Automatic is quote: always, so now using bulkImport everything is super quoted, but it matches how not using bulkImport works :)