### PR TITLE
[oIVz2Y7V] apoc.refactor.cloneNodes does not need to be in its own transaction

### DIFF
--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -168,6 +168,19 @@ public class Util {
         return new Label[] {Label.label(labelNames.toString())};
     }
 
+    public static Label[] getLabelsArray(Node node) {
+        List<Label> labels = getLabels(node);
+        return labels.toArray(new Label[0]);
+    }
+
+    public static List<Label> getLabels(Node node) {
+        return getLabelsAsStream(node).collect(Collectors.toList());
+    }
+
+    private static Stream<Label> getLabelsAsStream(Node node) {
+        return StreamSupport.stream(node.getLabels().spliterator(), false);
+    }
+
     public static Stream<Object> stream(Object values) {
         return ConvertUtils.convertToList(values).stream();
     }


### PR DESCRIPTION
There was a github issue where a user complained that if the Cypher query failed after this procedure ran, the procedure itself still committed the result. This is because it opened new transactions inside, this seemed overkill, so removed that from happening. 