### PR TITLE
[G9u7OAg9] Ignore check for optimizations if the format is CSV

### DIFF
--- a/common/src/main/java/apoc/export/util/ExportConfig.java
+++ b/common/src/main/java/apoc/export/util/ExportConfig.java
@@ -127,6 +127,10 @@ public class ExportConfig extends CompressionConfig {
     }
 
     public ExportConfig(Map<String, Object> config) {
+        this(config, ExportFormat.CYPHER_SHELL);
+    }
+
+    public ExportConfig(Map<String, Object> config, ExportFormat exportFormat) {
         super(config);
         config = config != null ? config : Collections.emptyMap();
         this.saveIndexNames = toBoolean(config.getOrDefault("saveIndexNames", false));
@@ -138,7 +142,7 @@ public class ExportConfig extends CompressionConfig {
         this.nodesOfRelationships = toBoolean(config.get("nodesOfRelationships"));
         this.bulkImport = toBoolean(config.get("bulkImport"));
         this.separateHeader = toBoolean(config.get("separateHeader"));
-        this.format = ExportFormat.fromString((String) config.getOrDefault("format", "cypher-shell"));
+        this.format = ExportFormat.fromString((String) config.getOrDefault("format", exportFormat.getFormat()));
         this.cypherFormat = CypherFormat.fromString((String) config.getOrDefault("cypherFormat", "create"));
         this.config = config;
         this.streamStatements = toBoolean(config.get("streamStatements")) || toBoolean(config.get("stream"));
@@ -169,7 +173,9 @@ public class ExportConfig extends CompressionConfig {
                     "`useOptimizations: 'UNWIND_BATCH_PARAMS'` can be used only in combination with `format: 'CYPHER_SHELL' but got [format:`"
                             + this.format + "]");
         }
-        if (!OptimizationType.NONE.equals(this.optimizationType) && this.unwindBatchSize > this.batchSize) {
+        // CSV doesn't use optimization type
+        if (!OptimizationType.NONE.equals(this.optimizationType) && this.unwindBatchSize > this.batchSize
+            && !ExportFormat.CSV.equals(this.format)) {
             throw new RuntimeException("`unwindBatchSize` must be <= `batchSize`, but got [unwindBatchSize:"
                     + unwindBatchSize + ", batchSize:" + batchSize + "]");
         }

--- a/common/src/main/java/apoc/export/util/ExportFormat.java
+++ b/common/src/main/java/apoc/export/util/ExportFormat.java
@@ -34,7 +34,9 @@ public enum ExportFormat {
 
     GEPHI("gephi", "", "", "", ""),
 
-    TINKERPOP("tinkerpop", "", "", "", "");
+    TINKERPOP("tinkerpop", "", "", "", ""),
+
+    CSV("csv", "", "", "", "");
 
     private final String format;
 
@@ -54,6 +56,9 @@ public enum ExportFormat {
         this.indexAwait = indexAwait;
     }
 
+    public String getFormat() {
+        return format;
+    }
     public static final ExportFormat fromString(String format) {
         if (format != null && !format.isEmpty()) {
             for (ExportFormat exportFormat : ExportFormat.values()) {

--- a/core/src/main/java/apoc/export/csv/ExportCSV.java
+++ b/core/src/main/java/apoc/export/csv/ExportCSV.java
@@ -23,6 +23,7 @@ import apoc.Pools;
 import apoc.export.cypher.ExportFileManager;
 import apoc.export.cypher.FileManagerFactory;
 import apoc.export.util.ExportConfig;
+import apoc.export.util.ExportFormat;
 import apoc.export.util.ExportUtils;
 import apoc.export.util.NodesAndRelsSubGraph;
 import apoc.export.util.ProgressReporter;
@@ -75,7 +76,7 @@ public class ExportCSV {
     @Description("Exports the full database to the provided CSV file.")
     public Stream<ProgressInfo> all(@Name("file") String fileName, @Name("config") Map<String, Object> config) {
         String source = String.format("database: nodes(%d), rels(%d)", Util.nodeCount(tx), Util.relCount(tx));
-        return exportCsv(fileName, source, new DatabaseSubGraph(tx), new ExportConfig(config));
+        return exportCsv(fileName, source, new DatabaseSubGraph(tx), new ExportConfig(config, ExportFormat.CSV));
     }
 
     @NotThreadSafe
@@ -86,7 +87,7 @@ public class ExportCSV {
             @Name("rels") List<Relationship> rels,
             @Name("file") String fileName,
             @Name("config") Map<String, Object> config) {
-        ExportConfig exportConfig = new ExportConfig(config);
+        ExportConfig exportConfig = new ExportConfig(config, ExportFormat.CSV);
         preventBulkImport(exportConfig);
         String source = String.format("data: nodes(%d), rels(%d)", nodes.size(), rels.size());
         return exportCsv(fileName, source, new NodesAndRelsSubGraph(tx, nodes, rels), exportConfig);
@@ -102,7 +103,7 @@ public class ExportCSV {
         Collection<Node> nodes = (Collection<Node>) graph.get("nodes");
         Collection<Relationship> rels = (Collection<Relationship>) graph.get("relationships");
         String source = String.format("graph: nodes(%d), rels(%d)", nodes.size(), rels.size());
-        return exportCsv(fileName, source, new NodesAndRelsSubGraph(tx, nodes, rels), new ExportConfig(config));
+        return exportCsv(fileName, source, new NodesAndRelsSubGraph(tx, nodes, rels), new ExportConfig(config, ExportFormat.CSV));
     }
 
     @NotThreadSafe
@@ -110,7 +111,7 @@ public class ExportCSV {
     @Description("Exports the results from running the given Cypher query to the provided CSV file.")
     public Stream<ProgressInfo> query(
             @Name("query") String query, @Name("file") String fileName, @Name("config") Map<String, Object> config) {
-        ExportConfig exportConfig = new ExportConfig(config);
+        ExportConfig exportConfig = new ExportConfig(config, ExportFormat.CSV);
         preventBulkImport(exportConfig);
         Map<String, Object> params = config == null
                 ? Collections.emptyMap()

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -486,7 +486,7 @@ public class ExportCsvTest {
     @Test
     public void testExportAllCsvStreaming() {
         String statement =
-                "CALL apoc.export.csv.all(null,{stream:true,batchSize:2,useOptimizations:{unwindBatchSize:2}})";
+                "CALL apoc.export.csv.all(null,{stream:true,batchSize:2})";
         assertExportStreaming(statement, NONE);
     }
 
@@ -494,7 +494,7 @@ public class ExportCsvTest {
     public void testExportAllCsvStreamingCompressed() {
         final CompressionAlgo algo = GZIP;
         String statement = "CALL apoc.export.csv.all(null, {compression: '" + algo.name()
-                + "',stream:true,batchSize:2,useOptimizations:{unwindBatchSize:2}})";
+                + "',stream:true,batchSize:2})";
         assertExportStreaming(statement, algo);
     }
 
@@ -550,7 +550,7 @@ public class ExportCsvTest {
         StringBuilder sb = new StringBuilder();
         testResult(
                 db,
-                "CALL apoc.export.csv.query($query,null,{stream:true,batchSize:2, useOptimizations:{unwindBatchSize:2}})",
+                "CALL apoc.export.csv.query($query,null,{stream:true,batchSize:2})",
                 map("query", query),
                 getAndCheckStreamingMetadataQueryMatchUsers(sb));
         assertEquals(EXPECTED_QUERY, sb.toString());
@@ -562,7 +562,7 @@ public class ExportCsvTest {
         StringBuilder sb = new StringBuilder();
         testResult(
                 db,
-                "CALL apoc.export.csv.query($query,null,{quotes: false, stream:true,batchSize:2, useOptimizations:{unwindBatchSize:2}})",
+                "CALL apoc.export.csv.query($query,null,{quotes: false, stream:true,batchSize:2})",
                 map("query", query),
                 getAndCheckStreamingMetadataQueryMatchUsers(sb));
 
@@ -600,7 +600,7 @@ public class ExportCsvTest {
         StringBuilder sb = new StringBuilder();
         testResult(
                 db,
-                "CALL apoc.export.csv.query($query,null,{quotes: 'always', stream:true,batchSize:2, useOptimizations:{unwindBatchSize:2}})",
+                "CALL apoc.export.csv.query($query,null,{quotes: 'always', stream:true,batchSize:2})",
                 map("query", query),
                 getAndCheckStreamingMetadataQueryMatchAddress(sb));
 
@@ -613,7 +613,7 @@ public class ExportCsvTest {
         StringBuilder sb = new StringBuilder();
         testResult(
                 db,
-                "CALL apoc.export.csv.query($query,null,{quotes: 'ifNeeded', stream:true,batchSize:2, useOptimizations:{unwindBatchSize:2}})",
+                "CALL apoc.export.csv.query($query,null,{quotes: 'ifNeeded', stream:true,batchSize:2})",
                 map("query", query),
                 getAndCheckStreamingMetadataQueryMatchAddress(sb));
 
@@ -626,7 +626,7 @@ public class ExportCsvTest {
         StringBuilder sb = new StringBuilder();
         testResult(
                 db,
-                "CALL apoc.export.csv.query($query,null,{quotes: 'none', stream:true,batchSize:2, useOptimizations:{unwindBatchSize:2}})",
+                "CALL apoc.export.csv.query($query,null,{quotes: 'none', stream:true,batchSize:2})",
                 map("query", query),
                 getAndCheckStreamingMetadataQueryMatchAddress(sb));
 


### PR DESCRIPTION
CSV export can't use optimizations, so the check that it is correct is not very useful. In general we should probably clean up these configs as it is quite messy having all of them, but that requires an investigation into which procedure needs what 👀