### PR TITLE
Use Injected URLAccessChecker for checking access to URLs 

### DIFF
--- a/common/src/main/java/apoc/load/LoadJsonUtils.java
+++ b/common/src/main/java/apoc/load/LoadJsonUtils.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.TerminationGuard;
 
@@ -38,13 +39,14 @@ public class LoadJsonUtils {
             boolean failOnError,
             String compressionAlgo,
             List<String> pathOptions,
-            TerminationGuard terminationGuard) {
+            TerminationGuard terminationGuard,
+            URLAccessChecker urlAccessChecker) {
         if (urlOrKeyOrBinary instanceof String) {
             headers = null != headers ? headers : new HashMap<>();
             headers.putAll(Util.extractCredentialsIfNeeded((String) urlOrKeyOrBinary, failOnError));
         }
-        Stream<Object> stream =
-                JsonUtil.loadJson(urlOrKeyOrBinary, headers, payload, path, failOnError, compressionAlgo, pathOptions);
+        Stream<Object> stream = JsonUtil.loadJson(
+                urlOrKeyOrBinary, headers, payload, path, failOnError, compressionAlgo, pathOptions, urlAccessChecker);
         return stream.flatMap((value) -> {
             if (terminationGuard != null) {
                 terminationGuard.check();

--- a/common/src/main/java/apoc/util/JsonUtil.java
+++ b/common/src/main/java/apoc/util/JsonUtil.java
@@ -42,6 +42,7 @@ import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.apache.commons.lang3.StringUtils;
+import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.graphdb.spatial.Point;
 import org.neo4j.values.storable.DurationValue;
 
@@ -94,8 +95,9 @@ public class JsonUtil {
             String payload,
             String path,
             boolean failOnError,
-            List<String> options) {
-        return loadJson(urlOrBinary, headers, payload, path, failOnError, null, options);
+            List<String> options,
+            URLAccessChecker urlAccessChecker) {
+        return loadJson(urlOrBinary, headers, payload, path, failOnError, null, options, urlAccessChecker);
     }
 
     public static Stream<Object> loadJson(
@@ -105,13 +107,15 @@ public class JsonUtil {
             String path,
             boolean failOnError,
             String compressionAlgo,
-            List<String> options) {
+            List<String> options,
+            URLAccessChecker urlAccessChecker) {
         try {
             if (urlOrBinary instanceof String) {
                 String url = (String) urlOrBinary;
                 urlOrBinary = Util.getLoadUrlByConfigFile("json", url, "url").orElse(url);
             }
-            InputStream input = FileUtils.inputStreamFor(urlOrBinary, headers, payload, compressionAlgo);
+            InputStream input =
+                    FileUtils.inputStreamFor(urlOrBinary, headers, payload, compressionAlgo, urlAccessChecker);
             JsonParser parser = OBJECT_MAPPER.getFactory().createParser(input);
             MappingIterator<Object> it = OBJECT_MAPPER.readValues(parser, Object.class);
             Stream<Object> stream = StreamSupport.stream(Spliterators.spliteratorUnknownSize(it, 0), false);

--- a/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
+++ b/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.logging.Log;
 
 public class CsvEntityLoader {
@@ -41,15 +42,17 @@ public class CsvEntityLoader {
     private final CsvLoaderConfig clc;
     private final ProgressReporter reporter;
     private final Log log;
+    private final URLAccessChecker urlAccessChecker;
 
     /**
      * @param clc configuration object
      * @param reporter
      */
-    public CsvEntityLoader(CsvLoaderConfig clc, ProgressReporter reporter, Log log) {
+    public CsvEntityLoader(CsvLoaderConfig clc, ProgressReporter reporter, Log log, URLAccessChecker urlAccessChecker) {
         this.clc = clc;
         this.reporter = reporter;
         this.log = log;
+        this.urlAccessChecker = urlAccessChecker;
     }
 
     /**
@@ -70,7 +73,7 @@ public class CsvEntityLoader {
             final Map<String, Map<String, String>> idMapping)
             throws IOException {
 
-        try (final CountingReader reader = FileUtils.readerFor(fileName, clc.getCompressionAlgo())) {
+        try (final CountingReader reader = FileUtils.readerFor(fileName, clc.getCompressionAlgo(), urlAccessChecker)) {
             final String header = readFirstLine(reader);
             final List<CsvHeaderField> fields =
                     CsvHeaderFields.processHeader(header, clc.getDelimiter(), clc.getQuotationCharacter());
@@ -201,10 +204,11 @@ public class CsvEntityLoader {
             final Object data,
             final String type,
             final GraphDatabaseService db,
-            final Map<String, Map<String, String>> idMapping)
+            final Map<String, Map<String, String>> idMapping,
+            final URLAccessChecker urlAccessChecker)
             throws IOException {
 
-        try (final CountingReader reader = FileUtils.readerFor(data, clc.getCompressionAlgo())) {
+        try (final CountingReader reader = FileUtils.readerFor(data, clc.getCompressionAlgo(), urlAccessChecker)) {
             final String header = readFirstLine(reader);
             final List<CsvHeaderField> fields =
                     CsvHeaderFields.processHeader(header, clc.getDelimiter(), clc.getQuotationCharacter());

--- a/core/src/main/java/apoc/export/graphml/ExportGraphML.java
+++ b/core/src/main/java/apoc/export/graphml/ExportGraphML.java
@@ -43,6 +43,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Mode;
@@ -71,6 +72,9 @@ public class ExportGraphML {
     @Context
     public TerminationGuard terminationGuard;
 
+    @Context
+    public URLAccessChecker urlAccessChecker;
+
     @Procedure(name = "apoc.import.graphml", mode = Mode.WRITE)
     @Description("Imports a graph from the provided GraphML file.")
     public Stream<ProgressInfo> file(
@@ -95,7 +99,8 @@ public class ExportGraphML {
             if (exportConfig.storeNodeIds()) graphMLReader.storeNodeIds();
 
             graphMLReader.parseXML(
-                    FileUtils.readerFor(urlOrBinaryFile, exportConfig.getCompressionAlgo()), terminationGuard);
+                    FileUtils.readerFor(urlOrBinaryFile, exportConfig.getCompressionAlgo(), urlAccessChecker),
+                    terminationGuard);
             return reporter.getTotal();
         });
         return Stream.of(result);

--- a/core/src/main/java/apoc/load/LoadArrow.java
+++ b/core/src/main/java/apoc/load/LoadArrow.java
@@ -46,12 +46,17 @@ import org.apache.arrow.vector.ipc.ArrowFileReader;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
 import org.apache.arrow.vector.util.Text;
+import org.neo4j.graphdb.security.URLAccessChecker;
+import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.values.storable.Values;
 
 public class LoadArrow {
+
+    @Context
+    public URLAccessChecker urlAccessChecker;
 
     private static class ArrowSpliterator extends Spliterators.AbstractSpliterator<MapResult> {
 
@@ -114,8 +119,8 @@ public class LoadArrow {
     public Stream<MapResult> file(
             @Name("file") String fileName, @Name(value = "config", defaultValue = "{}") Map<String, Object> config)
             throws IOException {
-        final SeekableByteChannel channel =
-                FileUtils.inputStreamFor(fileName, null, null, null).asChannel();
+        final SeekableByteChannel channel = FileUtils.inputStreamFor(fileName, null, null, null, urlAccessChecker)
+                .asChannel();
         RootAllocator allocator = new RootAllocator();
         ArrowFileReader streamReader = new ArrowFileReader(channel, allocator);
         VectorSchemaRoot schemaRoot = streamReader.getVectorSchemaRoot();

--- a/core/src/main/java/apoc/load/LoadJson.java
+++ b/core/src/main/java/apoc/load/LoadJson.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
@@ -40,6 +41,9 @@ public class LoadJson {
     @Context
     public TerminationGuard terminationGuard;
 
+    @Context
+    public URLAccessChecker urlAccessChecker;
+
     @SuppressWarnings("unchecked")
     @Procedure("apoc.load.jsonArray")
     @Description("Loads array from a JSON URL (e.g. web-API) to then import the given JSON file as a stream of values.")
@@ -47,7 +51,8 @@ public class LoadJson {
             @Name("url") String url,
             @Name(value = "path", defaultValue = "") String path,
             @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
-        return JsonUtil.loadJson(url, null, null, path, true, (List<String>) config.get("pathOptions"))
+        return JsonUtil.loadJson(
+                        url, null, null, path, true, (List<String>) config.get("pathOptions"), urlAccessChecker)
                 .flatMap((value) -> {
                     if (value instanceof List) {
                         List list = (List) value;
@@ -84,6 +89,14 @@ public class LoadJson {
         String compressionAlgo = (String) config.getOrDefault(COMPRESSION, CompressionAlgo.NONE.name());
         List<String> pathOptions = (List<String>) config.get("pathOptions");
         return loadJsonStream(
-                urlOrKeyOrBinary, headers, payload, path, failOnError, compressionAlgo, pathOptions, terminationGuard);
+                urlOrKeyOrBinary,
+                headers,
+                payload,
+                path,
+                failOnError,
+                compressionAlgo,
+                pathOptions,
+                terminationGuard,
+                urlAccessChecker);
     }
 }


### PR DESCRIPTION
Fixes #<Replace with the number of the issue, Mandatory>

Use Injected URLAccessChecker for checking access to URLs calling internal WebURLAccessRule directly

## Proposed Changes (Mandatory)

Inject a new URLAccessChecker to separate out APOC from making internal calls into WebURLAccessRule, as this needs to changes to support RBAC permissions as well. Having this injectable will mean that we can late get this new functionality in APOC as well for free.

The alternative is to move the config only based checks into APOC. 
