### PR TITLE
[pb3CtuNX] Adds convert.paths.toTree to deprecate old convert.toTree

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -74,7 +74,7 @@ jobs:
       - uses: ./.github/actions/setup-jdk
       - uses: ./.github/actions/setup-gradle-cache
       - name: Check all the files are properly formatted
-        run: ./gradlew spotlessApply
+        run: ./gradlew spotlessCheck
 
   license-checks:
     runs-on: ubuntu-latest

--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -11,18 +11,19 @@ Apache-2.0
   accessors-smart-2.5.0.jar
   annotations-17.0.0.jar
   annotations-4.1.1.4.jar
-  arrow-format-15.0.0.jar
-  arrow-memory-core-15.0.0.jar
-  arrow-memory-netty-15.0.0.jar
-  arrow-vector-15.0.0.jar
+  arrow-format-15.0.2.jar
+  arrow-memory-core-15.0.2.jar
+  arrow-memory-netty-15.0.2.jar
+  arrow-vector-15.0.2.jar
   assertj-core-3.25.3.jar
   audience-annotations-0.12.0.jar
   avro-1.9.2.jar
-  awaitility-4.2.0.jar
+  awaitility-4.2.1.jar
   aws-java-sdk-core-1.12.643.jar
   aws-java-sdk-kms-1.12.643.jar
   aws-java-sdk-s3-1.12.643.jar
   byte-buddy-1.14.12.jar
+  byte-buddy-1.14.9.jar
   byte-buddy-agent-1.14.12.jar
   caffeine-3.1.8.jar
   cassandra-driver-core-3.10.0.jar
@@ -30,11 +31,11 @@ Apache-2.0
   commons-cli-1.5.0.jar
   commons-codec-1.16.1.jar
   commons-collections-3.2.2.jar
-  commons-compress-1.26.0.jar
+  commons-compress-1.26.1.jar
   commons-configuration2-2.10.1.jar
   commons-csv-1.9.0.jar
   commons-daemon-1.0.13.jar
-  commons-io-2.15.1.jar
+  commons-io-2.16.0.jar
   commons-lang-2.6.jar
   commons-lang3-3.12.0.jar
   commons-lang3-3.14.0.jar
@@ -53,7 +54,7 @@ Apache-2.0
   error_prone_annotations-2.23.0.jar
   failureaccess-1.0.2.jar
   flatbuffers-java-23.5.26.jar
-  flight-core-15.0.0.jar
+  flight-core-15.0.2.jar
   fst-2.50.jar
   geronimo-jcache_1.0_spec-1.0-alpha-1.jar
   gradle-tooling-api-7.3.jar
@@ -102,18 +103,18 @@ Apache-2.0
   http2-server-10.0.20.jar
   httpclient-4.5.13.jar
   httpcore-4.4.13.jar
-  ipaddress-5.4.2.jar
+  ipaddress-5.5.0.jar
   jPowerShell-3.0.jar
   jProcesses-1.6.5.jar
-  jackson-annotations-2.16.1.jar
-  jackson-core-2.16.1.jar
-  jackson-databind-2.16.1.jar
-  jackson-dataformat-cbor-2.16.1.jar
-  jackson-dataformat-csv-2.16.1.jar
-  jackson-datatype-jsr310-2.16.1.jar
-  jackson-jaxrs-base-2.16.1.jar
-  jackson-jaxrs-json-provider-2.16.1.jar
-  jackson-module-jaxb-annotations-2.16.1.jar
+  jackson-annotations-2.17.0.jar
+  jackson-core-2.17.0.jar
+  jackson-databind-2.17.0.jar
+  jackson-dataformat-cbor-2.17.0.jar
+  jackson-dataformat-csv-2.17.0.jar
+  jackson-datatype-jsr310-2.17.0.jar
+  jackson-jaxrs-base-2.17.0.jar
+  jackson-jaxrs-json-provider-2.17.0.jar
+  jackson-module-jaxb-annotations-2.17.0.jar
   jakarta.validation-api-2.0.2.jar
   javapoet-1.13.0.jar
   javassist-3.25.0-GA.jar
@@ -192,7 +193,8 @@ Apache-2.0
   netty-resolver-dns-classes-macos-4.1.101.Final.jar
   netty-resolver-dns-native-macos-4.1.101.Final-osx-aarch_64.jar
   netty-resolver-dns-native-macos-4.1.101.Final-osx-x86_64.jar
-  netty-tcnative-classes-2.0.61.Final.jar
+  netty-tcnative-boringssl-static-2.0.61.Final.jar
+  netty-tcnative-classes-2.0.65.Final.jar
   netty-transport-4.1.101.Final.jar
   netty-transport-classes-epoll-4.1.101.Final.jar
   netty-transport-classes-kqueue-4.1.101.Final.jar
@@ -212,7 +214,7 @@ Apache-2.0
   perfmark-api-0.26.0.jar
   picocli-4.7.5.jar
   proto-google-common-protos-2.29.0.jar
-  reactor-core-3.6.3.jar
+  reactor-core-3.6.5.jar
   reload4j-1.2.22.jar
   scala-collection-contrib_2.13-0.3.0.jar
   scala-library-2.13.11.jar
@@ -446,7 +448,7 @@ BSD-2-Clause
   jline-3.22.0.jar
   jsch-0.1.55.jar
   stax2-api-4.2.1.jar
-  zstd-jni-1.5.5-11.jar
+  zstd-jni-1.5.6-2.jar
 ------------------------------------------------------------------------------
 
 Copyright <year> <copyright holder>
@@ -502,11 +504,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 BSD-3-Clause
-  asm-9.6.jar
-  asm-analysis-9.6.jar
+  asm-9.7.jar
+  asm-analysis-9.7.jar
   asm-commons-5.0.3.jar
-  asm-tree-9.6.jar
-  asm-util-9.6.jar
+  asm-tree-9.7.jar
+  asm-util-9.7.jar
   hamcrest-2.2.jar
   hamcrest-core-2.2.jar
   hamcrest-library-2.2.jar

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -41,18 +41,19 @@ Apache-2.0
   accessors-smart-2.5.0.jar
   annotations-17.0.0.jar
   annotations-4.1.1.4.jar
-  arrow-format-15.0.0.jar
-  arrow-memory-core-15.0.0.jar
-  arrow-memory-netty-15.0.0.jar
-  arrow-vector-15.0.0.jar
+  arrow-format-15.0.2.jar
+  arrow-memory-core-15.0.2.jar
+  arrow-memory-netty-15.0.2.jar
+  arrow-vector-15.0.2.jar
   assertj-core-3.25.3.jar
   audience-annotations-0.12.0.jar
   avro-1.9.2.jar
-  awaitility-4.2.0.jar
+  awaitility-4.2.1.jar
   aws-java-sdk-core-1.12.643.jar
   aws-java-sdk-kms-1.12.643.jar
   aws-java-sdk-s3-1.12.643.jar
   byte-buddy-1.14.12.jar
+  byte-buddy-1.14.9.jar
   byte-buddy-agent-1.14.12.jar
   caffeine-3.1.8.jar
   cassandra-driver-core-3.10.0.jar
@@ -60,11 +61,11 @@ Apache-2.0
   commons-cli-1.5.0.jar
   commons-codec-1.16.1.jar
   commons-collections-3.2.2.jar
-  commons-compress-1.26.0.jar
+  commons-compress-1.26.1.jar
   commons-configuration2-2.10.1.jar
   commons-csv-1.9.0.jar
   commons-daemon-1.0.13.jar
-  commons-io-2.15.1.jar
+  commons-io-2.16.0.jar
   commons-lang-2.6.jar
   commons-lang3-3.12.0.jar
   commons-lang3-3.14.0.jar
@@ -83,7 +84,7 @@ Apache-2.0
   error_prone_annotations-2.23.0.jar
   failureaccess-1.0.2.jar
   flatbuffers-java-23.5.26.jar
-  flight-core-15.0.0.jar
+  flight-core-15.0.2.jar
   fst-2.50.jar
   geronimo-jcache_1.0_spec-1.0-alpha-1.jar
   gradle-tooling-api-7.3.jar
@@ -132,18 +133,18 @@ Apache-2.0
   http2-server-10.0.20.jar
   httpclient-4.5.13.jar
   httpcore-4.4.13.jar
-  ipaddress-5.4.2.jar
+  ipaddress-5.5.0.jar
   jPowerShell-3.0.jar
   jProcesses-1.6.5.jar
-  jackson-annotations-2.16.1.jar
-  jackson-core-2.16.1.jar
-  jackson-databind-2.16.1.jar
-  jackson-dataformat-cbor-2.16.1.jar
-  jackson-dataformat-csv-2.16.1.jar
-  jackson-datatype-jsr310-2.16.1.jar
-  jackson-jaxrs-base-2.16.1.jar
-  jackson-jaxrs-json-provider-2.16.1.jar
-  jackson-module-jaxb-annotations-2.16.1.jar
+  jackson-annotations-2.17.0.jar
+  jackson-core-2.17.0.jar
+  jackson-databind-2.17.0.jar
+  jackson-dataformat-cbor-2.17.0.jar
+  jackson-dataformat-csv-2.17.0.jar
+  jackson-datatype-jsr310-2.17.0.jar
+  jackson-jaxrs-base-2.17.0.jar
+  jackson-jaxrs-json-provider-2.17.0.jar
+  jackson-module-jaxb-annotations-2.17.0.jar
   jakarta.validation-api-2.0.2.jar
   javapoet-1.13.0.jar
   javassist-3.25.0-GA.jar
@@ -222,7 +223,8 @@ Apache-2.0
   netty-resolver-dns-classes-macos-4.1.101.Final.jar
   netty-resolver-dns-native-macos-4.1.101.Final-osx-aarch_64.jar
   netty-resolver-dns-native-macos-4.1.101.Final-osx-x86_64.jar
-  netty-tcnative-classes-2.0.61.Final.jar
+  netty-tcnative-boringssl-static-2.0.61.Final.jar
+  netty-tcnative-classes-2.0.65.Final.jar
   netty-transport-4.1.101.Final.jar
   netty-transport-classes-epoll-4.1.101.Final.jar
   netty-transport-classes-kqueue-4.1.101.Final.jar
@@ -242,7 +244,7 @@ Apache-2.0
   perfmark-api-0.26.0.jar
   picocli-4.7.5.jar
   proto-google-common-protos-2.29.0.jar
-  reactor-core-3.6.3.jar
+  reactor-core-3.6.5.jar
   reload4j-1.2.22.jar
   scala-collection-contrib_2.13-0.3.0.jar
   scala-library-2.13.11.jar
@@ -278,17 +280,17 @@ BSD-2-Clause
   jline-3.22.0.jar
   jsch-0.1.55.jar
   stax2-api-4.2.1.jar
-  zstd-jni-1.5.5-11.jar
+  zstd-jni-1.5.6-2.jar
 
 BSD-2-Clause
   dnsjava-3.4.0.jar
 
 BSD-3-Clause
-  asm-9.6.jar
-  asm-analysis-9.6.jar
+  asm-9.7.jar
+  asm-analysis-9.7.jar
   asm-commons-5.0.3.jar
-  asm-tree-9.6.jar
-  asm-util-9.6.jar
+  asm-tree-9.7.jar
+  asm-util-9.7.jar
   hamcrest-2.2.jar
   hamcrest-core-2.2.jar
   hamcrest-library-2.2.jar

--- a/core/src/main/java/apoc/convert/Json.java
+++ b/core/src/main/java/apoc/convert/Json.java
@@ -169,7 +169,7 @@ public class Json {
         return JsonUtil.parse(value, path, List.class, pathOptions);
     }
 
-    @Procedure("apoc.convert.toTree")
+    @Procedure(value = "apoc.convert.toTree", deprecatedBy = "apoc.paths.toJsonTree")
     @Description(
             "Returns a stream of `MAP` values, representing the given `PATH` values as a tree with at least one root.")
     public Stream<MapResult> toTree(
@@ -225,6 +225,73 @@ public class Json {
                 .map(MapResult::new);
     }
 
+    @Procedure("apoc.paths.toJsonTree")
+    @Description(
+            "apoc.paths.toJsonTree([paths],[lowerCaseRels=true], [config]) creates a stream of nested documents representing the graph as a tree by traversing outgoing relationships")
+    // todo optinally provide root node
+    public Stream<MapResult> pathsToTree(
+            @Name("paths") List<Path> paths,
+            @Name(value = "lowerCaseRels", defaultValue = "true") boolean lowerCaseRels,
+            @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
+        if (paths == null || paths.isEmpty()) return Stream.of(new MapResult(Collections.emptyMap()));
+        ConvertConfig conf = new ConvertConfig(config);
+        Map<String, List<String>> nodes = conf.getNodes();
+        Map<String, List<String>> rels = conf.getRels();
+        Set<Long> visitedInOtherPaths = new HashSet<>();
+        Set<Long> nodesToKeepInResult = new HashSet<>();
+        Map<Long, Map<String, Object>> tree = new HashMap<>();
+
+        Stream<Path> allPaths = paths.stream();
+        if (conf.isSortPaths()) {
+            allPaths = allPaths.sorted(Comparator.comparingInt(Path::length).reversed());
+        }
+        allPaths.forEach(path -> {
+            // This api will always return relationships in an outgoing fashion ()-[r]->()
+            var pathRelationships = path.relationships();
+            pathRelationships.iterator().forEachRemaining((currentRel) -> {
+                Node currentNode = currentRel.getStartNode();
+                Long currentNodeId = currentNode.getId();
+
+                if (!visitedInOtherPaths.contains(currentNodeId)) {
+                    nodesToKeepInResult.add(currentNodeId);
+                }
+
+                Node nextNode = currentRel.getEndNode();
+                Map<String, Object> nodeMap =
+                        tree.computeIfAbsent(currentNode.getId(), (id) -> toMap(currentNode, nodes));
+
+                Long nextNodeId = nextNode.getId();
+                String typeName = lowerCaseRels
+                        ? currentRel.getType().name().toLowerCase()
+                        : currentRel.getType().name();
+                // todo take direction into account and create collection into outgoing direction ??
+                // parent-[:HAS_CHILD]->(child) vs. (parent)<-[:PARENT_OF]-(child)
+                if (!nodeMap.containsKey(typeName)) nodeMap.put(typeName, new ArrayList<>());
+                // Check that this combination of rel and node doesn't already exist
+                List<Map<String, Object>> currentNodeRels = (List) nodeMap.get(typeName);
+                boolean alreadyProcessedRel = currentNodeRels.stream()
+                        .anyMatch(elem -> elem.get("_id").equals(nextNodeId)
+                                && elem.get(typeName + "._id").equals(currentRel.getId()));
+                if (!alreadyProcessedRel) {
+                    boolean nodeAlreadyVisited = tree.containsKey(nextNodeId);
+                    Map<String, Object> nextNodeMap = toMap(nextNode, nodes);
+                    addRelProperties(nextNodeMap, typeName, currentRel, rels);
+
+                    if (!nodeAlreadyVisited) {
+                        tree.put(nextNodeId, nextNodeMap);
+                    }
+
+                    visitedInOtherPaths.add(nextNodeId);
+                    currentNodeRels.add(nextNodeMap);
+                }
+            });
+        });
+
+        var result =
+                nodesToKeepInResult.stream().map(nodeId -> tree.get(nodeId)).map(MapResult::new);
+        return result;
+    }
+
     @UserFunction("apoc.convert.toSortedJsonMap")
     @Description("Converts a serialized JSON object from the property of a given `NODE` into a Cypher `MAP`.")
     public String toSortedJsonMap(
@@ -275,8 +342,11 @@ public class Json {
         result.put("_id", n.getId());
         result.put("_elementId", n.getElementId());
         result.put("_type", type);
-        if (nodeFilters.containsKey(type)) { // Check if list contains LABEL
-            props = filterProperties(props, nodeFilters.get(type));
+        var types = type.split(":");
+        var filter =
+                Arrays.stream(types).filter((t) -> nodeFilters.containsKey(t)).findFirst();
+        if (filter.isPresent()) { // Check if list contains LABEL
+            props = filterProperties(props, nodeFilters.get(filter.get()));
         }
         result.putAll(props);
         return result;

--- a/core/src/main/java/apoc/periodic/Periodic.java
+++ b/core/src/main/java/apoc/periodic/Periodic.java
@@ -309,7 +309,7 @@ public class Periodic {
         int failedParams = Util.toInteger(config.getOrDefault("failedParams", -1));
 
         final Map<String, Object> metaData;
-        if(tx instanceof InternalTransaction iTx){
+        if (tx instanceof InternalTransaction iTx) {
             metaData = iTx.kernelTransaction().getMetaData();
         } else {
             metaData = Map.of();
@@ -341,7 +341,7 @@ public class Periodic {
                     retries,
                     result,
                     (tx, p) -> {
-                        if(tx instanceof InternalTransaction iTx){
+                        if (tx instanceof InternalTransaction iTx) {
                             iTx.setMetaData(metaData);
                         }
                         final Result r = tx.execute(innerStatement, merge(params, p));

--- a/core/src/test/java/apoc/convert/PathsToJsonTreeTest.java
+++ b/core/src/test/java/apoc/convert/PathsToJsonTreeTest.java
@@ -1,0 +1,569 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package apoc.convert;
+
+import static org.junit.Assert.assertEquals;
+
+import apoc.util.JsonUtil;
+import apoc.util.TestUtil;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+public class PathsToJsonTreeTest {
+    private Object parseJson(String json) {
+        return JsonUtil.parse(json, null, null);
+    }
+
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
+
+    @Before
+    public void setUp() throws Exception {
+        TestUtil.registerProcedure(db, Json.class);
+    }
+
+    @After
+    public void teardown() {
+        db.shutdown();
+    }
+
+    @After
+    public void clear() {
+        db.executeTransactionally("MATCH (n) DETACH DELETE n;");
+    }
+
+    @Test
+    public void testToTreeSimplePath() throws Exception {
+        /*            r:R
+              a:A --------> b:B
+        */
+        db.executeTransactionally("CREATE (a: A {nodeName: 'a'})-[r: R {relName: 'r'}]->(b: B {nodeName: 'b'})");
+
+        var query = "MATCH path = (n)-[r]->(m)\n"
+                + "WITH COLLECT(path) AS paths\n"
+                + "CALL apoc.paths.toJsonTree(paths, true, {sortPaths: false}) YIELD value AS tree\n"
+                + "RETURN tree";
+
+        try (Transaction tx = db.beginTx()) {
+            Result result = tx.execute(query);
+            var rows = result.stream().collect(Collectors.toList());
+            var expectedRow = "{" + "   \"tree\":{"
+                    + "      \"nodeName\":\"a\","
+                    + "      \"r\":["
+                    + "         {"
+                    + "            \"nodeName\":\"b\","
+                    + "            \"r._id\":0,"
+                    + "            \"_type\":\"B\","
+                    + "            \"_id\":1,"
+                    + "            \"r.relName\":\"r\""
+                    + "         }"
+                    + "      ],"
+                    + "      \"_type\":\"A\","
+                    + "      \"_id\":0"
+                    + "   }"
+                    + "}";
+            assertEquals(rows.size(), 1);
+            assertEquals(parseJson(expectedRow), rows.get(0));
+        }
+    }
+
+    @Test
+    public void testToTreeSimpleReversePath() {
+        /*            r:R
+              a:A <-------- b:B
+        */
+        db.executeTransactionally("CREATE " + "(a: A {nodeName: 'a'})<-[r: R {relName: 'r'}]-(b: B {nodeName: 'b'})");
+
+        var query = "MATCH path = (n)<-[r]-(m)\n"
+                + "WITH COLLECT(path) AS paths\n"
+                + "CALL apoc.paths.toJsonTree(paths, true, {sortPaths: false}) YIELD value AS tree\n"
+                + "RETURN tree";
+
+        try (Transaction tx = db.beginTx()) {
+            Result result = tx.execute(query);
+            var rows = result.stream().collect(Collectors.toList());
+            var expectedRow = "{" + "   \"tree\":{"
+                    + "      \"nodeName\":\"b\","
+                    + "      \"r\":["
+                    + "         {"
+                    + "            \"nodeName\":\"a\","
+                    + "            \"r._id\":0,"
+                    + "            \"_type\":\"A\","
+                    + "            \"_id\":0,"
+                    + "            \"r.relName\":\"r\""
+                    + "         }"
+                    + "      ],"
+                    + "      \"_type\":\"B\","
+                    + "      \"_id\":1"
+                    + "   }"
+                    + "}";
+            assertEquals(rows.size(), 1);
+            assertEquals(parseJson(expectedRow), rows.get(0));
+        }
+    }
+
+    @Test
+    public void testToTreeSimpleBidirectionalPath() {
+        /*         r1:R
+                 -------->
+             a:A          b:B
+                 <--------
+                   r2:R
+        */
+        db.executeTransactionally("CREATE "
+                + "(a: A {nodeName: 'a'})<-[r1: R {relName: 'r'}]-(b: B {nodeName: 'b'}),"
+                + "(a)-[r2: R {relName: 'r'}]->(b)");
+
+        var query = "MATCH path = (n)-[r]-(m)\n"
+                + "WITH COLLECT(path) AS paths\n"
+                + "CALL apoc.paths.toJsonTree(paths, true, {sortPaths: false}) YIELD value AS tree\n"
+                + "RETURN tree";
+
+        try (Transaction tx = db.beginTx()) {
+            Result result = tx.execute(query);
+            var rows = result.stream().collect(Collectors.toList());
+            var expectedRow = "{" + "   \"tree\":{"
+                    + "      \"nodeName\":\"a\","
+                    + "      \"r\":["
+                    + "         {"
+                    + "            \"nodeName\":\"b\","
+                    + "            \"r._id\":1,"
+                    + "            \"r\":["
+                    + "               {"
+                    + "                  \"nodeName\":\"a\","
+                    + "                  \"r._id\":0,"
+                    + "                  \"_type\":\"A\","
+                    + "                  \"_id\":0,"
+                    + "                  \"r.relName\":\"r\""
+                    + "               }"
+                    + "            ],"
+                    + "            \"_type\":\"B\","
+                    + "            \"_id\":1,"
+                    + "            \"r.relName\":\"r\""
+                    + "         }"
+                    + "      ],"
+                    + "      \"_type\":\"A\","
+                    + "      \"_id\":0"
+                    + "   }"
+                    + "}";
+            assertEquals(rows.size(), 1);
+            assertEquals(parseJson(expectedRow), rows.get(0));
+        }
+    }
+
+    @Test
+    public void testToTreeSimpleBidirectionalQuery() {
+        /*         r1:R
+             a:A --------> b:B
+        */
+        db.executeTransactionally("CREATE (a: A {nodeName: 'a'})-[r1: R {relName: 'r'}]->(b: B {nodeName: 'b'})");
+
+        // Note this would be returning both the path (a)-[r]->(b) and (b)<-[r]-(a)
+        // but we only expect a tree starting in 'a'
+        var query = "MATCH path = (n)-[r]-(m)\n"
+                + "WITH COLLECT(path) AS paths\n"
+                + "CALL apoc.paths.toJsonTree(paths, true, {sortPaths: false}) YIELD value AS tree\n"
+                + "RETURN tree";
+
+        try (Transaction tx = db.beginTx()) {
+            Result result = tx.execute(query);
+            var rows = result.stream().collect(Collectors.toList());
+            var expectedRow = "{" + "   \"tree\":{"
+                    + "      \"nodeName\":\"a\","
+                    + "      \"r\":["
+                    + "         {"
+                    + "            \"nodeName\":\"b\","
+                    + "            \"r._id\":0,"
+                    + "            \"_type\":\"B\","
+                    + "            \"_id\":1,"
+                    + "            \"r.relName\":\"r\""
+                    + "         }"
+                    + "      ],"
+                    + "      \"_type\":\"A\","
+                    + "      \"_id\":0"
+                    + "   }"
+                    + "}";
+            assertEquals(rows.size(), 1);
+            assertEquals(parseJson(expectedRow), rows.get(0));
+        }
+    }
+
+    @Test
+    public void testToTreeBidirectionalPathAndQuery() {
+        /*          r1:R1         r2:R2
+              a:A ---------> b:B --------> a
+        */
+        db.executeTransactionally(
+                "CREATE (a: A {nodeName: 'a'})-[r1: R1 {relName: 'r1'}]->(b: B {nodeName: 'b'})-[r2: R2 {relName: 'r2'}]->(a)");
+
+        // The query is bidirectional in this case, so
+        // we would have duplicated paths, but we do not
+        // expect duplicated trees
+        var query = "MATCH path = (n)-[r]-(m)\n"
+                + "WITH COLLECT(path) AS paths\n"
+                + "CALL apoc.paths.toJsonTree(paths, true, {sortPaths: false}) YIELD value AS tree\n"
+                + "RETURN tree";
+
+        try (Transaction tx = db.beginTx()) {
+            Result result = tx.execute(query);
+            var rows = result.stream().collect(Collectors.toList());
+
+            assertEquals(rows.size(), 1);
+            var expectedRow = "{" + "   \"tree\":{"
+                    + "      \"nodeName\":\"b\","
+                    + "      \"_type\":\"B\","
+                    + "      \"_id\":1,"
+                    + "      \"r2\":["
+                    + "         {"
+                    + "            \"nodeName\":\"a\","
+                    + "            \"r1\":["
+                    + "               {"
+                    + "                  \"nodeName\":\"b\","
+                    + "                  \"r1._id\":0,"
+                    + "                  \"_type\":\"B\","
+                    + "                  \"r1.relName\":\"r1\","
+                    + "                  \"_id\":1"
+                    + "               }"
+                    + "            ],"
+                    + "            \"_type\":\"A\","
+                    + "            \"r2._id\":1,"
+                    + "            \"_id\":0,"
+                    + "            \"r2.relName\":\"r2\""
+                    + "         }"
+                    + "      ]"
+                    + "   }"
+                    + "}";
+            assertEquals(parseJson(expectedRow), rows.get(0));
+        }
+    }
+
+    @Test
+    public void testToTreeComplexGraph() {
+        /*          r1:R1         r2:R2
+              a:A --------> b:B ------> c:C
+                             |
+                      r3:R3  |
+                            \|/
+                            d:D
+        */
+        db.executeTransactionally("CREATE " + "(a: A {nodeName: 'a'})-[r1: R1 {relName: 'r1'}]->(b: B {nodeName: 'b'}),"
+                + "(b)-[r2: R2 {relName: 'r2'}]->(c: C {nodeName: 'c'}),"
+                + "(b)-[r3: R3 {relName: 'r3'}]->(d: D {nodeName: 'd'})");
+
+        var query = "MATCH path = (n)-[r]->(m)\n"
+                + "WITH COLLECT(path) AS paths\n"
+                + "CALL apoc.paths.toJsonTree(paths, true, {sortPaths: false}) YIELD value AS tree\n"
+                + "RETURN tree";
+
+        try (Transaction tx = db.beginTx()) {
+            Result result = tx.execute(query);
+            var rows = result.stream().collect(Collectors.toList());
+
+            assertEquals(rows.size(), 1);
+            var expectedRow = "{" + "  \"tree\": {"
+                    + "    \"nodeName\": \"a\","
+                    + "    \"_type\": \"A\","
+                    + "    \"_id\": 0,"
+                    + "    \"r1\": ["
+                    + "      {"
+                    + "        \"nodeName\": \"b\","
+                    + "        \"r2\": ["
+                    + "          {"
+                    + "            \"nodeName\": \"c\","
+                    + "            \"r2._id\": 1,"
+                    + "            \"_type\": \"C\","
+                    + "            \"r2.relName\": \"r2\","
+                    + "            \"_id\": 2"
+                    + "          }"
+                    + "        ],"
+                    + "        \"r3\": ["
+                    + "          {"
+                    + "            \"nodeName\": \"d\","
+                    + "            \"r3._id\": 2,"
+                    + "            \"r3.relName\": \"r3\","
+                    + "            \"_type\": \"D\","
+                    + "            \"_id\": 3"
+                    + "          }"
+                    + "        ],"
+                    + "        \"_type\": \"B\","
+                    + "        \"r1._id\": 0,"
+                    + "        \"_id\": 1,"
+                    + "        \"r1.relName\": \"r1\""
+                    + "      }"
+                    + "    ]"
+                    + "  }"
+                    + "}";
+            assertEquals(parseJson(expectedRow), rows.get(0));
+        }
+    }
+
+    @Test
+    public void testToTreeComplexGraphBidirectionalQuery() {
+        /*          r1:R1         r2:R2
+              a:A --------> b:B -------> c:C
+                             |
+                      r3:R3  |
+                            \|/
+                            d:D
+        */
+        db.executeTransactionally("CREATE " + "(a: A {nodeName: 'a'})-[r1: R1 {relName: 'r1'}]->(b: B {nodeName: 'b'}),"
+                + "(b)-[r2: R2 {relName: 'r2'}]->(c: C {nodeName: 'c'}),"
+                + "(b)-[r3: R3 {relName: 'r3'}]->(d: D {nodeName: 'd'})");
+
+        // The query is bidirectional in this case, we don't expect duplicated paths
+        var query = "MATCH path = (n)-[r]-(m)\n"
+                + "WITH COLLECT(path) AS paths\n"
+                + "CALL apoc.paths.toJsonTree(paths, true, {sortPaths: false}) YIELD value AS tree\n"
+                + "RETURN tree";
+
+        try (Transaction tx = db.beginTx()) {
+            Result result = tx.execute(query);
+            var rows = result.stream().collect(Collectors.toList());
+
+            assertEquals(rows.size(), 1);
+            var expectedRow = "{" + "  \"tree\": {"
+                    + "    \"nodeName\": \"a\","
+                    + "    \"_type\": \"A\","
+                    + "    \"_id\": 0,"
+                    + "    \"r1\": ["
+                    + "      {"
+                    + "        \"nodeName\": \"b\","
+                    + "        \"r2\": ["
+                    + "          {"
+                    + "            \"nodeName\": \"c\","
+                    + "            \"r2._id\": 1,"
+                    + "            \"_type\": \"C\","
+                    + "            \"r2.relName\": \"r2\","
+                    + "            \"_id\": 2"
+                    + "          }"
+                    + "        ],"
+                    + "        \"r3\": ["
+                    + "          {"
+                    + "            \"nodeName\": \"d\","
+                    + "            \"r3._id\": 2,"
+                    + "            \"r3.relName\": \"r3\","
+                    + "            \"_type\": \"D\","
+                    + "            \"_id\": 3"
+                    + "          }"
+                    + "        ],"
+                    + "        \"_type\": \"B\","
+                    + "        \"r1._id\": 0,"
+                    + "        \"_id\": 1,"
+                    + "        \"r1.relName\": \"r1\""
+                    + "      }"
+                    + "    ]"
+                    + "  }"
+                    + "}";
+            assertEquals(parseJson(expectedRow), rows.get(0));
+        }
+    }
+
+    @Test
+    public void testToTreeGraphWithLoops() {
+        /*          r1:R1          r2:R2
+              a:A ---------> b:B --------> c:C
+                            /  /|\
+                            |___|
+                            r3:R3
+        */
+        db.executeTransactionally("CREATE " + "(a: A {nodeName: 'a'})-[r1: R1 {relName: 'r1'}]->(b: B {nodeName: 'b'}),"
+                + "(b)-[r2: R2 {relName: 'r2'}]->(c:C {nodeName: 'c'}),"
+                + "(b)-[r3: R3 {relName: 'r3'}]->(b)");
+
+        var query = "MATCH path = (n)-[r]->(m)\n"
+                + "WITH COLLECT(path) AS paths\n"
+                + "CALL apoc.paths.toJsonTree(paths, true, {sortPaths: false}) YIELD value AS tree\n"
+                + "RETURN tree";
+
+        try (Transaction tx = db.beginTx()) {
+            Result result = tx.execute(query);
+            var rows = result.stream().collect(Collectors.toList());
+
+            assertEquals(rows.size(), 1);
+            var expectedRow = "{" + "   \"tree\":{"
+                    + "      \"nodeName\":\"a\","
+                    + "      \"_type\":\"A\","
+                    + "      \"_id\":0,"
+                    + "      \"r1\":["
+                    + "         {"
+                    + "            \"nodeName\":\"b\","
+                    + "            \"r2\":["
+                    + "               {"
+                    + "                  \"nodeName\":\"c\","
+                    + "                  \"r2._id\":1,"
+                    + "                  \"_type\":\"C\","
+                    + "                  \"r2.relName\":\"r2\","
+                    + "                  \"_id\":2"
+                    + "               }"
+                    + "            ],"
+                    + "            \"r3\":["
+                    + "               {"
+                    + "                  \"nodeName\":\"b\","
+                    + "                  \"r3._id\":2,"
+                    + "                  \"r3.relName\":\"r3\","
+                    + "                  \"_type\":\"B\","
+                    + "                  \"_id\":1"
+                    + "               }"
+                    + "            ],"
+                    + "            \"_type\":\"B\","
+                    + "            \"r1._id\":0,"
+                    + "            \"_id\":1,"
+                    + "            \"r1.relName\":\"r1\""
+                    + "         }"
+                    + "      ]"
+                    + "   }"
+                    + "}";
+            assertEquals(parseJson(expectedRow), rows.get(0));
+        }
+    }
+
+    @Test
+    public void testIncomingRelationships() {
+        /*          r1:R1         r2:R2
+              a:A --------> b:B <------ c:C
+        */
+        db.executeTransactionally(
+                "CREATE (a: A {nodeName: 'a'})-[r1: R1 {relName: 'r1'}]->(b: B {nodeName: 'b'})<-[r2: R2 {relName: 'r2'}]-(c:C {nodeName: 'c'})");
+
+        var query = "MATCH path = (n)-[:R1]->(m)<-[:R2]-(o)\n"
+                + "WITH COLLECT(path) AS paths\n"
+                + "CALL apoc.paths.toJsonTree(paths, true, {sortPaths: false}) YIELD value AS tree\n"
+                + "RETURN tree";
+
+        try (Transaction tx = db.beginTx()) {
+            Result result = tx.execute(query);
+            var rows = result.stream().collect(Collectors.toList());
+
+            assertEquals(rows.size(), 2);
+            var expectedFirstRow = "{" + "   \"tree\":{"
+                    + "      \"nodeName\":\"a\","
+                    + "      \"_type\":\"A\","
+                    + "      \"_id\":0,"
+                    + "      \"r1\":["
+                    + "         {"
+                    + "            \"nodeName\":\"b\","
+                    + "            \"_type\":\"B\","
+                    + "            \"r1._id\":0,"
+                    + "            \"_id\":1,"
+                    + "            \"r1.relName\":\"r1\""
+                    + "         }"
+                    + "      ]"
+                    + "   }"
+                    + "}";
+            var expectedSecondRow = "{" + "   \"tree\":{"
+                    + "      \"nodeName\":\"c\","
+                    + "      \"r2\":["
+                    + "         {"
+                    + "            \"nodeName\":\"b\","
+                    + "            \"r2._id\":1,"
+                    + "            \"_type\":\"B\","
+                    + "            \"r2.relName\":\"r2\","
+                    + "            \"_id\":1"
+                    + "         }"
+                    + "      ],"
+                    + "      \"_type\":\"C\","
+                    + "      \"_id\":2"
+                    + "   }"
+                    + "}";
+            assertEquals(parseJson(expectedFirstRow), rows.get(0));
+            assertEquals(parseJson(expectedSecondRow), rows.get(1));
+        }
+    }
+
+    @Test
+    public void testToTreeMultiLabelFilters() {
+        /*            r:R
+              a:A:B -------> c:C
+        */
+        db.executeTransactionally(
+                "CREATE " + "(a: A: B {nodeName: 'a & b'})-[r: R {relName: 'r'}]->(c: C {nodeName: 'c'})");
+
+        var query = "MATCH path = (n)-[r]->(m)\n"
+                + "WITH COLLECT(path) AS paths\n"
+                + "CALL apoc.paths.toJsonTree(paths, true, {nodes: { A: ['-nodeName'] } }) YIELD value AS tree\n"
+                + "RETURN tree";
+
+        try (Transaction tx = db.beginTx()) {
+            Result result = tx.execute(query);
+            var rows = result.stream().collect(Collectors.toList());
+
+            assertEquals(rows.size(), 1);
+            // No nodename under A:B
+            var expectedRow = "{" + "   \"tree\":{"
+                    + "      \"r\":["
+                    + "         {"
+                    + "            \"nodeName\":\"c\","
+                    + "            \"r._id\":0,"
+                    + "            \"_type\":\"C\","
+                    + "            \"_id\":1,"
+                    + "            \"r.relName\":\"r\""
+                    + "         }"
+                    + "      ],"
+                    + "      \"_type\":\"A:B\","
+                    + "      \"_id\":0"
+                    + "   }"
+                    + "}";
+            assertEquals(parseJson(expectedRow), rows.get(0));
+        }
+    }
+
+    @Test
+    public void testToTreeMultiLabelFiltersForOldProcedure() {
+        /*            r:R
+              a:A:B -------> c:C
+        */
+        db.executeTransactionally(
+                "CREATE " + "(a: A: B {nodeName: 'a & b'})-[r: R {relName: 'r'}]->(c: C {nodeName: 'c'})");
+
+        var query = "MATCH path = (n)-[r]->(m)\n"
+                + "WITH COLLECT(path) AS paths\n"
+                + "CALL apoc.convert.toTree(paths, true, {nodes: { A: ['-nodeName'] } }) YIELD value AS tree\n"
+                + "RETURN tree";
+
+        try (Transaction tx = db.beginTx()) {
+            Result result = tx.execute(query);
+            var rows = result.stream().collect(Collectors.toList());
+
+            assertEquals(rows.size(), 1);
+            // No nodename under A:B
+            var expectedRow = "{" + "   \"tree\":{"
+                    + "      \"r\":["
+                    + "         {"
+                    + "            \"nodeName\":\"c\","
+                    + "            \"r._id\":0,"
+                    + "            \"_type\":\"C\","
+                    + "            \"_id\":1,"
+                    + "            \"r.relName\":\"r\""
+                    + "         }"
+                    + "      ],"
+                    + "      \"_type\":\"A:B\","
+                    + "      \"_id\":0"
+                    + "   }"
+                    + "}";
+            assertEquals(parseJson(expectedRow), rows.get(0));
+        }
+    }
+}

--- a/core/src/test/java/apoc/convert/PathsToJsonTreeTest.java
+++ b/core/src/test/java/apoc/convert/PathsToJsonTreeTest.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertEquals;
 
 import apoc.util.JsonUtil;
 import apoc.util.TestUtil;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
@@ -34,7 +36,27 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 public class PathsToJsonTreeTest {
     private Object parseJson(String json) {
-        return JsonUtil.parse(json, null, null);
+        return JsonUtil.parse(json, null, Object.class);
+    }
+
+    // Because the nodes and relationships contain elementId, which is random,
+    // we need to test out equality leaving it out of the assertion
+    private Object removeElementId(Object a) {
+        if (a != null) {
+            if (a instanceof HashMap) {
+                HashMap<String, Object> obj = (HashMap<String, Object>) a;
+                var keysToRemove = obj.keySet().stream()
+                        .filter(key -> key.contains("elementId"))
+                        .collect(Collectors.toList());
+                keysToRemove.forEach((key) -> obj.remove(key));
+                obj.values().forEach((child) -> removeElementId(child));
+            } else if (a instanceof ArrayList) {
+                ArrayList<Object> obj = (ArrayList<Object>) a;
+                obj.forEach((child) -> removeElementId(child));
+            }
+        }
+
+        return a;
     }
 
     @Rule
@@ -86,7 +108,7 @@ public class PathsToJsonTreeTest {
                     + "   }"
                     + "}";
             assertEquals(rows.size(), 1);
-            assertEquals(parseJson(expectedRow), rows.get(0));
+            assertEquals(parseJson(expectedRow), removeElementId(rows.get(0)));
         }
     }
 
@@ -121,7 +143,8 @@ public class PathsToJsonTreeTest {
                     + "   }"
                     + "}";
             assertEquals(rows.size(), 1);
-            assertEquals(parseJson(expectedRow), rows.get(0));
+
+            assertEquals(parseJson(expectedRow), removeElementId(rows.get(0)));
         }
     }
 
@@ -146,31 +169,31 @@ public class PathsToJsonTreeTest {
             Result result = tx.execute(query);
             var rows = result.stream().collect(Collectors.toList());
             var expectedRow = "{" + "   \"tree\":{"
-                    + "      \"nodeName\":\"a\","
+                    + "      \"nodeName\":\"b\","
                     + "      \"r\":["
                     + "         {"
-                    + "            \"nodeName\":\"b\","
-                    + "            \"r._id\":1,"
+                    + "            \"nodeName\":\"a\","
+                    + "            \"r._id\":0,"
                     + "            \"r\":["
                     + "               {"
-                    + "                  \"nodeName\":\"a\","
-                    + "                  \"r._id\":0,"
-                    + "                  \"_type\":\"A\","
-                    + "                  \"_id\":0,"
+                    + "                  \"nodeName\":\"b\","
+                    + "                  \"r._id\":1,"
+                    + "                  \"_type\":\"B\","
+                    + "                  \"_id\":1,"
                     + "                  \"r.relName\":\"r\""
                     + "               }"
                     + "            ],"
-                    + "            \"_type\":\"B\","
-                    + "            \"_id\":1,"
+                    + "            \"_type\":\"A\","
+                    + "            \"_id\":0,"
                     + "            \"r.relName\":\"r\""
                     + "         }"
                     + "      ],"
-                    + "      \"_type\":\"A\","
-                    + "      \"_id\":0"
+                    + "      \"_type\":\"B\","
+                    + "      \"_id\":1"
                     + "   }"
                     + "}";
             assertEquals(rows.size(), 1);
-            assertEquals(parseJson(expectedRow), rows.get(0));
+            assertEquals(parseJson(expectedRow), removeElementId(rows.get(0)));
         }
     }
 
@@ -207,7 +230,7 @@ public class PathsToJsonTreeTest {
                     + "   }"
                     + "}";
             assertEquals(rows.size(), 1);
-            assertEquals(parseJson(expectedRow), rows.get(0));
+            assertEquals(parseJson(expectedRow), removeElementId(rows.get(0)));
         }
     }
 
@@ -233,30 +256,30 @@ public class PathsToJsonTreeTest {
 
             assertEquals(rows.size(), 1);
             var expectedRow = "{" + "   \"tree\":{"
-                    + "      \"nodeName\":\"b\","
-                    + "      \"_type\":\"B\","
-                    + "      \"_id\":1,"
-                    + "      \"r2\":["
+                    + "      \"nodeName\":\"a\","
+                    + "      \"_type\":\"A\","
+                    + "      \"_id\":0,"
+                    + "      \"r1\":["
                     + "         {"
-                    + "            \"nodeName\":\"a\","
-                    + "            \"r1\":["
+                    + "            \"nodeName\":\"b\","
+                    + "            \"r2\":["
                     + "               {"
-                    + "                  \"nodeName\":\"b\","
-                    + "                  \"r1._id\":0,"
-                    + "                  \"_type\":\"B\","
-                    + "                  \"r1.relName\":\"r1\","
-                    + "                  \"_id\":1"
+                    + "                  \"nodeName\":\"a\","
+                    + "                  \"r2._id\":1,"
+                    + "                  \"_type\":\"A\","
+                    + "                  \"r2.relName\":\"r2\","
+                    + "                  \"_id\":0"
                     + "               }"
                     + "            ],"
-                    + "            \"_type\":\"A\","
-                    + "            \"r2._id\":1,"
-                    + "            \"_id\":0,"
-                    + "            \"r2.relName\":\"r2\""
+                    + "            \"_type\":\"B\","
+                    + "            \"r1._id\":0,"
+                    + "            \"_id\":1,"
+                    + "            \"r1.relName\":\"r1\""
                     + "         }"
                     + "      ]"
                     + "   }"
                     + "}";
-            assertEquals(parseJson(expectedRow), rows.get(0));
+            assertEquals(parseJson(expectedRow), removeElementId(rows.get(0)));
         }
     }
 
@@ -316,7 +339,7 @@ public class PathsToJsonTreeTest {
                     + "    ]"
                     + "  }"
                     + "}";
-            assertEquals(parseJson(expectedRow), rows.get(0));
+            assertEquals(parseJson(expectedRow), removeElementId(rows.get(0)));
         }
     }
 
@@ -377,7 +400,7 @@ public class PathsToJsonTreeTest {
                     + "    ]"
                     + "  }"
                     + "}";
-            assertEquals(parseJson(expectedRow), rows.get(0));
+            assertEquals(parseJson(expectedRow), removeElementId(rows.get(0)));
         }
     }
 
@@ -436,7 +459,7 @@ public class PathsToJsonTreeTest {
                     + "      ]"
                     + "   }"
                     + "}";
-            assertEquals(parseJson(expectedRow), rows.get(0));
+            assertEquals(parseJson(expectedRow), removeElementId(rows.get(0)));
         }
     }
 
@@ -488,8 +511,8 @@ public class PathsToJsonTreeTest {
                     + "      \"_id\":2"
                     + "   }"
                     + "}";
-            assertEquals(parseJson(expectedFirstRow), rows.get(0));
-            assertEquals(parseJson(expectedSecondRow), rows.get(1));
+            assertEquals(parseJson(expectedFirstRow), removeElementId(rows.get(0)));
+            assertEquals(parseJson(expectedSecondRow), removeElementId(rows.get(1)));
         }
     }
 
@@ -526,7 +549,7 @@ public class PathsToJsonTreeTest {
                     + "      \"_id\":0"
                     + "   }"
                     + "}";
-            assertEquals(parseJson(expectedRow), rows.get(0));
+            assertEquals(parseJson(expectedRow), removeElementId(rows.get(0)));
         }
     }
 
@@ -563,7 +586,7 @@ public class PathsToJsonTreeTest {
                     + "      \"_id\":0"
                     + "   }"
                     + "}";
-            assertEquals(parseJson(expectedRow), rows.get(0));
+            assertEquals(parseJson(expectedRow), removeElementId(rows.get(0)));
         }
     }
 }

--- a/it/src/test/java/apoc/it/core/ApocSplitTest.java
+++ b/it/src/test/java/apoc/it/core/ApocSplitTest.java
@@ -199,6 +199,7 @@ public class ApocSplitTest {
             "apoc.warmup.run",
             "apoc.stats.degrees",
             "apoc.help",
+            "apoc.paths.toJsonTree",
             "apoc.refactor.rename.label",
             "apoc.refactor.rename.type",
             "apoc.refactor.rename.nodeProperty",

--- a/test-utils/src/main/java/apoc/util/Neo4jContainerExtension.java
+++ b/test-utils/src/main/java/apoc/util/Neo4jContainerExtension.java
@@ -120,7 +120,7 @@ public class Neo4jContainerExtension extends Neo4jContainer<Neo4jContainerExtens
     }
 
     public String queryLogs() throws IOException, InterruptedException {
-       return execInContainer("cat", "logs/query.log").toString();
+        return execInContainer("cat", "logs/query.log").toString();
     }
 
     private void executeScript(String filePath) {


### PR DESCRIPTION
Cherry picked from https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4044

## What

Adds a new method `convert.paths.toTree` that deprecates `convert.toTree`.

Closes #3996, #3997

## Why

There were several problems with the old method. For paths:

```
v1 -> v2 -> v3
v2 -> v2 //self-loop
```

it was outputting:

```
v1 -> v2 -> v2
v2 -> v2
```

instead of:

```
v1 -> v2 -> v2
         -> v3
```

This PR adds a new method that:
* Fixes the behaviour for cyclic paths.
* Fixes the behaviour for bidirectional paths.
* Fixes the properties filter for both of the method when the nodes have several labels.