### PR TITLE
[NOID] Fix broken APOC test

### DIFF
--- a/core/src/test/java/apoc/util/LogsUtilTest.java
+++ b/core/src/test/java/apoc/util/LogsUtilTest.java
@@ -43,6 +43,6 @@ public class LogsUtilTest {
     public void whitespaceDeprecationSucceedsSanitization() {
         String sanitized = LogsUtil.sanitizeQuery(
                 "CREATE USER dum\u0085my IF NOT EXISTS SET PASSWORD 'pass12345' CHANGE NOT REQUIRED");
-        assertEquals(sanitized, "CREATE USER dum\u0085my IF NOT EXISTS SET PASSWORD '******' CHANGE NOT REQUIRED");
+        assertEquals(sanitized, "CREATE USER `dum\u0085my` IF NOT EXISTS SET PASSWORD '******' CHANGE NOT REQUIRED");
     }
 }


### PR DESCRIPTION
Because \u0085 is being removed, to help users keep consistent queries, this is quoted in 5 (and in 6), was a minor change that I wasn't expecting APOC to be testing of all places 😆