### PR TITLE
[h7Q1epCi] Make hashing functions stable on all neo4j types

### DIFF
--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -681,8 +681,8 @@ public class Meta {
         List<String> labels =
                 Iterables.stream(tx.getAllLabelsInUse()).map(Label::name).collect(Collectors.toList());
         TokenRead tokenRead = kernelTx.tokenRead();
-        return labels.stream().collect(Collectors.toMap(e -> e, e -> kernelTx.dataRead()
-                .countsForNode(tokenRead.nodeLabel(e))));
+        return labels.stream()
+                .collect(Collectors.toMap(e -> e, e -> kernelTx.dataRead().countsForNode(tokenRead.nodeLabel(e))));
     }
 
     public static long getSampleForLabelCount(long labelCount, long sample) {

--- a/core/src/test/java/apoc/util/UtilsTest.java
+++ b/core/src/test/java/apoc/util/UtilsTest.java
@@ -326,6 +326,11 @@ public class UtilsTest {
     }
 
     @Test
+    public void sha512IsStableOnAllTypes() {
+        hashIsStable("sha512");
+    }
+
+    @Test
     public void sha384IsStableOnAllTypes() {
         hashIsStable("sha384");
     }

--- a/core/src/test/java/apoc/util/UtilsTest.java
+++ b/core/src/test/java/apoc/util/UtilsTest.java
@@ -20,26 +20,36 @@ package apoc.util;
 
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCallEmpty;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toUnmodifiableMap;
+import static java.util.stream.IntStream.range;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.hamcrest.Matchers;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
+import org.neo4j.values.storable.RandomValues;
+import org.neo4j.values.storable.ValueType;
 
 /**
  * @author mh
@@ -289,6 +299,118 @@ public class UtilsTest {
                 db,
                 "RETURN apoc.util.md5(['ABC']) AS value",
                 r -> assertEquals("902fbdd2b1df0c4f70b4a5d23525e932", r.get("value")));
+    }
+
+    @Test
+    public void md5WithNestedTypes() {
+        TestUtil.testCall(
+                db,
+                "RETURN apoc.util.md5(['ABC', true, {b: 'hej', a: [1, 2]}, ['hej', {b:'hå'}]]) AS value",
+                r -> assertEquals("f0603bd38267c6e59c0cf6896f4b4bcd", r.get("value")));
+    }
+
+    @Test
+    public void md5IsStableOnAllTypes() {
+        hashIsStable("md5");
+    }
+
+    @Test
+    public void sha1IsStableOnAllTypes() {
+        hashIsStable("sha1");
+    }
+
+    @Test
+    public void sha256IsStableOnAllTypes() {
+        hashIsStable("sha256");
+    }
+
+    @Test
+    public void sha384IsStableOnAllTypes() {
+        hashIsStable("sha384");
+    }
+
+    public void hashIsStable(String hashFunc) {
+        final var seed = new Random().nextLong();
+        final var rand = RandomValues.create(new Random(seed));
+        final var randStorables = stream(ValueType.values())
+                .map(t -> rand.nextValueOfType(t).asObject())
+                .toList();
+        final var randMap =
+                range(0, randStorables.size()).boxed().collect(toUnmodifiableMap(i -> "p" + i, randStorables::get));
+
+        // Create node with random property values
+        try (final var tx = db.beginTx()) {
+            final var node = tx.createNode(Label.label("HashFunctionsAreStable"));
+            for (int i = randStorables.size() - 1; i >= 0; --i) {
+                node.setProperty("p" + i, randStorables.get(i));
+            }
+            tx.commit();
+        }
+
+        try (final var tx = db.beginTx()) {
+            for (int i = 0; i < randStorables.size(); ++i) {
+                final var value = randStorables.get(i);
+                final var query =
+                        """
+                        match (n:HashFunctionsAreStable)
+                        return
+                          apoc.util.%s([n.%s]) as hash1,
+                          apoc.util.%s([$value]) as hash2,
+                          apoc.util.%s($list) as hash3
+                        """
+                                .formatted(hashFunc, "p" + i, hashFunc, hashFunc);
+                final var params = Map.of("value", value, "list", List.of(value));
+                assertStableHash(seed, value, tx, query, params);
+            }
+
+            final var mapQuery =
+                    """
+                    match (n:HashFunctionsAreStable)
+                    return
+                      apoc.util.%s([properties(n)]) as hash1,
+                      apoc.util.%s($value) as hash2
+                    """
+                            .formatted(hashFunc, hashFunc);
+            assertStableHash(seed, randMap, tx, mapQuery, Map.of("value", List.of(randMap)));
+
+            final var listCypher = IntStream.range(0, randStorables.size())
+                    .mapToObj(i -> "n.p" + i)
+                    .collect(Collectors.joining(","));
+            final var listQuery =
+                    """
+                match (n:HashFunctionsAreStable)
+                return
+                  apoc.util.%s([%s]) as hash1,
+                  apoc.util.%s($value) as hash2
+                """
+                            .formatted(hashFunc, listCypher, hashFunc);
+            assertStableHash(seed, randStorables, tx, listQuery, Map.of("value", randStorables));
+
+            final var listOfListsQuery =
+                    """
+                match (n:HashFunctionsAreStable)
+                return
+                  apoc.util.%s([[%s]]) as hash1,
+                  apoc.util.%s([$value]) as hash2
+                """
+                            .formatted(hashFunc, listCypher, hashFunc);
+            assertStableHash(seed, randStorables, tx, listOfListsQuery, Map.of("value", randStorables));
+        } finally {
+            db.executeTransactionally("cypher runtime=slotted match (n) detach delete n");
+        }
+    }
+
+    private static void assertStableHash(
+            long seed, Object val, Transaction tx, String query, Map<String, Object> params) {
+        final var a = tx.execute(query, params).stream().toList();
+        final var b = tx.execute(query, params).stream().toList();
+        final var message = "%s should have stable hash (seed=%s)".formatted(val, seed);
+        assertEquals(message, a, b);
+        assertEquals(1, a.size());
+        final var first = a.get(0).entrySet().iterator().next();
+        for (final var e : a.get(0).entrySet()) {
+            assertEquals(message, first.getValue(), e.getValue());
+        }
     }
 
     @Test

--- a/core/src/test/java/apoc/util/UtilsTest.java
+++ b/core/src/test/java/apoc/util/UtilsTest.java
@@ -408,8 +408,7 @@ public class UtilsTest {
                 """
                 match (a:HashFunctionsAreStable)-[r]->(b:HashFunctionsAreStable)
                 return
-                  apoc.util.%s([a, b, r, [a, b, r]]) as hash1,
-                  apoc.util.%s([a, b, r, [a, b, r]]) as hash2
+                  apoc.util.%s([a, b, r, [a, b, r]]) as hash1
                 """.formatted(hashFunc, hashFunc);
             assertStableHash(seed, "nodes and rels", tx, nodesHashQuery, Map.of());
         } finally {


### PR DESCRIPTION
The hash functions are only intended for strings, but unfortunately their signature allows all types. This is a safety for users that use hash functions on non string values despite the documentation.