### PR TITLE
[NOID] Solves populated git-diff index bug when no changes have happened

### DIFF
--- a/.github/actions/gradle-command-on-pr/action.yaml
+++ b/.github/actions/gradle-command-on-pr/action.yaml
@@ -38,7 +38,9 @@ runs:
     - name: Check for modified files
       shell: bash
       id: git-check
-      run: echo modified=$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi) >> $GITHUB_OUTPUT
+      run: |
+        git update-index --refresh
+        echo modified=$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi) >> $GITHUB_OUTPUT
 
     - name: Commit to the PR branch
       shell: bash


### PR DESCRIPTION
## What
Solves bug in bot to format / update licenses where `git diff-index` could be returning results even if no files have had updates.

This bug probably is present in the monorepo as I copied those files from there.

## Why
For reference the answer to this question https://stackoverflow.com/questions/3878624/how-do-i-programmatically-determine-if-there-are-uncommitted-changes

> if there are files that have been touched, but whose contents are the same as in the index, you'll need to run git update-index --refresh before git diff-index, otherwise diff-index will incorrectly report that the tree is dirty)
