### PR TITLE
[NOID] Upgrade driver used in tests to 5.16.0

### DIFF
--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -177,7 +177,9 @@ Apache-2.0
   netty-3.10.6.Final.jar
   netty-all-4.1.89.Final.jar
   netty-buffer-4.1.101.Final.jar
+  netty-buffer-4.1.104.Final.jar
   netty-codec-4.1.101.Final.jar
+  netty-codec-4.1.104.Final.jar
   netty-codec-dns-4.1.89.Final.jar
   netty-codec-haproxy-4.1.89.Final.jar
   netty-codec-http-4.1.101.Final.jar
@@ -190,15 +192,20 @@ Apache-2.0
   netty-codec-stomp-4.1.89.Final.jar
   netty-codec-xml-4.1.89.Final.jar
   netty-common-4.1.101.Final.jar
+  netty-common-4.1.104.Final.jar
   netty-handler-4.1.101.Final.jar
+  netty-handler-4.1.104.Final.jar
   netty-handler-proxy-4.1.89.Final.jar
   netty-handler-ssl-ocsp-4.1.89.Final.jar
   netty-resolver-4.1.101.Final.jar
+  netty-resolver-4.1.104.Final.jar
   netty-resolver-dns-4.1.89.Final.jar
   netty-resolver-dns-classes-macos-4.1.89.Final.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-aarch_64.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-x86_64.jar
+  netty-tcnative-classes-2.0.61.Final.jar
   netty-transport-4.1.101.Final.jar
+  netty-transport-4.1.104.Final.jar
   netty-transport-classes-epoll-4.1.101.Final.jar
   netty-transport-classes-kqueue-4.1.101.Final.jar
   netty-transport-native-epoll-4.1.101.Final-linux-aarch_64.jar
@@ -207,6 +214,7 @@ Apache-2.0
   netty-transport-native-kqueue-4.1.101.Final-osx-aarch_64.jar
   netty-transport-native-kqueue-4.1.101.Final-osx-x86_64.jar
   netty-transport-native-unix-common-4.1.101.Final.jar
+  netty-transport-native-unix-common-4.1.104.Final.jar
   netty-transport-rxtx-4.1.89.Final.jar
   netty-transport-sctp-4.1.89.Final.jar
   netty-transport-udt-4.1.89.Final.jar
@@ -218,6 +226,7 @@ Apache-2.0
   opentest4j-1.3.0.jar
   picocli-4.7.5.jar
   reactor-core-3.6.0.jar
+  reactor-core-3.6.1.jar
   reload4j-1.2.22.jar
   scala-collection-contrib_2.13-0.3.0.jar
   scala-library-2.13.11.jar

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -207,7 +207,9 @@ Apache-2.0
   netty-3.10.6.Final.jar
   netty-all-4.1.89.Final.jar
   netty-buffer-4.1.101.Final.jar
+  netty-buffer-4.1.104.Final.jar
   netty-codec-4.1.101.Final.jar
+  netty-codec-4.1.104.Final.jar
   netty-codec-dns-4.1.89.Final.jar
   netty-codec-haproxy-4.1.89.Final.jar
   netty-codec-http-4.1.101.Final.jar
@@ -220,15 +222,20 @@ Apache-2.0
   netty-codec-stomp-4.1.89.Final.jar
   netty-codec-xml-4.1.89.Final.jar
   netty-common-4.1.101.Final.jar
+  netty-common-4.1.104.Final.jar
   netty-handler-4.1.101.Final.jar
+  netty-handler-4.1.104.Final.jar
   netty-handler-proxy-4.1.89.Final.jar
   netty-handler-ssl-ocsp-4.1.89.Final.jar
   netty-resolver-4.1.101.Final.jar
+  netty-resolver-4.1.104.Final.jar
   netty-resolver-dns-4.1.89.Final.jar
   netty-resolver-dns-classes-macos-4.1.89.Final.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-aarch_64.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-x86_64.jar
+  netty-tcnative-classes-2.0.61.Final.jar
   netty-transport-4.1.101.Final.jar
+  netty-transport-4.1.104.Final.jar
   netty-transport-classes-epoll-4.1.101.Final.jar
   netty-transport-classes-kqueue-4.1.101.Final.jar
   netty-transport-native-epoll-4.1.101.Final-linux-aarch_64.jar
@@ -237,6 +244,7 @@ Apache-2.0
   netty-transport-native-kqueue-4.1.101.Final-osx-aarch_64.jar
   netty-transport-native-kqueue-4.1.101.Final-osx-x86_64.jar
   netty-transport-native-unix-common-4.1.101.Final.jar
+  netty-transport-native-unix-common-4.1.104.Final.jar
   netty-transport-rxtx-4.1.89.Final.jar
   netty-transport-sctp-4.1.89.Final.jar
   netty-transport-udt-4.1.89.Final.jar
@@ -248,6 +256,7 @@ Apache-2.0
   opentest4j-1.3.0.jar
   picocli-4.7.5.jar
   reactor-core-3.6.0.jar
+  reactor-core-3.6.1.jar
   reload4j-1.2.22.jar
   scala-collection-contrib_2.13-0.3.0.jar
   scala-library-2.13.11.jar

--- a/it/src/test/java/apoc/it/core/CypherEnterpriseTest.java
+++ b/it/src/test/java/apoc/it/core/CypherEnterpriseTest.java
@@ -61,7 +61,7 @@ public class CypherEnterpriseTest {
 
     @After
     public void after() {
-        session.writeTransaction(tx -> tx.run("MATCH (n) DETACH DELETE n"));
+        session.executeWrite(tx -> tx.run("MATCH (n) DETACH DELETE n").consume());
     }
 
     @Test
@@ -85,7 +85,7 @@ public class CypherEnterpriseTest {
         String query = "CALL apoc.cypher.runManyReadOnly($statement, {})";
         Map<String, Object> params = Map.of("statement", SET_AND_RETURN_QUERIES);
 
-        session.writeTransaction(tx -> tx.run(CREATE_RESULT_NODES));
+        session.executeWrite(tx -> tx.run(CREATE_RESULT_NODES).consume());
 
         // even if this procedure is read-only and execute a write operation, it doesn't fail but just skip the
         // statements
@@ -137,7 +137,7 @@ public class CypherEnterpriseTest {
         String query = "CALL apoc.cypher.run($statement, {})";
         Map<String, Object> params = Map.of("statement", SET_NODE);
 
-        session.writeTransaction(tx -> tx.run(CREATE_RESULT_NODES));
+        session.executeWrite(tx -> tx.run(CREATE_RESULT_NODES).consume());
 
         RuntimeException e = assertThrows(RuntimeException.class, () -> testCall(session, query, params, (res) -> {}));
         String expectedMessage =
@@ -154,7 +154,7 @@ public class CypherEnterpriseTest {
     }
 
     private static void testRunSingleStatementProcedureWithResults(String query, Map<String, Object> params) {
-        session.writeTransaction(tx -> tx.run(CREATE_RETURNQUERY_NODES));
+        session.executeWrite(tx -> tx.run(CREATE_RETURNQUERY_NODES).consume());
 
         testResult(session, query, params, r -> {
             Map<String, Object> next = r.next();
@@ -171,7 +171,7 @@ public class CypherEnterpriseTest {
     }
 
     private static void testRunSingleStatementProcedureWithSetAndResults(String query, Map<String, Object> params) {
-        session.writeTransaction(tx -> tx.run(CREATE_RESULT_NODES));
+        session.executeWrite(tx -> tx.run(CREATE_RESULT_NODES).consume());
 
         testResult(session, query, params, r -> {
             Map<String, Object> next = r.next();

--- a/it/src/test/java/apoc/it/core/ExportCsvIT.java
+++ b/it/src/test/java/apoc/it/core/ExportCsvIT.java
@@ -64,8 +64,8 @@ public class ExportCsvIT {
                 + "This article is distributed by The American Society for Cell Biology under license from the author(s). Two months after publication it is available to the public under an Attribution-Noncommercial-Share Alike 3.0 Unported Creative Commons License.\n"
                 + "\n";
         String pk = "5921569";
-        session.writeTransaction(tx ->
-                tx.run("CREATE (n:Document{pk:$pk, copyright: $copyright})", map("copyright", copyright, "pk", pk)));
+        session.executeWrite(tx ->
+                tx.run("CREATE (n:Document{pk:$pk, copyright: $copyright})", map("copyright", copyright, "pk", pk)).consume());
         String query = "MATCH (n:Document{pk:'5921569'}) return n.pk as pk, n.copyright as copyright";
         testCall(
                 session,
@@ -77,6 +77,6 @@ public class ExportCsvIT {
                     assertArrayEquals(new String[] {"pk", "copyright"}, csv.get(0));
                     assertArrayEquals(new String[] {"5921569", copyright}, csv.get(1));
                 });
-        session.writeTransaction(tx -> tx.run("MATCH (d:Document) DETACH DELETE d"));
+        session.executeWrite(tx -> tx.run("MATCH (d:Document) DETACH DELETE d").consume());
     }
 }

--- a/it/src/test/java/apoc/it/core/GraphRefactoringEnterpriseTest.java
+++ b/it/src/test/java/apoc/it/core/GraphRefactoringEnterpriseTest.java
@@ -76,42 +76,42 @@ public class GraphRefactoringEnterpriseTest {
 
     @Test
     public void testExtractNodesWithNodeKeyConstraint() {
-        session.writeTransaction(tx -> tx.run(CREATE_REL_FOR_EXTRACT_NODE));
+        session.executeWrite(tx -> tx.run(CREATE_REL_FOR_EXTRACT_NODE).consume());
         nodeKeyCommons(EXTRACT_QUERY);
-        session.writeTransaction(tx -> tx.run(DELETE_REL_FOR_EXTRACT_NODE));
+        session.executeWrite(tx -> tx.run(DELETE_REL_FOR_EXTRACT_NODE).consume());
     }
 
     @Test
     public void testExtractNodesWithBothExistenceAndUniqueConstraint() {
-        session.writeTransaction(tx -> tx.run(CREATE_REL_FOR_EXTRACT_NODE));
+        session.executeWrite(tx -> tx.run(CREATE_REL_FOR_EXTRACT_NODE).consume());
         uniqueNotNullCommons(EXTRACT_QUERY);
-        session.writeTransaction(tx -> tx.run(DELETE_REL_FOR_EXTRACT_NODE));
+        session.executeWrite(tx -> tx.run(DELETE_REL_FOR_EXTRACT_NODE).consume());
     }
 
     private void nodeKeyCommons(String query) {
-        session.writeTransaction(
-                tx -> tx.run("CREATE CONSTRAINT nodeKey FOR (p:MyBook) REQUIRE (p.name, p.surname) IS NODE KEY"));
+        session.executeWrite(
+                tx -> tx.run("CREATE CONSTRAINT nodeKey FOR (p:MyBook) REQUIRE (p.name, p.surname) IS NODE KEY").consume());
         cloneNodesAssertions(
                 query, "already exists with label `MyBook` and properties `name` = 'foobar', `surname` = 'baz'");
-        session.writeTransaction(tx -> tx.run("DROP CONSTRAINT nodeKey"));
+        session.executeWrite(tx -> tx.run("DROP CONSTRAINT nodeKey").consume());
     }
 
     private void uniqueNotNullCommons(String query) {
-        session.writeTransaction(tx -> tx.run("CREATE CONSTRAINT unique FOR (p:MyBook) REQUIRE (p.name) IS UNIQUE"));
-        session.writeTransaction(tx -> tx.run("CREATE CONSTRAINT notNull FOR (p:MyBook) REQUIRE (p.name) IS NOT NULL"));
+        session.executeWrite(tx -> tx.run("CREATE CONSTRAINT unique FOR (p:MyBook) REQUIRE (p.name) IS UNIQUE").consume());
+        session.executeWrite(tx -> tx.run("CREATE CONSTRAINT notNull FOR (p:MyBook) REQUIRE (p.name) IS NOT NULL").consume());
 
         cloneNodesAssertions(query, "already exists with label `MyBook` and property `name` = 'foobar'");
-        session.writeTransaction(tx -> tx.run("DROP CONSTRAINT unique"));
-        session.writeTransaction(tx -> tx.run("DROP CONSTRAINT notNull"));
+        session.executeWrite(tx -> tx.run("DROP CONSTRAINT unique").consume());
+        session.executeWrite(tx -> tx.run("DROP CONSTRAINT notNull").consume());
     }
 
     private void cloneNodesAssertions(String query, String message) {
-        session.writeTransaction(tx -> tx.run("CREATE (n:MyBook {name: 'foobar', surname: 'baz'})"));
+        session.executeWrite(tx -> tx.run("CREATE (n:MyBook {name: 'foobar', surname: 'baz'})").consume());
         testCall(session, query, r -> {
             final String error = (String) r.get("error");
             assertTrue(error.contains(message));
             assertNull(r.get("output"));
         });
-        session.writeTransaction(tx -> tx.run("MATCH (n:MyBook) DELETE n"));
+        session.executeWrite(tx -> tx.run("MATCH (n:MyBook) DELETE n").consume());
     }
 }

--- a/it/src/test/java/apoc/it/core/TriggerEnterpriseFeaturesTest.java
+++ b/it/src/test/java/apoc/it/core/TriggerEnterpriseFeaturesTest.java
@@ -93,7 +93,7 @@ public class TriggerEnterpriseFeaturesTest {
         assertTrue(neo4jContainer.isRunning());
 
         try (Session sysSession = neo4jContainer.getDriver().session(forDatabase(SYSTEM_DATABASE_NAME))) {
-            sysSession.writeTransaction(tx -> tx.run(String.format("CREATE DATABASE %s WAIT;", FOO_DB)));
+            sysSession.executeWrite(tx -> tx.run(String.format("CREATE DATABASE %s WAIT;", FOO_DB)).consume());
 
             sysSession.run(String.format(
                     "CREATE USER %s SET PASSWORD '%s' SET PASSWORD CHANGE NOT REQUIRED", NO_ADMIN_USER, NO_ADMIN_PWD));
@@ -200,7 +200,7 @@ public class TriggerEnterpriseFeaturesTest {
             final String dbToDelete = "todelete";
 
             // create database with name `todelete`
-            sysSession.writeTransaction(tx -> tx.run(String.format("CREATE DATABASE %s WAIT;", dbToDelete)));
+            sysSession.executeWrite(tx -> tx.run(String.format("CREATE DATABASE %s WAIT;", dbToDelete)).consume());
 
             testDeleteTriggerAfterDropDb(dbToDelete, sysSession);
         }
@@ -244,7 +244,7 @@ public class TriggerEnterpriseFeaturesTest {
                 r -> assertEquals(defaultTriggerName, r.get("name")));
 
         // drop database
-        sysSession.writeTransaction(tx -> tx.run(String.format("DROP DATABASE %s WAIT;", dbToDelete)));
+        sysSession.executeWrite(tx -> tx.run(String.format("DROP DATABASE %s WAIT;", dbToDelete)).consume());
 
         // check that the trigger has been removed
         testCallEmpty(sysSession, "CALL apoc.trigger.show($dbName)", Map.of("dbName", dbToDelete));
@@ -256,13 +256,13 @@ public class TriggerEnterpriseFeaturesTest {
 
         // create a node in the Neo4j db that looks like a trigger
         try (Session defaultSession = session(DEFAULT_DATABASE_NAME)) {
-            defaultSession.writeTransaction(tx -> tx.run(
-                    String.format("CREATE (:%s {%s:'%s'})", SystemLabels.ApocTrigger, database.name(), dbToDelete)));
+            defaultSession.executeWrite(tx -> tx.run(
+                    String.format("CREATE (:%s {%s:'%s'})", SystemLabels.ApocTrigger, database.name(), dbToDelete)).consume());
         }
 
         try (Session sysSession = session(SYSTEM_DATABASE_NAME)) {
             // create database with name `todelete`
-            sysSession.writeTransaction(tx -> tx.run(String.format("CREATE DATABASE %s WAIT;", dbToDelete)));
+            sysSession.executeWrite(tx -> tx.run(String.format("CREATE DATABASE %s WAIT;", dbToDelete)).consume());
 
             // install a trigger for the database
             final String defaultTriggerName = UUID.randomUUID().toString();
@@ -273,7 +273,7 @@ public class TriggerEnterpriseFeaturesTest {
                     r -> assertEquals(defaultTriggerName, r.get("name")));
 
             // drop database
-            sysSession.writeTransaction(tx -> tx.run(String.format("DROP DATABASE %s WAIT;", dbToDelete)));
+            sysSession.executeWrite(tx -> tx.run(String.format("DROP DATABASE %s WAIT;", dbToDelete)).consume());
         }
 
         // check that the node in Neo4j database is still there

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     api group: 'org.hamcrest', name: 'hamcrest-library', version: '2.2'
     api group: 'org.neo4j.community', name: 'it-test-support', version: neo4jVersionEffective // , classifier: "tests"
     api group: 'org.neo4j', name: 'log-test-utils', version: neo4jVersionEffective // , classifier: "tests"
-    api group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.4.12'
+    api group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '5.16.0'
     api group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.6', withoutServers.andThen(withoutLoggers)
     // If updated check if the transitive dependency to javax.servlet.jsp:jsp-api:2.1 has also updated
     // and remove the manual licensing check for it in licenses-3rdparties.gradle

--- a/test-utils/src/main/java/apoc/cypher/CypherTestUtil.java
+++ b/test-utils/src/main/java/apoc/cypher/CypherTestUtil.java
@@ -65,18 +65,17 @@ public class CypherTestUtil {
 
     public static void testRunProcedureWithSimpleReturnResults(
             Session session, String query, Map<String, Object> params) {
-        session.writeTransaction(tx -> tx.run(CREATE_RETURNQUERY_NODES));
+        session.executeWrite(tx -> tx.run(CREATE_RETURNQUERY_NODES).consume());
         // Due to flaky tests, this is a debug section to see if we can
         // figure out a reason why the results aren't always returning the
         // entire result set.
-        session.readTransaction(tx -> {
+        session.executeRead(tx -> {
             List<Record> result = tx.run("MATCH (n:ReturnQuery) RETURN n.id").list();
             System.out.println("DEBUG: testRunProcedureWithSimpleReturnResults");
             System.out.println("DEBUG: " + result.size());
             for (Record r : result) {
                 System.out.println("DEBUG: " + r);
             }
-            tx.commit();
             return null;
         });
         testResult(session, query, params, r -> {
@@ -123,7 +122,7 @@ public class CypherTestUtil {
     // placed in test-utils because is used by extended as well
     public static void testRunProcedureWithSetAndReturnResults(
             Session session, String query, Map<String, Object> params) {
-        session.writeTransaction(tx -> tx.run(CREATE_RESULT_NODES));
+        session.executeWrite(tx -> tx.run(CREATE_RESULT_NODES).consume());
 
         testResult(session, query, params, r -> {
             // check that all results from the 1st statement are correctly returned

--- a/test-utils/src/main/java/apoc/util/TestContainerUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestContainerUtil.java
@@ -277,13 +277,12 @@ public class TestContainerUtil {
             String call,
             Map<String, Object> params,
             Consumer<Iterator<Map<String, Object>>> resultConsumer) {
-        session.writeTransaction(tx -> {
+        session.executeWrite(tx -> {
             Map<String, Object> p = (params == null) ? Collections.<String, Object>emptyMap() : params;
             resultConsumer.accept(tx.run(call, p).list().stream()
                     .map(Record::asMap)
                     .collect(Collectors.toList())
                     .iterator());
-            tx.commit();
             return null;
         });
     }
@@ -314,13 +313,12 @@ public class TestContainerUtil {
             String call,
             Map<String, Object> params,
             Consumer<Iterator<Map<String, Object>>> resultConsumer) {
-        session.readTransaction(tx -> {
+        session.executeRead(tx -> {
             Map<String, Object> p = (params == null) ? Collections.<String, Object>emptyMap() : params;
             resultConsumer.accept(tx.run(call, p).list().stream()
                     .map(Record::asMap)
                     .collect(Collectors.toList())
                     .iterator());
-            tx.commit();
             return null;
         });
     }


### PR DESCRIPTION
Updates the java-driver dependency used in the ITs to the latest currently (from `4.4.12` -> `5.16.0`).

There have been some [additional checks](https://neo4j.com/docs/java-manual/current/session-api/#java-driver-simple-result-consume) added in the 5.x series of the driver. This PR also migrates some usages of the driver from the deprecated `writeTransaction()` to `executeWrite()`.