### PR TITLE
[NOID] Update wait strategy

### DIFF
--- a/test-utils/src/main/java/apoc/util/Neo4jContainerExtension.java
+++ b/test-utils/src/main/java/apoc/util/Neo4jContainerExtension.java
@@ -192,14 +192,9 @@ public class Neo4jContainerExtension extends Neo4jContainer<Neo4jContainerExtens
                     .withReadTimeout(Duration.ofSeconds(3))
                     .withStartupTimeout(timeout));
         } else {
-            this.setWaitStrategy(Wait.forHttp("/")
-                    .forPort(7474)
-                    .forStatusCodeMatching(t -> {
-                        logger.debug("/ [" + t.toString() + "]");
-                        return t == 200;
-                    })
-                    .withReadTimeout(Duration.ofSeconds(3))
-                    .withStartupTimeout(timeout));
+            this.setWaitStrategy(
+                    Wait.forSuccessfulCommand("wget --no-verbose --tries=1 --spider localhost:7474 || exit 1")
+                            .withStartupTimeout(timeout));
         }
 
         return this;


### PR DESCRIPTION
HTTP wait strategy fails in certain builds when browser is not bundled.