### PR TITLE
[z9rBzmVK] Make recursiveRebind nullsafe for maps.

### DIFF
--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -22,7 +22,6 @@ import static apoc.ApocConfig.apocConfig;
 import static apoc.export.util.LimitedSizeInputStream.toLimitedIStream;
 import static apoc.util.DateFormatUtil.getOrCreate;
 import static java.net.HttpURLConnection.HTTP_NOT_MODIFIED;
-import static java.util.stream.Collectors.toUnmodifiableMap;
 import static org.eclipse.jetty.util.URIUtil.encodePath;
 import static org.neo4j.configuration.GraphDatabaseSettings.SYSTEM_DATABASE_NAME;
 
@@ -958,8 +957,9 @@ public class Util {
         if (o instanceof Entity entity) {
             return rebind(tx, entity);
         } else if (o instanceof Map<?, ?> map && needsRebind(map)) {
-            return map.entrySet().stream()
-                    .collect(toUnmodifiableMap(e -> e.getKey().toString(), e -> recursiveRebind(tx, e.getValue())));
+            Map<String, Object> m = new HashMap<>();
+            map.forEach((key, value) -> m.put(key.toString(), recursiveRebind(tx, value)));
+            return m;
         } else if (o instanceof List<?> list && needsRebind(list)) {
             return list.stream().map(e -> recursiveRebind(tx, e)).toList();
         } else {

--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -720,7 +720,7 @@ public class PeriodicTest {
                 db,
                 """
                 CALL apoc.periodic.iterate(
-                    "WITH {a: null, b: {c: 1}} as value RETURN value",
+                    "WITH {a: null, b: {c: 1}, c: [null]} as value RETURN value",
                     "RETURN 1",
                      {})
                 """,

--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -715,6 +715,24 @@ public class PeriodicTest {
     }
 
     @Test
+    public void testIterateWithNullRebind() {
+        testResult(
+                db,
+                """
+                CALL apoc.periodic.iterate(
+                    "WITH {a: null, b: {c: 1}} as value RETURN value",
+                    "RETURN 1",
+                     {})
+                """,
+                result -> {
+                    Map<String, Object> row = Iterators.single(result);
+                    assertEquals(1L, row.get("batches"));
+                    assertEquals(1L, row.get("total"));
+                    assertEquals(0L, row.get("failedBatches"));
+                });
+    }
+
+    @Test
     public void testCountdown() {
         int startValue = 3;
         int rate = 1;


### PR DESCRIPTION
For maps which in turn contain maps or lists, we would call Collectors.toUnmodifiableMap, which throws a null pointer if the map also contains null values. This should be valid in Cypher.

Inspiration for the fix comes from https://stackoverflow.com/questions/24630963/nullpointerexception-in-collectors-tomap-with-null-entry-values