### PR TITLE
[WVuGDROz] Allow cypher.export.schema return using a stream

### DIFF
--- a/core/src/main/java/apoc/export/cypher/ExportCypher.java
+++ b/core/src/main/java/apoc/export/cypher/ExportCypher.java
@@ -142,9 +142,6 @@ public class ExportCypher {
             @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
         if (Util.isNullOrEmpty(fileName)) fileName = null;
         String source = String.format("database: nodes(%d), rels(%d)", Util.nodeCount(tx), Util.relCount(tx));
-        // streamStatements
-        config.put("stream", false);
-        config.put("streamStatements", false);
         return exportCypher(fileName, source, new DatabaseSubGraph(tx), new ExportConfig(config), true);
     }
 
@@ -195,7 +192,7 @@ public class ExportCypher {
             ExportFileManager cypherFileManager) {
         MultiStatementCypherSubGraphExporter exporter = new MultiStatementCypherSubGraphExporter(graph, c, db);
 
-        if (onlySchema) exporter.exportOnlySchema(cypherFileManager, c);
+        if (onlySchema) exporter.exportOnlySchema(cypherFileManager, reporter, c);
         else exporter.export(c, reporter, cypherFileManager);
     }
 

--- a/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
+++ b/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
@@ -26,6 +26,7 @@ import apoc.export.cypher.formatter.CypherFormatter;
 import apoc.export.cypher.formatter.CypherFormatterUtils;
 import apoc.export.util.ExportConfig;
 import apoc.export.util.ExportFormat;
+import apoc.export.util.ProgressReporter;
 import apoc.export.util.Reporter;
 import apoc.util.Util;
 import apoc.util.collection.Iterables;
@@ -118,10 +119,11 @@ public class MultiStatementCypherSubGraphExporter {
         reporter.done();
     }
 
-    public void exportOnlySchema(ExportFileManager cypherFileManager, ExportConfig config) {
+    public void exportOnlySchema(ExportFileManager cypherFileManager, ProgressReporter reporter, ExportConfig config) {
         PrintWriter schemaWriter = cypherFileManager.getPrintWriter("schema");
         exportSchema(schemaWriter, config);
         schemaWriter.close();
+        reporter.done();
     }
 
     // ---- Nodes ----


### PR DESCRIPTION
If stream is forced then a user must have their config set to allow export, even when filename is null which is that the user wants to stream those results. This was not streaming because the reporter never considered itself "done" so set done after schema values are collected.