### PR TITLE
[3yfKdDEx] Give a clear error message when a relationship is defined before its node

### DIFF
--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
@@ -379,6 +379,10 @@ public class XmlGraphMLReader {
         final String id = cache.get(sourceTargetValue);
         // without source/target config, we look for the internal id
         if (StringUtils.isBlank(nodeConfig.label)) {
+            if (id == null) {
+                throw new RuntimeException("The node with the given id: " + sourceTargetValue
+                        + " was not found. Check that it is defined before the referencing relationship.");
+            }
             return tx.getNodeByElementId(id);
         }
         // with source/target configured, we search a node with a specified label


### PR DESCRIPTION
If a relationship in a graphml file are defined before the nodes they reference, a null error is thrown which is not very descriptive. So this updates it to make it clearer.

Note, I looked into holding off and continuing with the nodes and coming back to the missed relationship, but it gets complicated because the file is read line by line and the properties etc are part of this. But let me know if you think we should be doing that approach instead. It is doable, but I am not sure of the use case (as this is the first issue finding this).