### PR TITLE
[yaWCMgIP] Exclude asm to fix startup issue

### DIFF
--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -474,7 +474,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 BSD-3-Clause
-  asm-9.3.jar
   asm-9.6.jar
   asm-analysis-9.6.jar
   asm-commons-5.0.3.jar

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -281,7 +281,6 @@ BSD-2-Clause
   zstd-jni-1.5.5-10.jar
 
 BSD-3-Clause
-  asm-9.3.jar
   asm-9.6.jar
   asm-analysis-9.6.jar
   asm-commons-5.0.3.jar

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'
         exclude group: 'ch.qos.logback', module: 'logback-classic'
+        exclude group: 'org.ow2.asm', module: 'asm'
     }
 }
 


### PR DESCRIPTION
I tested this manually by copying the jar to desktop and changing the name to: apoc5plus-5.15.0, without this change it fails, with it works (also with it, there is no trace of it in the logs either)