### PR TITLE
[4Bece3wd] Use Neo4j home to determine default config location.

### DIFF
--- a/common/src/test/java/apoc/ApocConfigCommandExpansionTest.java
+++ b/common/src/test/java/apoc/ApocConfigCommandExpansionTest.java
@@ -41,6 +41,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Collections;
 import java.util.Set;
@@ -74,6 +75,7 @@ public class ApocConfigCommandExpansionTest {
         when(neo4jConfig.get(any())).thenReturn(null);
         when(neo4jConfig.get(GraphDatabaseSettings.allow_file_urls)).thenReturn(false);
         when(neo4jConfig.expandCommands()).thenReturn(true);
+        when(neo4jConfig.get(GraphDatabaseSettings.neo4j_home)).thenReturn(Path.of("C:/neo4j/neo4j-enterprise-5.x.0"));
 
         apocConfigCommandExpansionFile = new File(getClass()
                 .getClassLoader()
@@ -150,6 +152,7 @@ public class ApocConfigCommandExpansionTest {
         when(neo4jConfig.getDeclaredSettings()).thenReturn(Collections.emptyMap());
         when(neo4jConfig.get(any())).thenReturn(null);
         when(neo4jConfig.expandCommands()).thenReturn(false);
+        when(neo4jConfig.get(GraphDatabaseSettings.neo4j_home)).thenReturn(Path.of("C:/neo4j/neo4j-enterprise-5.x.0"));
 
         GlobalProceduresRegistry registry = mock(GlobalProceduresRegistry.class);
         DatabaseManagementService databaseManagementService = mock(DatabaseManagementService.class);
@@ -173,6 +176,7 @@ public class ApocConfigCommandExpansionTest {
         when(neo4jConfig.getDeclaredSettings()).thenReturn(Collections.emptyMap());
         when(neo4jConfig.get(any())).thenReturn(null);
         when(neo4jConfig.expandCommands()).thenReturn(false);
+        when(neo4jConfig.get(GraphDatabaseSettings.neo4j_home)).thenReturn(Path.of("C:/neo4j/neo4j-enterprise-5.x.0"));
 
         GlobalProceduresRegistry registry = mock(GlobalProceduresRegistry.class);
         DatabaseManagementService databaseManagementService = mock(DatabaseManagementService.class);

--- a/common/src/test/java/apoc/ApocConfigTest.java
+++ b/common/src/test/java/apoc/ApocConfigTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,6 +50,7 @@ public class ApocConfigTest {
         when(neo4jConfig.getDeclaredSettings()).thenReturn(Collections.emptyMap());
         when(neo4jConfig.get(any())).thenReturn(null);
         when(neo4jConfig.get(GraphDatabaseSettings.allow_file_urls)).thenReturn(false);
+        when(neo4jConfig.get(GraphDatabaseSettings.neo4j_home)).thenReturn(Path.of("C:/neo4j/neo4j-enterprise-5.x.0"));
 
         apocConfigFile =
                 new File(getClass().getClassLoader().getResource("apoc.conf").toURI());
@@ -69,7 +71,7 @@ public class ApocConfigTest {
     @Test
     public void testDetermineNeo4jConfFolderDefault() {
         System.setProperty(SUN_JAVA_COMMAND, "");
-        assertEquals(".", apocConfig.determineNeo4jConfFolder());
+        assertEquals("C:/neo4j/neo4j-enterprise-5.x.0/conf", apocConfig.determineNeo4jConfFolder());
     }
 
     @Test


### PR DESCRIPTION
On Windows service, 'sun.java.command' is not supported. The fallback default path to the config folder was set to '.' which is not the actual default. With this solution, the home folder of Neo4j is instead used to calculate the default.

In order to get it to work when both APOC Core and Extended is installed, I reckon the same change should also be applied to [extended/src/main/java/apoc/ExtendedApocConfig.java](https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/dev/extended/src/main/java/apoc/ExtendedApocConfig.java)