### PR TITLE
[hxmGFWvF] Only create a TriggerHandler if triggers are enabled.

### DIFF
--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -128,6 +128,7 @@ import org.neo4j.values.storable.Values;
  * @since 24.04.16
  */
 public class Util {
+
     public static final Label[] NO_LABELS = new Label[0];
     public static final String NODE_COUNT = "MATCH (n) RETURN count(*) as result";
     public static final String REL_COUNT = "MATCH ()-->() RETURN count(*) as result";
@@ -1301,10 +1302,11 @@ public class Util {
                 .toList();
     }
 
-    public static <T> T withBackOffRetries(Supplier<T> func, long initialTimeout, long upperTimeout) {
+    public static <T> T withBackOffRetries(Supplier<T> func, long initialTimeout, long upperTimeout, Log log) {
         T result = null;
+        var startTime = System.currentTimeMillis();
         var timeout = initialTimeout;
-        var lastTry = System.currentTimeMillis() - timeout;
+        var lastTry = startTime - timeout;
 
         while (true) {
             var timeStamp = System.currentTimeMillis();
@@ -1314,6 +1316,11 @@ public class Util {
                     break;
                 } catch (Exception e) {
                     if (timeout >= upperTimeout) {
+                        Long totalTime = (System.currentTimeMillis() - startTime) / 1000;
+                        if (log.isDebugEnabled()) {
+                            log.debug(String.format(
+                                    "Got %s: %s after %s seconds.", e.getClass(), e.getMessage(), totalTime));
+                        }
                         throw e;
                     }
                 }

--- a/core/src/main/java/apoc/CoreApocGlobalComponents.java
+++ b/core/src/main/java/apoc/CoreApocGlobalComponents.java
@@ -18,6 +18,8 @@
  */
 package apoc;
 
+import static apoc.ApocConfig.APOC_TRIGGER_ENABLED;
+
 import apoc.cypher.CypherInitializer;
 import apoc.trigger.TriggerHandler;
 import java.util.Collection;
@@ -34,15 +36,20 @@ public class CoreApocGlobalComponents implements ApocGlobalComponents {
 
     @Override
     public Map<String, Lifecycle> getServices(GraphDatabaseAPI db, ApocExtensionFactory.Dependencies dependencies) {
-        return Collections.singletonMap(
-                "trigger",
-                new TriggerHandler(
-                        db,
-                        dependencies.databaseManagementService(),
-                        dependencies.apocConfig(),
-                        dependencies.log().getUserLog(TriggerHandler.class),
-                        dependencies.pools(),
-                        dependencies.scheduler()));
+        var apocConfig = dependencies.apocConfig();
+
+        if (apocConfig.getConfig().getBoolean(APOC_TRIGGER_ENABLED)) {
+            return Collections.singletonMap(
+                    "trigger",
+                    new TriggerHandler(
+                            db,
+                            dependencies.databaseManagementService(),
+                            apocConfig,
+                            dependencies.log().getUserLog(TriggerHandler.class),
+                            dependencies.pools(),
+                            dependencies.scheduler()));
+        }
+        return Collections.emptyMap();
     }
 
     @Override

--- a/core/src/main/java/apoc/trigger/TriggerHandler.java
+++ b/core/src/main/java/apoc/trigger/TriggerHandler.java
@@ -18,7 +18,6 @@
  */
 package apoc.trigger;
 
-import static apoc.ApocConfig.APOC_TRIGGER_ENABLED;
 import static apoc.ApocConfig.apocConfig;
 import static apoc.SystemLabels.ApocTrigger;
 
@@ -79,9 +78,6 @@ public class TriggerHandler extends LifecycleAdapter implements TransactionEvent
 
     private final AtomicBoolean registeredWithKernel = new AtomicBoolean(false);
 
-    public static final String NOT_ENABLED_ERROR = "Triggers have not been enabled."
-            + " Set 'apoc.trigger.enabled=true' in your apoc.conf file located in the $NEO4J_HOME/conf/ directory.";
-
     public TriggerHandler(
             GraphDatabaseService db,
             DatabaseManagementService databaseManagementService,
@@ -95,16 +91,6 @@ public class TriggerHandler extends LifecycleAdapter implements TransactionEvent
         this.log = log;
         this.pools = pools;
         this.jobScheduler = jobScheduler;
-    }
-
-    private boolean isEnabled() {
-        return apocConfig.getBoolean(APOC_TRIGGER_ENABLED);
-    }
-
-    public void checkEnabled() {
-        if (!isEnabled()) {
-            throw new RuntimeException(NOT_ENABLED_ERROR);
-        }
     }
 
     public void updateCache() {
@@ -174,7 +160,6 @@ public class TriggerHandler extends LifecycleAdapter implements TransactionEvent
 
     public Map<String, Object> add(
             String name, String statement, Map<String, Object> selector, Map<String, Object> params) {
-        checkEnabled();
         final var previous = triggersSnapshot.get().get(name);
 
         withSystemDb(tx -> {
@@ -197,7 +182,6 @@ public class TriggerHandler extends LifecycleAdapter implements TransactionEvent
     }
 
     public Map<String, Object> remove(String name) {
-        checkEnabled();
         final var previous = triggersSnapshot.get().get(name);
 
         withSystemDb(tx -> {
@@ -216,7 +200,6 @@ public class TriggerHandler extends LifecycleAdapter implements TransactionEvent
     }
 
     public Map<String, Object> updatePaused(String name, boolean paused) {
-        checkEnabled();
         withSystemDb(tx -> {
             tx.findNodes(
                             ApocTrigger,
@@ -233,7 +216,6 @@ public class TriggerHandler extends LifecycleAdapter implements TransactionEvent
     }
 
     public Map<String, Map<String, Object>> removeAll() {
-        checkEnabled();
         final var previous = triggersSnapshot.get();
         withSystemDb(tx -> {
             tx.findNodes(ApocTrigger, SystemPropertyKeys.database.name(), db.databaseName())
@@ -246,7 +228,6 @@ public class TriggerHandler extends LifecycleAdapter implements TransactionEvent
     }
 
     public Map<String, Map<String, Object>> list() {
-        checkEnabled();
         return triggersSnapshot.get();
     }
 

--- a/core/src/main/java/apoc/trigger/TriggerHandler.java
+++ b/core/src/main/java/apoc/trigger/TriggerHandler.java
@@ -367,7 +367,8 @@ public class TriggerHandler extends LifecycleAdapter implements TransactionEvent
                     return result;
                 },
                 timeout,
-                upperTimeout);
+                upperTimeout,
+                log);
     }
 
     private long getLastUpdate() {

--- a/core/src/test/java/apoc/trigger/TriggerDisabledTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerDisabledTest.java
@@ -20,6 +20,7 @@ package apoc.trigger;
 
 import static apoc.ApocConfig.APOC_TRIGGER_ENABLED;
 import static apoc.ApocConfig.apocConfig;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import apoc.util.TestUtil;
@@ -61,43 +62,48 @@ public class TriggerDisabledTest {
 
     @Test
     public void testTriggerDisabledList() {
-        assertThrows(
-                TriggerHandler.NOT_ENABLED_ERROR,
+        Exception e = assertThrows(
+                "Expected a runtime error when running apoc.trigger.list with triggers disabled.",
                 RuntimeException.class,
                 () -> db.executeTransactionally(
                         "CALL apoc.trigger.list() YIELD name RETURN name", Map.of(), Result::resultAsString));
+        assertEquals(TriggerHandler.NOT_ENABLED_ERROR, e.getMessage());
     }
 
     @Test
     public void testTriggerDisabledAdd() {
-        assertThrows(
-                TriggerHandler.NOT_ENABLED_ERROR,
+        Exception e = assertThrows(
+                "Expected a runtime error when running apoc.trigger.add with triggers disabled.",
                 RuntimeException.class,
                 () -> db.executeTransactionally(
                         "CALL apoc.trigger.add('test-trigger', 'RETURN 1', {phase: 'before'}) YIELD name RETURN name"));
+        assertEquals(TriggerHandler.NOT_ENABLED_ERROR, e.getMessage());
     }
 
     @Test
     public void testTriggerDisabledRemove() {
-        assertThrows(
-                TriggerHandler.NOT_ENABLED_ERROR,
+        Exception e = assertThrows(
+                "Expected a runtime error when running apoc.trigger.remove with triggers disabled.",
                 RuntimeException.class,
                 () -> db.executeTransactionally("CALL apoc.trigger.remove('test-trigger')"));
+        assertEquals(TriggerHandler.NOT_ENABLED_ERROR, e.getMessage());
     }
 
     @Test
     public void testTriggerDisabledResume() {
-        assertThrows(
-                TriggerHandler.NOT_ENABLED_ERROR,
+        Exception e = assertThrows(
+                "Expected a runtime error when running apoc.trigger.resume with triggers disabled.",
                 RuntimeException.class,
                 () -> db.executeTransactionally("CALL apoc.trigger.resume('test-trigger')"));
+        assertEquals(TriggerHandler.NOT_ENABLED_ERROR, e.getMessage());
     }
 
     @Test
     public void testTriggerDisabledPause() {
-        assertThrows(
-                TriggerHandler.NOT_ENABLED_ERROR,
+        Exception e = assertThrows(
+                "Expected a runtime error when running apoc.trigger.pause with triggers disabled.",
                 RuntimeException.class,
                 () -> db.executeTransactionally("CALL apoc.trigger.pause('test-trigger')"));
+        assertEquals(TriggerHandler.NOT_ENABLED_ERROR, e.getMessage());
     }
 }

--- a/core/src/test/java/apoc/trigger/TriggerDisabledTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerDisabledTest.java
@@ -67,7 +67,7 @@ public class TriggerDisabledTest {
                 RuntimeException.class,
                 () -> db.executeTransactionally(
                         "CALL apoc.trigger.list() YIELD name RETURN name", Map.of(), Result::resultAsString));
-        assertEquals(TriggerHandler.NOT_ENABLED_ERROR, e.getMessage());
+        assertEquals(expectedDisabledError("apoc.trigger.list"), e.getMessage());
     }
 
     @Test
@@ -77,7 +77,7 @@ public class TriggerDisabledTest {
                 RuntimeException.class,
                 () -> db.executeTransactionally(
                         "CALL apoc.trigger.add('test-trigger', 'RETURN 1', {phase: 'before'}) YIELD name RETURN name"));
-        assertEquals(TriggerHandler.NOT_ENABLED_ERROR, e.getMessage());
+        assertEquals(expectedDisabledError("apoc.trigger.add"), e.getMessage());
     }
 
     @Test
@@ -86,7 +86,16 @@ public class TriggerDisabledTest {
                 "Expected a runtime error when running apoc.trigger.remove with triggers disabled.",
                 RuntimeException.class,
                 () -> db.executeTransactionally("CALL apoc.trigger.remove('test-trigger')"));
-        assertEquals(TriggerHandler.NOT_ENABLED_ERROR, e.getMessage());
+        assertEquals(expectedDisabledError("apoc.trigger.remove"), e.getMessage());
+    }
+
+    @Test
+    public void testTriggerDisabledRemoveAll() {
+        Exception e = assertThrows(
+                "Expected a runtime error when running apoc.trigger.removeAll with triggers disabled.",
+                RuntimeException.class,
+                () -> db.executeTransactionally("CALL apoc.trigger.removeAll()"));
+        assertEquals(expectedDisabledError("apoc.trigger.removeAll"), e.getMessage());
     }
 
     @Test
@@ -95,7 +104,7 @@ public class TriggerDisabledTest {
                 "Expected a runtime error when running apoc.trigger.resume with triggers disabled.",
                 RuntimeException.class,
                 () -> db.executeTransactionally("CALL apoc.trigger.resume('test-trigger')"));
-        assertEquals(TriggerHandler.NOT_ENABLED_ERROR, e.getMessage());
+        assertEquals(expectedDisabledError("apoc.trigger.resume"), e.getMessage());
     }
 
     @Test
@@ -104,6 +113,12 @@ public class TriggerDisabledTest {
                 "Expected a runtime error when running apoc.trigger.pause with triggers disabled.",
                 RuntimeException.class,
                 () -> db.executeTransactionally("CALL apoc.trigger.pause('test-trigger')"));
-        assertEquals(TriggerHandler.NOT_ENABLED_ERROR, e.getMessage());
+        assertEquals(expectedDisabledError("apoc.trigger.pause"), e.getMessage());
+    }
+
+    private String expectedDisabledError(String procedureName) {
+        return String.format(
+                "Failed to invoke procedure `%s`: Caused by: java.lang.RuntimeException: %s",
+                procedureName, Trigger.NOT_ENABLED_ERROR);
     }
 }

--- a/core/src/test/java/apoc/trigger/TriggerRestartTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerRestartTest.java
@@ -18,12 +18,12 @@
  */
 package apoc.trigger;
 
+import static apoc.ApocConfig.APOC_TRIGGER_ENABLED;
 import static apoc.trigger.TriggerTestUtil.TRIGGER_DEFAULT_REFRESH;
 import static apoc.trigger.TriggerTestUtil.awaitTriggerDiscovered;
 import static apoc.util.TestUtil.waitDbsAvailable;
 import static org.junit.Assert.assertEquals;
 
-import apoc.ApocConfig;
 import apoc.util.TestUtil;
 import java.io.IOException;
 import java.util.Collections;
@@ -54,6 +54,11 @@ public class TriggerRestartTest {
     public static final ProvideSystemProperty systemPropertyRule =
             new ProvideSystemProperty("apoc.trigger.refresh", String.valueOf(TRIGGER_DEFAULT_REFRESH));
 
+    // we cannot set via apocConfig().setProperty(apoc.trigger.enabled, ...) in `@Before`, because is too late
+    @ClassRule
+    public static final ProvideSystemProperty systemPropertyRule2 =
+            new ProvideSystemProperty(APOC_TRIGGER_ENABLED, String.valueOf(true));
+
     @Before
     public void setUp() throws IOException {
         databaseManagementService =
@@ -61,7 +66,6 @@ public class TriggerRestartTest {
         db = databaseManagementService.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
         sysDb = databaseManagementService.database(GraphDatabaseSettings.SYSTEM_DATABASE_NAME);
         waitDbsAvailable(db, sysDb);
-        ApocConfig.apocConfig().setProperty("apoc.trigger.enabled", "true");
         TestUtil.registerProcedure(db, TriggerNewProcedures.class, Trigger.class);
     }
 

--- a/core/src/test/java/apoc/trigger/TriggerTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerTest.java
@@ -19,7 +19,6 @@
 package apoc.trigger;
 
 import static apoc.ApocConfig.APOC_TRIGGER_ENABLED;
-import static apoc.ApocConfig.apocConfig;
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
 import static org.junit.Assert.*;
@@ -35,8 +34,10 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.ProvideSystemProperty;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Relationship;
@@ -53,6 +54,11 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
  */
 public class TriggerTest {
 
+    // we cannot set via apocConfig().setProperty(apoc.trigger.enabled, ...) in `@Before`, because is too late
+    @ClassRule
+    public static final ProvideSystemProperty systemPropertyRule =
+            new ProvideSystemProperty(APOC_TRIGGER_ENABLED, String.valueOf(true));
+
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule().withSetting(procedure_unrestricted, List.of("apoc*"));
 
@@ -62,7 +68,6 @@ public class TriggerTest {
     public void setUp() {
         start = System.currentTimeMillis();
         TestUtil.registerProcedure(db, Trigger.class, Nodes.class);
-        apocConfig().setProperty(APOC_TRIGGER_ENABLED, true);
     }
 
     @After

--- a/core/src/test/java/apoc/util/UtilTest.java
+++ b/core/src/test/java/apoc/util/UtilTest.java
@@ -38,6 +38,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.ResultTransformer;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.logging.NullLog;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -187,7 +188,7 @@ public class UtilTest {
     @Test
     public void testWithBackOffRetriesWithSuccess() {
         long start = System.currentTimeMillis();
-        int result = Util.withBackOffRetries(this::testFunction, 100, 2000);
+        int result = Util.withBackOffRetries(this::testFunction, 100, 2000, NullLog.getInstance());
         long time = System.currentTimeMillis() - start;
 
         assertEquals(4, result);
@@ -201,7 +202,9 @@ public class UtilTest {
     @Test
     public void testWithBackOffRetriesWithError() {
         long start = System.currentTimeMillis();
-        assertThrows(RuntimeException.class, () -> Util.withBackOffRetries(this::testFunction, 100, 300));
+        assertThrows(
+                RuntimeException.class,
+                () -> Util.withBackOffRetries(this::testFunction, 100, 300, NullLog.getInstance()));
 
         // The method should be run directly, after 200ms and after 400ms when it will fail
         // So the total time should be roughly 600 ms


### PR DESCRIPTION
Some of the TriggerHandler code, in particular the start() method was run even if triggers were disabled. This could cause issues in some edge cases as well as impact performance.

Also improve testing of disabled triggers.
