### PR TITLE
[NOID] Remove commons math3

### DIFF
--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -18,7 +18,7 @@ Apache-2.0
   arrow-memory-netty-15.0.0.jar
   arrow-vector-13.0.0.jar
   arrow-vector-15.0.0.jar
-  assertj-core-3.25.1.jar
+  assertj-core-3.25.3.jar
   audience-annotations-0.5.0.jar
   avro-1.7.7.jar
   awaitility-4.2.0.jar
@@ -26,7 +26,7 @@ Apache-2.0
   aws-java-sdk-kms-1.12.643.jar
   aws-java-sdk-s3-1.12.643.jar
   byte-buddy-1.14.11.jar
-  byte-buddy-agent-1.14.10.jar
+  byte-buddy-agent-1.14.11.jar
   caffeine-3.1.8.jar
   cassandra-driver-core-3.10.0.jar
   commons-beanutils-1.9.4.jar
@@ -43,7 +43,7 @@ Apache-2.0
   commons-io-2.15.1.jar
   commons-lang3-3.14.0.jar
   commons-logging-1.2.jar
-  commons-math3-3.6.1.jar
+  commons-math3-3.1.1.jar
   commons-net-3.9.0.jar
   commons-text-1.10.0.jar
   commons-text-1.11.0.jar
@@ -102,7 +102,7 @@ Apache-2.0
   httpclient-4.5.13.jar
   httpcore-4.4.13.jar
   ipaddress-5.3.3.jar
-  ipaddress-5.4.0.jar
+  ipaddress-5.4.2.jar
   j2objc-annotations-1.1.jar
   j2objc-annotations-2.8.jar
   jPowerShell-3.0.jar
@@ -180,11 +180,11 @@ Apache-2.0
   metrics-core-3.2.4.jar
   netty-3.10.6.Final.jar
   netty-all-4.1.89.Final.jar
-  netty-buffer-4.1.105.Final.jar
-  netty-codec-4.1.105.Final.jar
+  netty-buffer-4.1.106.Final.jar
+  netty-codec-4.1.106.Final.jar
   netty-codec-dns-4.1.89.Final.jar
   netty-codec-haproxy-4.1.89.Final.jar
-  netty-codec-http-4.1.105.Final.jar
+  netty-codec-http-4.1.106.Final.jar
   netty-codec-http2-4.1.89.Final.jar
   netty-codec-memcache-4.1.89.Final.jar
   netty-codec-mqtt-4.1.89.Final.jar
@@ -193,25 +193,25 @@ Apache-2.0
   netty-codec-socks-4.1.89.Final.jar
   netty-codec-stomp-4.1.89.Final.jar
   netty-codec-xml-4.1.89.Final.jar
-  netty-common-4.1.105.Final.jar
-  netty-handler-4.1.105.Final.jar
+  netty-common-4.1.106.Final.jar
+  netty-handler-4.1.106.Final.jar
   netty-handler-proxy-4.1.89.Final.jar
   netty-handler-ssl-ocsp-4.1.89.Final.jar
-  netty-resolver-4.1.105.Final.jar
+  netty-resolver-4.1.106.Final.jar
   netty-resolver-dns-4.1.89.Final.jar
   netty-resolver-dns-classes-macos-4.1.89.Final.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-aarch_64.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-x86_64.jar
   netty-tcnative-classes-2.0.61.Final.jar
-  netty-transport-4.1.105.Final.jar
-  netty-transport-classes-epoll-4.1.105.Final.jar
-  netty-transport-classes-kqueue-4.1.105.Final.jar
-  netty-transport-native-epoll-4.1.105.Final-linux-aarch_64.jar
-  netty-transport-native-epoll-4.1.105.Final-linux-x86_64.jar
-  netty-transport-native-epoll-4.1.105.Final.jar
-  netty-transport-native-kqueue-4.1.105.Final-osx-aarch_64.jar
-  netty-transport-native-kqueue-4.1.105.Final-osx-x86_64.jar
-  netty-transport-native-unix-common-4.1.105.Final.jar
+  netty-transport-4.1.106.Final.jar
+  netty-transport-classes-epoll-4.1.106.Final.jar
+  netty-transport-classes-kqueue-4.1.106.Final.jar
+  netty-transport-native-epoll-4.1.106.Final-linux-aarch_64.jar
+  netty-transport-native-epoll-4.1.106.Final-linux-x86_64.jar
+  netty-transport-native-epoll-4.1.106.Final.jar
+  netty-transport-native-kqueue-4.1.106.Final-osx-aarch_64.jar
+  netty-transport-native-kqueue-4.1.106.Final-osx-x86_64.jar
+  netty-transport-native-unix-common-4.1.106.Final.jar
   netty-transport-rxtx-4.1.89.Final.jar
   netty-transport-sctp-4.1.89.Final.jar
   netty-transport-udt-4.1.89.Final.jar
@@ -222,7 +222,7 @@ Apache-2.0
   opencsv-5.7.1.jar
   opentest4j-1.3.0.jar
   picocli-4.7.5.jar
-  reactor-core-3.6.1.jar
+  reactor-core-3.6.2.jar
   reload4j-1.2.22.jar
   scala-collection-contrib_2.13-0.3.0.jar
   scala-library-2.13.11.jar
@@ -1875,14 +1875,14 @@ Eclipse Public License - v 2.0
   jersey-container-servlet-core-2.34.jar
   jersey-hk2-2.34.jar
   jersey-server-2.34.jar
-  junit-jupiter-5.10.1.jar
-  junit-jupiter-api-5.10.1.jar
-  junit-jupiter-engine-5.10.1.jar
-  junit-jupiter-params-5.10.1.jar
-  junit-platform-commons-1.10.1.jar
-  junit-platform-engine-1.10.1.jar
-  junit-platform-launcher-1.10.1.jar
-  junit-platform-testkit-1.10.1.jar
+  junit-jupiter-5.10.2.jar
+  junit-jupiter-api-5.10.2.jar
+  junit-jupiter-engine-5.10.2.jar
+  junit-jupiter-params-5.10.2.jar
+  junit-platform-commons-1.10.2.jar
+  junit-platform-engine-1.10.2.jar
+  junit-platform-launcher-1.10.2.jar
+  junit-platform-testkit-1.10.2.jar
   osgi-resource-locator-1.0.3.jar
 ------------------------------------------------------------------------------
 
@@ -2582,7 +2582,7 @@ MIT
   jersey-hk2-2.34.jar
   jnr-x86asm-1.0.2.jar
   localstack-1.19.1.jar
-  mockito-core-5.8.0.jar
+  mockito-core-5.10.0.jar
   mssql-jdbc-6.2.1.jre7.jar
   mysql-1.19.1.jar
   neo4j-1.19.1.jar

--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -18,7 +18,7 @@ Apache-2.0
   arrow-memory-netty-15.0.0.jar
   arrow-vector-13.0.0.jar
   arrow-vector-15.0.0.jar
-  assertj-core-3.25.3.jar
+  assertj-core-3.25.1.jar
   audience-annotations-0.5.0.jar
   avro-1.7.7.jar
   awaitility-4.2.0.jar
@@ -26,7 +26,7 @@ Apache-2.0
   aws-java-sdk-kms-1.12.643.jar
   aws-java-sdk-s3-1.12.643.jar
   byte-buddy-1.14.11.jar
-  byte-buddy-agent-1.14.11.jar
+  byte-buddy-agent-1.14.10.jar
   caffeine-3.1.8.jar
   cassandra-driver-core-3.10.0.jar
   commons-beanutils-1.9.4.jar
@@ -102,7 +102,7 @@ Apache-2.0
   httpclient-4.5.13.jar
   httpcore-4.4.13.jar
   ipaddress-5.3.3.jar
-  ipaddress-5.4.2.jar
+  ipaddress-5.4.0.jar
   j2objc-annotations-1.1.jar
   j2objc-annotations-2.8.jar
   jPowerShell-3.0.jar
@@ -180,11 +180,11 @@ Apache-2.0
   metrics-core-3.2.4.jar
   netty-3.10.6.Final.jar
   netty-all-4.1.89.Final.jar
-  netty-buffer-4.1.106.Final.jar
-  netty-codec-4.1.106.Final.jar
+  netty-buffer-4.1.105.Final.jar
+  netty-codec-4.1.105.Final.jar
   netty-codec-dns-4.1.89.Final.jar
   netty-codec-haproxy-4.1.89.Final.jar
-  netty-codec-http-4.1.106.Final.jar
+  netty-codec-http-4.1.105.Final.jar
   netty-codec-http2-4.1.89.Final.jar
   netty-codec-memcache-4.1.89.Final.jar
   netty-codec-mqtt-4.1.89.Final.jar
@@ -193,25 +193,25 @@ Apache-2.0
   netty-codec-socks-4.1.89.Final.jar
   netty-codec-stomp-4.1.89.Final.jar
   netty-codec-xml-4.1.89.Final.jar
-  netty-common-4.1.106.Final.jar
-  netty-handler-4.1.106.Final.jar
+  netty-common-4.1.105.Final.jar
+  netty-handler-4.1.105.Final.jar
   netty-handler-proxy-4.1.89.Final.jar
   netty-handler-ssl-ocsp-4.1.89.Final.jar
-  netty-resolver-4.1.106.Final.jar
+  netty-resolver-4.1.105.Final.jar
   netty-resolver-dns-4.1.89.Final.jar
   netty-resolver-dns-classes-macos-4.1.89.Final.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-aarch_64.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-x86_64.jar
   netty-tcnative-classes-2.0.61.Final.jar
-  netty-transport-4.1.106.Final.jar
-  netty-transport-classes-epoll-4.1.106.Final.jar
-  netty-transport-classes-kqueue-4.1.106.Final.jar
-  netty-transport-native-epoll-4.1.106.Final-linux-aarch_64.jar
-  netty-transport-native-epoll-4.1.106.Final-linux-x86_64.jar
-  netty-transport-native-epoll-4.1.106.Final.jar
-  netty-transport-native-kqueue-4.1.106.Final-osx-aarch_64.jar
-  netty-transport-native-kqueue-4.1.106.Final-osx-x86_64.jar
-  netty-transport-native-unix-common-4.1.106.Final.jar
+  netty-transport-4.1.105.Final.jar
+  netty-transport-classes-epoll-4.1.105.Final.jar
+  netty-transport-classes-kqueue-4.1.105.Final.jar
+  netty-transport-native-epoll-4.1.105.Final-linux-aarch_64.jar
+  netty-transport-native-epoll-4.1.105.Final-linux-x86_64.jar
+  netty-transport-native-epoll-4.1.105.Final.jar
+  netty-transport-native-kqueue-4.1.105.Final-osx-aarch_64.jar
+  netty-transport-native-kqueue-4.1.105.Final-osx-x86_64.jar
+  netty-transport-native-unix-common-4.1.105.Final.jar
   netty-transport-rxtx-4.1.89.Final.jar
   netty-transport-sctp-4.1.89.Final.jar
   netty-transport-udt-4.1.89.Final.jar
@@ -222,7 +222,7 @@ Apache-2.0
   opencsv-5.7.1.jar
   opentest4j-1.3.0.jar
   picocli-4.7.5.jar
-  reactor-core-3.6.2.jar
+  reactor-core-3.6.1.jar
   reload4j-1.2.22.jar
   scala-collection-contrib_2.13-0.3.0.jar
   scala-library-2.13.11.jar
@@ -1875,14 +1875,14 @@ Eclipse Public License - v 2.0
   jersey-container-servlet-core-2.34.jar
   jersey-hk2-2.34.jar
   jersey-server-2.34.jar
-  junit-jupiter-5.10.2.jar
-  junit-jupiter-api-5.10.2.jar
-  junit-jupiter-engine-5.10.2.jar
-  junit-jupiter-params-5.10.2.jar
-  junit-platform-commons-1.10.2.jar
-  junit-platform-engine-1.10.2.jar
-  junit-platform-launcher-1.10.2.jar
-  junit-platform-testkit-1.10.2.jar
+  junit-jupiter-5.10.1.jar
+  junit-jupiter-api-5.10.1.jar
+  junit-jupiter-engine-5.10.1.jar
+  junit-jupiter-params-5.10.1.jar
+  junit-platform-commons-1.10.1.jar
+  junit-platform-engine-1.10.1.jar
+  junit-platform-launcher-1.10.1.jar
+  junit-platform-testkit-1.10.1.jar
   osgi-resource-locator-1.0.3.jar
 ------------------------------------------------------------------------------
 
@@ -2582,7 +2582,7 @@ MIT
   jersey-hk2-2.34.jar
   jnr-x86asm-1.0.2.jar
   localstack-1.19.1.jar
-  mockito-core-5.10.0.jar
+  mockito-core-5.8.0.jar
   mssql-jdbc-6.2.1.jre7.jar
   mysql-1.19.1.jar
   neo4j-1.19.1.jar

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -48,7 +48,7 @@ Apache-2.0
   arrow-memory-netty-15.0.0.jar
   arrow-vector-13.0.0.jar
   arrow-vector-15.0.0.jar
-  assertj-core-3.25.3.jar
+  assertj-core-3.25.1.jar
   audience-annotations-0.5.0.jar
   avro-1.7.7.jar
   awaitility-4.2.0.jar
@@ -56,7 +56,7 @@ Apache-2.0
   aws-java-sdk-kms-1.12.643.jar
   aws-java-sdk-s3-1.12.643.jar
   byte-buddy-1.14.11.jar
-  byte-buddy-agent-1.14.11.jar
+  byte-buddy-agent-1.14.10.jar
   caffeine-3.1.8.jar
   cassandra-driver-core-3.10.0.jar
   commons-beanutils-1.9.4.jar
@@ -132,7 +132,7 @@ Apache-2.0
   httpclient-4.5.13.jar
   httpcore-4.4.13.jar
   ipaddress-5.3.3.jar
-  ipaddress-5.4.2.jar
+  ipaddress-5.4.0.jar
   j2objc-annotations-1.1.jar
   j2objc-annotations-2.8.jar
   jPowerShell-3.0.jar
@@ -210,11 +210,11 @@ Apache-2.0
   metrics-core-3.2.4.jar
   netty-3.10.6.Final.jar
   netty-all-4.1.89.Final.jar
-  netty-buffer-4.1.106.Final.jar
-  netty-codec-4.1.106.Final.jar
+  netty-buffer-4.1.105.Final.jar
+  netty-codec-4.1.105.Final.jar
   netty-codec-dns-4.1.89.Final.jar
   netty-codec-haproxy-4.1.89.Final.jar
-  netty-codec-http-4.1.106.Final.jar
+  netty-codec-http-4.1.105.Final.jar
   netty-codec-http2-4.1.89.Final.jar
   netty-codec-memcache-4.1.89.Final.jar
   netty-codec-mqtt-4.1.89.Final.jar
@@ -223,25 +223,25 @@ Apache-2.0
   netty-codec-socks-4.1.89.Final.jar
   netty-codec-stomp-4.1.89.Final.jar
   netty-codec-xml-4.1.89.Final.jar
-  netty-common-4.1.106.Final.jar
-  netty-handler-4.1.106.Final.jar
+  netty-common-4.1.105.Final.jar
+  netty-handler-4.1.105.Final.jar
   netty-handler-proxy-4.1.89.Final.jar
   netty-handler-ssl-ocsp-4.1.89.Final.jar
-  netty-resolver-4.1.106.Final.jar
+  netty-resolver-4.1.105.Final.jar
   netty-resolver-dns-4.1.89.Final.jar
   netty-resolver-dns-classes-macos-4.1.89.Final.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-aarch_64.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-x86_64.jar
   netty-tcnative-classes-2.0.61.Final.jar
-  netty-transport-4.1.106.Final.jar
-  netty-transport-classes-epoll-4.1.106.Final.jar
-  netty-transport-classes-kqueue-4.1.106.Final.jar
-  netty-transport-native-epoll-4.1.106.Final-linux-aarch_64.jar
-  netty-transport-native-epoll-4.1.106.Final-linux-x86_64.jar
-  netty-transport-native-epoll-4.1.106.Final.jar
-  netty-transport-native-kqueue-4.1.106.Final-osx-aarch_64.jar
-  netty-transport-native-kqueue-4.1.106.Final-osx-x86_64.jar
-  netty-transport-native-unix-common-4.1.106.Final.jar
+  netty-transport-4.1.105.Final.jar
+  netty-transport-classes-epoll-4.1.105.Final.jar
+  netty-transport-classes-kqueue-4.1.105.Final.jar
+  netty-transport-native-epoll-4.1.105.Final-linux-aarch_64.jar
+  netty-transport-native-epoll-4.1.105.Final-linux-x86_64.jar
+  netty-transport-native-epoll-4.1.105.Final.jar
+  netty-transport-native-kqueue-4.1.105.Final-osx-aarch_64.jar
+  netty-transport-native-kqueue-4.1.105.Final-osx-x86_64.jar
+  netty-transport-native-unix-common-4.1.105.Final.jar
   netty-transport-rxtx-4.1.89.Final.jar
   netty-transport-sctp-4.1.89.Final.jar
   netty-transport-udt-4.1.89.Final.jar
@@ -252,7 +252,7 @@ Apache-2.0
   opencsv-5.7.1.jar
   opentest4j-1.3.0.jar
   picocli-4.7.5.jar
-  reactor-core-3.6.2.jar
+  reactor-core-3.6.1.jar
   reload4j-1.2.22.jar
   scala-collection-contrib_2.13-0.3.0.jar
   scala-library-2.13.11.jar
@@ -382,14 +382,14 @@ Eclipse Public License - v 2.0
   jersey-container-servlet-core-2.34.jar
   jersey-hk2-2.34.jar
   jersey-server-2.34.jar
-  junit-jupiter-5.10.2.jar
-  junit-jupiter-api-5.10.2.jar
-  junit-jupiter-engine-5.10.2.jar
-  junit-jupiter-params-5.10.2.jar
-  junit-platform-commons-1.10.2.jar
-  junit-platform-engine-1.10.2.jar
-  junit-platform-launcher-1.10.2.jar
-  junit-platform-testkit-1.10.2.jar
+  junit-jupiter-5.10.1.jar
+  junit-jupiter-api-5.10.1.jar
+  junit-jupiter-engine-5.10.1.jar
+  junit-jupiter-params-5.10.1.jar
+  junit-platform-commons-1.10.1.jar
+  junit-platform-engine-1.10.1.jar
+  junit-platform-launcher-1.10.1.jar
+  junit-platform-testkit-1.10.1.jar
   osgi-resource-locator-1.0.3.jar
 
 GNU General Public License (GPL), version 2, with the Classpath exception
@@ -450,7 +450,7 @@ MIT
   jersey-hk2-2.34.jar
   jnr-x86asm-1.0.2.jar
   localstack-1.19.1.jar
-  mockito-core-5.10.0.jar
+  mockito-core-5.8.0.jar
   mssql-jdbc-6.2.1.jre7.jar
   mysql-1.19.1.jar
   neo4j-1.19.1.jar

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -48,7 +48,7 @@ Apache-2.0
   arrow-memory-netty-15.0.0.jar
   arrow-vector-13.0.0.jar
   arrow-vector-15.0.0.jar
-  assertj-core-3.25.1.jar
+  assertj-core-3.25.3.jar
   audience-annotations-0.5.0.jar
   avro-1.7.7.jar
   awaitility-4.2.0.jar
@@ -56,7 +56,7 @@ Apache-2.0
   aws-java-sdk-kms-1.12.643.jar
   aws-java-sdk-s3-1.12.643.jar
   byte-buddy-1.14.11.jar
-  byte-buddy-agent-1.14.10.jar
+  byte-buddy-agent-1.14.11.jar
   caffeine-3.1.8.jar
   cassandra-driver-core-3.10.0.jar
   commons-beanutils-1.9.4.jar
@@ -73,7 +73,7 @@ Apache-2.0
   commons-io-2.15.1.jar
   commons-lang3-3.14.0.jar
   commons-logging-1.2.jar
-  commons-math3-3.6.1.jar
+  commons-math3-3.1.1.jar
   commons-net-3.9.0.jar
   commons-text-1.10.0.jar
   commons-text-1.11.0.jar
@@ -132,7 +132,7 @@ Apache-2.0
   httpclient-4.5.13.jar
   httpcore-4.4.13.jar
   ipaddress-5.3.3.jar
-  ipaddress-5.4.0.jar
+  ipaddress-5.4.2.jar
   j2objc-annotations-1.1.jar
   j2objc-annotations-2.8.jar
   jPowerShell-3.0.jar
@@ -210,11 +210,11 @@ Apache-2.0
   metrics-core-3.2.4.jar
   netty-3.10.6.Final.jar
   netty-all-4.1.89.Final.jar
-  netty-buffer-4.1.105.Final.jar
-  netty-codec-4.1.105.Final.jar
+  netty-buffer-4.1.106.Final.jar
+  netty-codec-4.1.106.Final.jar
   netty-codec-dns-4.1.89.Final.jar
   netty-codec-haproxy-4.1.89.Final.jar
-  netty-codec-http-4.1.105.Final.jar
+  netty-codec-http-4.1.106.Final.jar
   netty-codec-http2-4.1.89.Final.jar
   netty-codec-memcache-4.1.89.Final.jar
   netty-codec-mqtt-4.1.89.Final.jar
@@ -223,25 +223,25 @@ Apache-2.0
   netty-codec-socks-4.1.89.Final.jar
   netty-codec-stomp-4.1.89.Final.jar
   netty-codec-xml-4.1.89.Final.jar
-  netty-common-4.1.105.Final.jar
-  netty-handler-4.1.105.Final.jar
+  netty-common-4.1.106.Final.jar
+  netty-handler-4.1.106.Final.jar
   netty-handler-proxy-4.1.89.Final.jar
   netty-handler-ssl-ocsp-4.1.89.Final.jar
-  netty-resolver-4.1.105.Final.jar
+  netty-resolver-4.1.106.Final.jar
   netty-resolver-dns-4.1.89.Final.jar
   netty-resolver-dns-classes-macos-4.1.89.Final.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-aarch_64.jar
   netty-resolver-dns-native-macos-4.1.89.Final-osx-x86_64.jar
   netty-tcnative-classes-2.0.61.Final.jar
-  netty-transport-4.1.105.Final.jar
-  netty-transport-classes-epoll-4.1.105.Final.jar
-  netty-transport-classes-kqueue-4.1.105.Final.jar
-  netty-transport-native-epoll-4.1.105.Final-linux-aarch_64.jar
-  netty-transport-native-epoll-4.1.105.Final-linux-x86_64.jar
-  netty-transport-native-epoll-4.1.105.Final.jar
-  netty-transport-native-kqueue-4.1.105.Final-osx-aarch_64.jar
-  netty-transport-native-kqueue-4.1.105.Final-osx-x86_64.jar
-  netty-transport-native-unix-common-4.1.105.Final.jar
+  netty-transport-4.1.106.Final.jar
+  netty-transport-classes-epoll-4.1.106.Final.jar
+  netty-transport-classes-kqueue-4.1.106.Final.jar
+  netty-transport-native-epoll-4.1.106.Final-linux-aarch_64.jar
+  netty-transport-native-epoll-4.1.106.Final-linux-x86_64.jar
+  netty-transport-native-epoll-4.1.106.Final.jar
+  netty-transport-native-kqueue-4.1.106.Final-osx-aarch_64.jar
+  netty-transport-native-kqueue-4.1.106.Final-osx-x86_64.jar
+  netty-transport-native-unix-common-4.1.106.Final.jar
   netty-transport-rxtx-4.1.89.Final.jar
   netty-transport-sctp-4.1.89.Final.jar
   netty-transport-udt-4.1.89.Final.jar
@@ -252,7 +252,7 @@ Apache-2.0
   opencsv-5.7.1.jar
   opentest4j-1.3.0.jar
   picocli-4.7.5.jar
-  reactor-core-3.6.1.jar
+  reactor-core-3.6.2.jar
   reload4j-1.2.22.jar
   scala-collection-contrib_2.13-0.3.0.jar
   scala-library-2.13.11.jar
@@ -382,14 +382,14 @@ Eclipse Public License - v 2.0
   jersey-container-servlet-core-2.34.jar
   jersey-hk2-2.34.jar
   jersey-server-2.34.jar
-  junit-jupiter-5.10.1.jar
-  junit-jupiter-api-5.10.1.jar
-  junit-jupiter-engine-5.10.1.jar
-  junit-jupiter-params-5.10.1.jar
-  junit-platform-commons-1.10.1.jar
-  junit-platform-engine-1.10.1.jar
-  junit-platform-launcher-1.10.1.jar
-  junit-platform-testkit-1.10.1.jar
+  junit-jupiter-5.10.2.jar
+  junit-jupiter-api-5.10.2.jar
+  junit-jupiter-engine-5.10.2.jar
+  junit-jupiter-params-5.10.2.jar
+  junit-platform-commons-1.10.2.jar
+  junit-platform-engine-1.10.2.jar
+  junit-platform-launcher-1.10.2.jar
+  junit-platform-testkit-1.10.2.jar
   osgi-resource-locator-1.0.3.jar
 
 GNU General Public License (GPL), version 2, with the Classpath exception
@@ -450,7 +450,7 @@ MIT
   jersey-hk2-2.34.jar
   jnr-x86asm-1.0.2.jar
   localstack-1.19.1.jar
-  mockito-core-5.8.0.jar
+  mockito-core-5.10.0.jar
   mssql-jdbc-6.2.1.jre7.jar
   mysql-1.19.1.jar
   neo4j-1.19.1.jar

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -39,7 +39,6 @@ dependencies {
             strictly '3.14.0'
         }
     }
-    api group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     api group: 'com.github.seancfoley', name: 'ipaddress', version: '5.3.3'
 
     // These will be dependencies not packaged with the .jar

--- a/core/src/main/java/apoc/coll/Coll.java
+++ b/core/src/main/java/apoc/coll/Coll.java
@@ -50,8 +50,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
-import org.apache.commons.math3.util.Combinations;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Relationship;
@@ -78,8 +76,8 @@ public class Coll {
             @Name("list") List<Number> list,
             @Name(value = "isBiasCorrected", defaultValue = "true") boolean isBiasCorrected) {
         if (list == null || list.isEmpty()) return null;
-        final double stdev = new StandardDeviation(isBiasCorrected)
-                .evaluate(list.stream().mapToDouble(Number::doubleValue).toArray());
+        final double stdev = StandardDeviation.stdDev(
+                list.stream().mapToDouble(Number::doubleValue).toArray(), isBiasCorrected);
         if ((long) stdev == stdev) return (long) stdev;
         return stdev;
     }

--- a/core/src/main/java/apoc/coll/Combinations.java
+++ b/core/src/main/java/apoc/coll/Combinations.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package apoc.coll;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.stream.IntStream;
+
+/**
+ * This code was copied from project commons-math3
+ */
+class Combinations implements Iterable<int[]> {
+    private final int n;
+    private final int k;
+
+    public Combinations(int n, int k) {
+        checkBinomial(n, k);
+        this.n = n;
+        this.k = k;
+    }
+
+    @Override
+    public Iterator<int[]> iterator() {
+        if (k == 0 || k == n) {
+            return new SingletonIterator(IntStream.range(0, k).toArray());
+        }
+        return new LexicographicIterator(n, k);
+    }
+
+    private static class LexicographicIterator implements Iterator<int[]> {
+        private final int k;
+        private final int[] c;
+        private boolean more = true;
+        private int j;
+
+        LexicographicIterator(int n, int k) {
+            this.k = k;
+            c = new int[k + 3];
+            if (k == 0 || k >= n) {
+                more = false;
+                return;
+            }
+            // Initialize c to start with lexicographically first k-set
+            for (int i = 1; i <= k; i++) {
+                c[i] = i - 1;
+            }
+            // Initialize sentinels
+            c[k + 1] = n;
+            c[k + 2] = 0;
+            j = k; // Set up invariant: j is smallest index such that c[j + 1] > j
+        }
+
+        @Override
+        public boolean hasNext() {
+            return more;
+        }
+
+        @Override
+        public int[] next() {
+            if (!more) {
+                throw new NoSuchElementException();
+            }
+            // Copy return value (prepared by last activation)
+            final int[] ret = new int[k];
+            System.arraycopy(c, 1, ret, 0, k);
+
+            // Prepare next iteration
+            // T2 and T6 loop
+            int x = 0;
+            if (j > 0) {
+                x = j;
+                c[j] = x;
+                j--;
+                return ret;
+            }
+            // T3
+            if (c[1] + 1 < c[2]) {
+                c[1]++;
+                return ret;
+            } else {
+                j = 2;
+            }
+            // T4
+            boolean stepDone = false;
+            while (!stepDone) {
+                c[j - 1] = j - 2;
+                x = c[j] + 1;
+                if (x == c[j + 1]) {
+                    j++;
+                } else {
+                    stepDone = true;
+                }
+            }
+            // T5
+            if (j > k) {
+                more = false;
+                return ret;
+            }
+            // T6
+            c[j] = x;
+            j--;
+            return ret;
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class SingletonIterator implements Iterator<int[]> {
+        private final int[] singleton;
+        private boolean more = true;
+
+        SingletonIterator(final int[] singleton) {
+            this.singleton = singleton;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return more;
+        }
+
+        @Override
+        public int[] next() {
+            if (more) {
+                more = false;
+                return singleton;
+            } else {
+                throw new NoSuchElementException();
+            }
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static void checkBinomial(final int n, final int k) {
+        if (n < k) {
+            throw new IllegalArgumentException(
+                    "must have n >= k for binomial coefficient (n, k), got k = %d, n = %d".formatted(k, n));
+        }
+        if (n < 0) {
+            throw new IllegalArgumentException("must have n >= 0 for binomial coefficient (n, k), got n = " + n);
+        }
+    }
+}

--- a/core/src/main/java/apoc/coll/StandardDeviation.java
+++ b/core/src/main/java/apoc/coll/StandardDeviation.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package apoc.coll;
+
+/**
+ * This code was copied from project commons-math3
+ */
+final class StandardDeviation {
+
+    private StandardDeviation() {}
+
+    public static double stdDev(double[] values, boolean isBiasCorrected) {
+        return Math.sqrt(variance(values, isBiasCorrected));
+    }
+
+    private static double variance(double[] values, boolean isBiasCorrected) {
+        double variance = Double.NaN;
+
+        int length = values.length;
+        if (length == 1) {
+            variance = 0.0;
+        } else if (length > 1) {
+            double m = meanValue(values, length);
+            double accum = 0.0;
+            double dev;
+            double accum2 = 0.0;
+            for (double value : values) {
+                dev = value - m;
+                accum += dev * dev;
+                accum2 += dev;
+            }
+            double len = length;
+            if (isBiasCorrected) {
+                variance = (accum - (accum2 * accum2 / len)) / (len - 1.0);
+            } else {
+                variance = (accum - (accum2 * accum2 / len)) / len;
+            }
+        }
+
+        return variance;
+    }
+
+    private static double meanValue(double[] values, int length) {
+        // Compute initial estimate using definitional formula
+        double sum = 0.0;
+        for (double i : values) {
+            sum += i;
+        }
+        double xbar = sum / length;
+
+        // Compute correction factor in second pass
+        double correction = 0;
+        for (double value : values) {
+            correction += value - xbar;
+        }
+        return xbar + (correction / length);
+    }
+}

--- a/core/src/main/java/apoc/math/Regression.java
+++ b/core/src/main/java/apoc/math/Regression.java
@@ -19,7 +19,6 @@
 package apoc.math;
 
 import java.util.stream.Stream;
-import org.apache.commons.math3.stat.regression.SimpleRegression;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterator;
@@ -53,14 +52,14 @@ public class Regression {
             "Returns the coefficient of determination (R-squared) for the values of propertyY and propertyX in the given label.")
     public Stream<Output> regr(@Name("label") String label, @Name("propertyY") String y, @Name("propertyX") String x) {
 
-        SimpleRegression regr = new SimpleRegression(false);
+        SimpleRegression regr = new SimpleRegression();
         double regrAvgX = 0;
         double regrAvgY = 0;
         int count = 0;
 
-        try (ResourceIterator it = tx.findNodes(Label.label(label))) {
+        try (ResourceIterator<Node> it = tx.findNodes(Label.label(label))) {
             while (it.hasNext()) {
-                Node node = (Node) it.next();
+                Node node = it.next();
                 Number propX = (Number) node.getProperty(x, null);
                 Number propY = (Number) node.getProperty(y, null);
                 if (propX != null && propY != null) {

--- a/core/src/main/java/apoc/math/SimpleRegression.java
+++ b/core/src/main/java/apoc/math/SimpleRegression.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package apoc.math;
+
+/**
+ * This code was copied from project commons-math3
+ */
+class SimpleRegression {
+    private double sumXX = 0d;
+    private double sumYY = 0d;
+    private double sumXY = 0d;
+    private long n = 0;
+
+    public void addData(final double x, final double y) {
+        sumXX += x * x;
+        sumYY += y * y;
+        sumXY += x * y;
+        n++;
+    }
+
+    public double getSlope() {
+        if (n < 2) {
+            return Double.NaN; // not enough data
+        }
+        if (Math.abs(sumXX) < 10 * Double.MIN_VALUE) {
+            return Double.NaN; // not enough variation in x
+        }
+        return sumXY / sumXX;
+    }
+
+    public double getSumSquaredErrors() {
+        return Math.max(0d, sumYY - sumXY * sumXY / sumXX);
+    }
+
+    public double getTotalSumSquares() {
+        if (n < 2) {
+            return Double.NaN;
+        }
+        return sumYY;
+    }
+
+    public double getR() {
+        double b1 = getSlope();
+        double result = Math.sqrt(getRSquare());
+        if (b1 < 0) {
+            result = -result;
+        }
+        return result;
+    }
+
+    public double getRSquare() {
+        double ssto = getTotalSumSquares();
+        return (ssto - getSumSquaredErrors()) / ssto;
+    }
+}

--- a/core/src/test/java/apoc/math/RegressionTest.java
+++ b/core/src/test/java/apoc/math/RegressionTest.java
@@ -21,7 +21,6 @@ package apoc.math;
 import static org.junit.Assert.assertEquals;
 
 import apoc.util.TestUtil;
-import org.apache.commons.math3.stat.regression.SimpleRegression;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -54,13 +53,10 @@ public class RegressionTest {
                 + "(:REGR_TEST {y_property: 10000 }),"
                 + "(:REGR_TEST {x_property: 3 , y_property: 6 })");
 
-        SimpleRegression expectedRegr = new SimpleRegression(false);
-        expectedRegr.addData(new double[][] {
-            {1, 1},
-            {2, 3},
-            // {3, 10000},
-            {3, 6}
-        });
+        SimpleRegression expectedRegr = new SimpleRegression();
+        expectedRegr.addData(1, 1);
+        expectedRegr.addData(2, 3);
+        expectedRegr.addData(3, 6);
         TestUtil.testCall(db, "CALL apoc.math.regr('REGR_TEST', 'y_property', 'x_property')", result -> {
             assertEquals(expectedRegr.getRSquare(), (Double) result.get("r2"), 0.1);
             assertEquals(2.0, (Double) result.get("avgX"), 0.1);
@@ -76,13 +72,10 @@ public class RegressionTest {
                 + "(:REGR_TEST2 {y_property: 10000 }),"
                 + "(:REGR_TEST2 {x_property: 1 , y_property: 1 })");
 
-        SimpleRegression expectedRegr = new SimpleRegression(false);
-        expectedRegr.addData(new double[][] {
-            {1, 1},
-            {1, 1},
-            // {3, 10000},
-            {1, 1}
-        });
+        SimpleRegression expectedRegr = new SimpleRegression();
+        expectedRegr.addData(1, 1);
+        expectedRegr.addData(1, 1);
+        expectedRegr.addData(1, 1);
 
         TestUtil.testCall(db, "CALL apoc.math.regr('REGR_TEST2', 'y_property', 'x_property')", result -> {
             assertEquals(expectedRegr.getRSquare(), (Double) result.get("r2"), 0.1);


### PR DESCRIPTION
We only used a few methods from the library. Also, the `FastMath` that the library is built on claims to be faster and more accurate, but this is a lie in modern versions of Java. Performance will actually be worse since no intrinsics will be used.