### PR TITLE
[NOID] Remove obsolete configuration

### DIFF
--- a/test-utils/src/main/java/apoc/util/TestContainerUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestContainerUtil.java
@@ -183,7 +183,6 @@ public class TestContainerUtil {
                 .withNeo4jConfig("dbms.logs.http.enabled", "true")
                 .withNeo4jConfig("dbms.logs.debug.level", "DEBUG")
                 .withNeo4jConfig("dbms.routing.driver.logging.level", "DEBUG")
-                .withNeo4jConfig("internal.dbms.type_constraints", "true")
                 .withFileSystemBind(logsDir.toString(), "/logs")
                 .withFileSystemBind(
                         canonicalPath, "/var/lib/neo4j/import") // map the "target/import" dir as the Neo4j's import dir


### PR DESCRIPTION
Fixes apoc tests after `internal.dbms.type_constraints` was removed in https://github.com/neo-technology/neo4j/pull/24597.