### PR TITLE
[NOID] Close resources for open readers

### DIFF
--- a/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
+++ b/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
@@ -205,8 +205,7 @@ public class CsvEntityLoader {
             final Object data,
             final String type,
             final GraphDatabaseService db,
-            final Map<String, Map<String, String>> idMapping,
-            final URLAccessChecker urlAccessChecker)
+            final Map<String, Map<String, String>> idMapping)
             throws IOException {
 
         try (final CountingReader reader = FileUtils.readerFor(data, clc.getCompressionAlgo(), urlAccessChecker)) {

--- a/core/src/main/java/apoc/export/csv/ImportCsv.java
+++ b/core/src/main/java/apoc/export/csv/ImportCsv.java
@@ -63,15 +63,15 @@ public class ImportCsv {
 
             final Map<String, Map<String, String>> idMapping = new HashMap<>();
             for (Map<String, Object> node : nodes) {
-                final Object data = node.getOrDefault("fileName", node.get("data"));
+                final Object fileName = node.getOrDefault("fileName", node.get("data"));
                 final List<String> labels = (List<String>) node.get("labels");
-                loader.loadNodes(data, labels, db, idMapping);
+                loader.loadNodes(fileName, labels, db, idMapping);
             }
 
             for (Map<String, Object> relationship : relationships) {
                 final Object fileName = relationship.getOrDefault("fileName", relationship.get("data"));
                 final String type = (String) relationship.get("type");
-                loader.loadRelationships(fileName, type, db, idMapping, urlAccessChecker);
+                loader.loadRelationships(fileName, type, db, idMapping);
             }
 
             return reporter.getTotal();

--- a/core/src/main/java/apoc/export/graphml/ExportGraphML.java
+++ b/core/src/main/java/apoc/export/graphml/ExportGraphML.java
@@ -99,10 +99,9 @@ public class ExportGraphML {
 
             if (exportConfig.storeNodeIds()) graphMLReader.storeNodeIds();
 
-            try (CountingReader reader = FileUtils.readerFor(urlOrBinaryFile, exportConfig.getCompressionAlgo(), urlAccessChecker)) {
-                graphMLReader.parseXML(
-                        reader,
-                        terminationGuard);
+            try (CountingReader reader =
+                    FileUtils.readerFor(urlOrBinaryFile, exportConfig.getCompressionAlgo(), urlAccessChecker)) {
+                graphMLReader.parseXML(reader, terminationGuard);
             }
 
             return reporter.getTotal();

--- a/core/src/main/java/apoc/export/graphml/ExportGraphML.java
+++ b/core/src/main/java/apoc/export/graphml/ExportGraphML.java
@@ -22,6 +22,7 @@ import apoc.ApocConfig;
 import apoc.Pools;
 import apoc.export.cypher.ExportFileManager;
 import apoc.export.cypher.FileManagerFactory;
+import apoc.export.util.CountingReader;
 import apoc.export.util.ExportConfig;
 import apoc.export.util.ExportUtils;
 import apoc.export.util.NodesAndRelsSubGraph;
@@ -98,9 +99,12 @@ public class ExportGraphML {
 
             if (exportConfig.storeNodeIds()) graphMLReader.storeNodeIds();
 
-            graphMLReader.parseXML(
-                    FileUtils.readerFor(urlOrBinaryFile, exportConfig.getCompressionAlgo(), urlAccessChecker),
-                    terminationGuard);
+            try (CountingReader reader = FileUtils.readerFor(urlOrBinaryFile, exportConfig.getCompressionAlgo(), urlAccessChecker)) {
+                graphMLReader.parseXML(
+                        reader,
+                        terminationGuard);
+            }
+
             return reporter.getTotal();
         });
         return Stream.of(result);

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
@@ -336,6 +336,7 @@ public class XmlGraphMLReader {
             tx.rollback();
             throw e;
         } finally {
+            reader.close();
             tx.close();
         }
         return count;

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
@@ -336,8 +336,8 @@ public class XmlGraphMLReader {
             tx.rollback();
             throw e;
         } finally {
-            reader.close();
             tx.close();
+            reader.close();
         }
         return count;
     }


### PR DESCRIPTION
Reports that the file is being reported as in use after the procedure has been used.