### PR TITLE
[f3ZUxEG2] Fix bugs and refactor apoc.cypher.runMany

### DIFF
--- a/core/src/main/java/apoc/cypher/Cypher.java
+++ b/core/src/main/java/apoc/cypher/Cypher.java
@@ -18,6 +18,7 @@
  */
 package apoc.cypher;
 
+import static apoc.cypher.Cypher.toMap;
 import static apoc.cypher.CypherUtils.runCypherQuery;
 import static apoc.cypher.CypherUtils.withParamMapping;
 import static apoc.util.MapUtil.map;
@@ -27,18 +28,15 @@ import static org.neo4j.procedure.Mode.WRITE;
 
 import apoc.Pools;
 import apoc.result.MapResult;
-import apoc.util.EntityUtil;
-import apoc.util.QueueBasedSpliterator;
 import apoc.util.Util;
-import java.io.Reader;
+import apoc.util.collection.Iterators;
 import java.io.StringReader;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
+import java.util.Spliterator;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -48,6 +46,7 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.QueryStatistics;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Mode;
@@ -81,92 +80,6 @@ public class Cypher {
         return runCypherQuery(tx, statement, params);
     }
 
-    private Stream<RowResult> runManyStatements(
-            Reader reader,
-            Map<String, Object> params,
-            boolean schemaOperation,
-            boolean addStatistics,
-            int queueCapacity) {
-        BlockingQueue<RowResult> queue = runInSeparateThreadAndSendTombstone(
-                queueCapacity,
-                internalQueue -> {
-                    if (schemaOperation) {
-                        runSchemaStatementsInTx(reader, internalQueue, params, addStatistics);
-                    } else {
-                        runDataStatementsInTx(reader, internalQueue, params, addStatistics);
-                    }
-                },
-                RowResult.TOMBSTONE);
-        return StreamSupport.stream(
-                new QueueBasedSpliterator<>(queue, RowResult.TOMBSTONE, terminationGuard, Integer.MAX_VALUE), false);
-    }
-
-    private <T> BlockingQueue<T> runInSeparateThreadAndSendTombstone(
-            int queueCapacity, Consumer<BlockingQueue<T>> action, T tombstone) {
-        /* NB: this must not be called via an existing thread pool - otherwise we could run into a deadlock
-          other jobs using the same pool might completely exhaust at and the thread sending TOMBSTONE will
-          wait in the pool's job queue.
-        */
-        BlockingQueue<T> queue = new ArrayBlockingQueue<>(queueCapacity);
-        Util.newDaemonThread(() -> {
-                    try {
-                        action.accept(queue);
-                    } finally {
-                        while (true) { // ensure we send TOMBSTONE even if there's an InterruptedException
-                            try {
-                                queue.put(tombstone);
-                                return;
-                            } catch (InterruptedException e) {
-                                Thread.currentThread().interrupt();
-                            }
-                        }
-                    }
-                })
-                .start();
-        return queue;
-    }
-
-    private void runDataStatementsInTx(
-            Reader reader, BlockingQueue<RowResult> queue, Map<String, Object> params, boolean addStatistics) {
-        Scanner scanner = new Scanner(reader);
-        scanner.useDelimiter(";\r?\n");
-        while (scanner.hasNext()) {
-            String stmt = removeShellControlCommands(scanner.next());
-            if (stmt.trim().isEmpty()) continue;
-            if (!isSchemaOperation(stmt)) {
-                if (isPeriodicOperation(stmt)) {
-                    Util.inThread(
-                            pools,
-                            () -> db.executeTransactionally(
-                                    stmt, params, result -> consumeResult(result, queue, addStatistics)));
-                } else {
-                    Util.inTx(db, pools, threadTx -> {
-                        try (Result result = threadTx.execute(stmt, params)) {
-                            return consumeResult(result, queue, addStatistics);
-                        }
-                    });
-                }
-            }
-        }
-    }
-
-    private void runSchemaStatementsInTx(
-            Reader reader, BlockingQueue<RowResult> queue, Map<String, Object> params, boolean addStatistics) {
-        Scanner scanner = new Scanner(reader);
-        scanner.useDelimiter(";\r?\n");
-        while (scanner.hasNext()) {
-            String stmt = removeShellControlCommands(scanner.next());
-            if (stmt.trim().isEmpty()) continue;
-            if (isSchemaOperation(stmt)) {
-                Util.inTx(db, pools, txInThread -> {
-                    try (Result result = txInThread.execute(stmt, params)) {
-                        return consumeResult(result, queue, addStatistics);
-                    }
-                });
-            }
-        }
-    }
-
     @Procedure(name = "apoc.cypher.runMany", mode = WRITE)
     @Description("Runs each semicolon separated statement and returns a summary of the statement outcomes.")
     public Stream<RowResult> runMany(
@@ -174,10 +87,39 @@ public class Cypher {
             @Name("params") Map<String, Object> params,
             @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
         boolean addStatistics = Util.toBoolean(config.getOrDefault("statistics", true));
-        int queueCapacity = Util.toInteger(config.getOrDefault("queueCapacity", 100));
 
-        StringReader stringReader = new StringReader(cypher);
-        return runManyStatements(stringReader, params, false, addStatistics, queueCapacity);
+        return Iterators.stream(new Scanner(new StringReader(cypher)).useDelimiter(";\r?\n"))
+                .map(Cypher::removeShellControlCommands)
+                .filter(s -> !s.isBlank())
+                .flatMap(s -> streamInNewTx(s, params, addStatistics));
+    }
+
+    private Stream<Cypher.RowResult> streamInNewTx(String cypher, Map<String, Object> params, boolean stats) {
+        final var innerTx = db.beginTx();
+        try {
+            // Hello fellow wanderer,
+            // At this point you may have questions like;
+            // - "Why do we execute this statement in a new transaction?"
+            // My guess is as good as yours. This is the way of the apoc. Safe travels.
+            final var results = new RunManyResultSpliterator(innerTx.execute(cypher, params), stats);
+            return StreamSupport.stream(results, false).onClose(results::close).onClose(innerTx::commit);
+        } catch (AuthorizationViolationException accessModeException) {
+            // We meet again, few people make it this far into this world!
+            // I hope you're not still seeking answers, there are few to give.
+            // It has been written, in some long forgotten commits,
+            // that failures of this kind should be avoided. The ancestors
+            // were brave and used a regex based cypher parser to avoid
+            // trying to execute schema changing statements all together.
+            // We don't have that courage, and try to forget about it
+            // after the fact instead.
+            // One can only hope that by keeping this tradition alive,
+            // in some form, we make some poor souls happier.
+            innerTx.close();
+            return Stream.empty();
+        } catch (Throwable t) {
+            innerTx.close();
+            throw t;
+        }
     }
 
     @NotThreadSafe
@@ -193,26 +135,7 @@ public class Cypher {
     private static final Pattern shellControl =
             Pattern.compile("^:?\\b(begin|commit|rollback)\\b", Pattern.CASE_INSENSITIVE);
 
-    private Object consumeResult(Result result, BlockingQueue<RowResult> queue, boolean addStatistics) {
-        try {
-            long time = System.currentTimeMillis();
-            int row = 0;
-            while (result.hasNext()) {
-                terminationGuard.check();
-                Map<String, Object> mapResult = EntityUtil.anyRebind(tx, result.next());
-                queue.put(new RowResult(row++, mapResult));
-            }
-            if (addStatistics) {
-                queue.put(
-                        new RowResult(-1, toMap(result.getQueryStatistics(), System.currentTimeMillis() - time, row)));
-            }
-            return row;
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private String removeShellControlCommands(String stmt) {
+    private static String removeShellControlCommands(String stmt) {
         Matcher matcher = shellControl.matcher(stmt.trim());
         if (matcher.find()) {
             // an empty file get transformed into ":begin\n:commit" and that statement is not matched by the pattern
@@ -222,15 +145,7 @@ public class Cypher {
         return stmt;
     }
 
-    private boolean isSchemaOperation(String stmt) {
-        return stmt.matches("(?is).*(create|drop)\\s+(index|constraint).*");
-    }
-
-    private boolean isPeriodicOperation(String stmt) {
-        return stmt.matches("(?is).*using\\s+periodic.*");
-    }
-
-    private Map<String, Object> toMap(QueryStatistics stats, long time, long rows) {
+    protected static Map<String, Object> toMap(QueryStatistics stats, long time, long rows) {
         final Map<String, Object> map = map(
                 "rows", rows,
                 "time", time);
@@ -253,16 +168,7 @@ public class Cypher {
                 "indexesRemoved", stats.getIndexesRemoved());
     }
 
-    public static class RowResult {
-        public static final RowResult TOMBSTONE = new RowResult(-1, null);
-        public long row;
-        public Map<String, Object> result;
-
-        public RowResult(long row, Map<String, Object> result) {
-            this.row = row;
-            this.result = result;
-        }
-    }
+    public record RowResult(long row, Map<String, Object> result) {}
 
     @Procedure(name = "apoc.cypher.doIt", mode = WRITE)
     @Description(
@@ -357,5 +263,53 @@ public class Cypher {
             @Name(value = "elseQuery", defaultValue = "") String elseQuery,
             @Name(value = "params", defaultValue = "{}") Map<String, Object> params) {
         return whenCase(conditionals, elseQuery, params);
+    }
+}
+
+class RunManyResultSpliterator implements Spliterator<Cypher.RowResult>, AutoCloseable {
+    private final Result result;
+    private final long start;
+    private boolean statistics;
+    private int rowCount;
+
+    RunManyResultSpliterator(Result result, boolean statistics) {
+        this.result = result;
+        this.start = System.currentTimeMillis();
+        this.statistics = statistics;
+    }
+
+    @Override
+    public boolean tryAdvance(Consumer<? super Cypher.RowResult> action) {
+        if (result.hasNext()) {
+            action.accept(new Cypher.RowResult(rowCount++, result.next()));
+            return true;
+        } else if (statistics) {
+            final var stats = toMap(result.getQueryStatistics(), System.currentTimeMillis() - start, rowCount);
+            statistics = false;
+            action.accept(new Cypher.RowResult(-1, stats));
+            return true;
+        }
+        close();
+        return false;
+    }
+
+    @Override
+    public Spliterator<Cypher.RowResult> trySplit() {
+        return null;
+    }
+
+    @Override
+    public long estimateSize() {
+        return result.hasNext() ? Long.MAX_VALUE : 1;
+    }
+
+    @Override
+    public int characteristics() {
+        return Spliterator.ORDERED;
+    }
+
+    @Override
+    public void close() {
+        result.close();
     }
 }


### PR DESCRIPTION
Fixes two issues in `apoc.cypher.runMany`:

- Transactions were accessed from multiple threads, this is not allowed and has undefined behavior (this has always been the case but recently this has started to cause more problems like flaky tests, probably some change in kernel that makes it more sensitive).
- Errors silently stopped the procedure from processing. This was not documented so I assume it was an oversight.

For simplicity, the implementation is changed to be single threaded. We previously spawned a second thread for executing inner queries. While this could have performance benefits in some situations, there is also an overhead of starting and synchronizing threads. We currently have no benchmarks for this procedure so there's not much to base this decision on either way.

Some undocumented behavior is kept from previous implementation:

- Ignore `AuthorizationViolationException` errors silently.
- Run inner statements in new transactions.
