### PR TITLE
[NOID] Adjusts versions job

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,18 +5,20 @@ import java.security.MessageDigest
 
 // Gets all Neo4j 5.0.0+ releases from Maven, ordered from oldest to most recent.
 static def neo4jReleases() {
-    def url = new URL("https://repo1.maven.org/maven2/org/neo4j/neo4j-kernel/")
-    def htmlString = url.getText()
-            .replace("<!DOCTYPE html>", "")
-            .replace("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">", "")
+    def url = new URL("https://repo1.maven.org/maven2/org/neo4j/neo4j-kernel/maven-metadata.xml")
+    def xmlString = url.getText()
 
-    def rootNode = new XmlParser().parseText(htmlString)
+    def rootNode = new XmlParser().parseText(xmlString)
     def releases = initialiseNeo4jReleases()
 
-    for (a in rootNode.body.main.pre.a) {
-        def href = a.attributes()["href"]
+    def versions = rootNode.versioning.versions.version
 
-        if (!href.contains("xml")) releases.add(href[0..-2])
+    for (a in versions) {
+        def version = a.value()
+        def size = version.size()
+        if (size > 0) {
+            releases.add(version.get(0))
+        }
     }
 
     return releases


### PR DESCRIPTION
## What

Uses the [`maven-metadata`](https://repo1.maven.org/maven2/org/neo4j/neo4j-kernel/maven-metadata.xml) file to generate the versions.json instead of parsing the [`html`](https://repo1.maven.org/maven2/org/neo4j/neo4j-kernel/).

I've tried (with JVM 8) doing:

```
mkdir -p build
./gradlew versions
```

and it correctly generates a `build/versions.json` file that contains the 5.15.0 entry:

```
    {
        "neo4j": "5.15.0",
        "neo4jVersion": "5.15.0",
        "apoc": "5.15.0",
        "version": "5.15.0",
        "url": "https://github.com/neo4j/apoc/releases/5.15.0",
        "homepageUrl": "https://github.com/neo4j/apoc/releases/5.15.0",
        "jar": "https://github.com/neo4j/apoc/releases/download/5.15.0/apoc-5.15.0-core.jar",
        "downloadUrl": "https://github.com/neo4j/apoc/releases/download/5.15.0/apoc-5.15.0-core.jar",
        "sha1": "f76b53599c9d0ca80a3643f489a0f662de9563c2",
        "sha256": "0c7a834d74948121666164b8f0db484e328219ec9522ae3fb5d07e05fe9ac755",
        "md5": "10e577a9cd887982b88d68003f8bb079",
        "config": {
            "+:dbms.security.procedures.unrestricted": [
                "apoc.*"
            ]
        }
    }
```
## Why

Because that's a better source of truth. Right now https://repo1.maven.org/maven2/org/neo4j/neo4j-kernel/maven-metadata.xml is showing 5.15.0 but there's no 5.15.0 listed under https://repo1.maven.org/maven2/org/neo4j/neo4j-kernel/

