### PR TITLE
[d4rLFQqM] Align all export modes with quoting consistency

### DIFF
--- a/core/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/core/src/main/java/apoc/export/csv/CsvFormat.java
@@ -227,7 +227,8 @@ public class CsvFormat {
                                     String prop = s.split(":")[0];
                                     return prop.isEmpty()
                                             ? String.valueOf(getNodeId(tx, n.getElementId()))
-                                            : FormatUtils.toString(n.getProperty(prop, ""));
+                                            : FormatUtils.toString(
+                                                    n.getProperty(prop, null), config.shouldDifferentiateNulls());
                                 })
                                 .collect(Collectors.toList());
                     })
@@ -316,12 +317,12 @@ public class CsvFormat {
             if (config.isSeparateHeader()) {
                 try (PrintWriter pwHeader = writer.getPrintWriter("header." + name)) {
                     CSVWriter csvWriterHeader = getCsvWriter(pwHeader, config);
-                    csvWriterHeader.writeNext(headerNode.toArray(new String[headerNode.size()]), false);
+                    csvWriterHeader.writeNext(headerNode.toArray(new String[headerNode.size()]), applyQuotesToAll);
                 }
             } else {
-                csvWriter.writeNext(headerNode.toArray(new String[headerNode.size()]), false);
+                csvWriter.writeNext(headerNode.toArray(new String[headerNode.size()]), applyQuotesToAll);
             }
-            rows.forEach(row -> csvWriter.writeNext(row.toArray(new String[row.size()]), false));
+            rows.forEach(row -> csvWriter.writeNext(row.toArray(new String[row.size()]), applyQuotesToAll));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/core/src/main/java/apoc/export/csv/ExportCSV.java
+++ b/core/src/main/java/apoc/export/csv/ExportCSV.java
@@ -84,10 +84,11 @@ public class ExportCSV {
                     {
                             stream = false :: BOOLEAN,
                             batchSize = 20000 :: INTEGER,
-                            bulkImport = true :: BOOLEAN,
+                            bulkImport = false :: BOOLEAN,
                             timeoutSeconds = 100 :: INTEGER,
                             compression = 'None' :: STRING,
                             charset = 'UTF_8' :: STRING,
+                            quotes = 'always' :: ['always', 'none', 'ifNeeded'],
                             differentiateNulls = false :: BOOLEAN,
                             sampling = false :: BOOLEAN,
                             samplingConfig :: MAP
@@ -113,10 +114,10 @@ public class ExportCSV {
                     {
                             stream = false :: BOOLEAN,
                             batchSize = 20000 :: INTEGER,
-                            bulkImport = true :: BOOLEAN,
                             timeoutSeconds = 100 :: INTEGER,
                             compression = 'None' :: STRING,
                             charset = 'UTF_8' :: STRING,
+                            quotes = 'always' :: ['always', 'none', 'ifNeeded'],
                             differentiateNulls = false :: BOOLEAN,
                             sampling = false :: BOOLEAN,
                             samplingConfig :: MAP
@@ -143,10 +144,11 @@ public class ExportCSV {
                     {
                             stream = false :: BOOLEAN,
                             batchSize = 20000 :: INTEGER,
-                            bulkImport = true :: BOOLEAN,
+                            bulkImport = false :: BOOLEAN,
                             timeoutSeconds = 100 :: INTEGER,
                             compression = 'None' :: STRING,
                             charset = 'UTF_8' :: STRING,
+                            quotes = 'always' :: ['always', 'none', 'ifNeeded'],
                             differentiateNulls = false :: BOOLEAN,
                             sampling = false :: BOOLEAN,
                             samplingConfig :: MAP
@@ -177,10 +179,10 @@ public class ExportCSV {
                     {
                             stream = false :: BOOLEAN,
                             batchSize = 20000 :: INTEGER,
-                            bulkImport = true :: BOOLEAN,
                             timeoutSeconds = 100 :: INTEGER,
                             compression = 'None':: STRING,
                             charset = 'UTF_8' :: STRING,
+                            quotes = 'always' :: ['always', 'none', 'ifNeeded'],
                             differentiateNulls = false :: BOOLEAN,
                             sampling = false :: BOOLEAN,
                             samplingConfig :: MAP

--- a/core/src/main/java/apoc/export/csv/ExportCSV.java
+++ b/core/src/main/java/apoc/export/csv/ExportCSV.java
@@ -203,7 +203,7 @@ public class ExportCSV {
     private void preventBulkImport(ExportConfig config) {
         if (config.isBulkImport()) {
             throw new RuntimeException(
-                    "You can use the `bulkImport` only with apoc.export.all and apoc.export.csv.graph");
+                    "You can use the `bulkImport` only with apoc.export.csv.all and apoc.export.csv.graph");
         }
     }
 

--- a/core/src/main/java/apoc/export/cypher/ExportCypher.java
+++ b/core/src/main/java/apoc/export/cypher/ExportCypher.java
@@ -89,7 +89,7 @@ public class ExportCypher {
                     {
                             stream = false :: BOOLEAN,
                             batchSize = 20000 :: INTEGER,
-                            bulkImport = true :: BOOLEAN,
+                            bulkImport = false :: BOOLEAN,
                             timeoutSeconds = 100 :: INTEGER,
                             compression = 'None' :: STRING,
                             charset = 'UTF_8' :: STRING,
@@ -123,7 +123,7 @@ public class ExportCypher {
                     {
                             stream = false :: BOOLEAN,
                             batchSize = 20000 :: INTEGER,
-                            bulkImport = true :: BOOLEAN,
+                            bulkImport = false :: BOOLEAN,
                             timeoutSeconds = 100 :: INTEGER,
                             compression = 'None' :: STRING,
                             charset = 'UTF_8' :: STRING,
@@ -154,7 +154,7 @@ public class ExportCypher {
                     {
                             stream = false :: BOOLEAN,
                             batchSize = 20000 :: INTEGER,
-                            bulkImport = true :: BOOLEAN,
+                            bulkImport = false :: BOOLEAN,
                             timeoutSeconds = 100 :: INTEGER,
                             compression = 'None' :: STRING,
                             charset = 'UTF_8' :: STRING,
@@ -191,7 +191,7 @@ public class ExportCypher {
                     {
                             stream = false :: BOOLEAN,
                             batchSize = 20000 :: INTEGER,
-                            bulkImport = true :: BOOLEAN,
+                            bulkImport = false :: BOOLEAN,
                             timeoutSeconds = 100 :: INTEGER,
                             compression = 'None' :: STRING,
                             charset = 'UTF_8' :: STRING,
@@ -228,7 +228,7 @@ public class ExportCypher {
                     {
                             stream = false :: BOOLEAN,
                             batchSize = 20000 :: INTEGER,
-                            bulkImport = true :: BOOLEAN,
+                            bulkImport = false :: BOOLEAN,
                             timeoutSeconds = 100 :: INTEGER,
                             compression = 'None' :: STRING,
                             charset = 'UTF_8' :: STRING,

--- a/core/src/main/java/apoc/export/graphml/ExportGraphML.java
+++ b/core/src/main/java/apoc/export/graphml/ExportGraphML.java
@@ -142,7 +142,7 @@ public class ExportGraphML {
                     {
                             stream = false :: BOOLEAN,
                             batchSize = 20000 :: INTEGER,
-                            bulkImport = true :: BOOLEAN,
+                            bulkImport = false :: BOOLEAN,
                             timeoutSeconds = 100 :: INTEGER,
                             compression = 'None' :: STRING,
                             charset = 'UTF_8' :: STRING,
@@ -171,7 +171,7 @@ public class ExportGraphML {
                     {
                             stream = false :: BOOLEAN,
                             batchSize = 20000 :: INTEGER,
-                            bulkImport = true :: BOOLEAN,
+                            bulkImport = false :: BOOLEAN,
                             timeoutSeconds = 100 :: INTEGER,
                             compression = 'None' :: STRING,
                             charset = 'UTF_8' :: STRING,
@@ -199,7 +199,7 @@ public class ExportGraphML {
                     {
                             stream = false :: BOOLEAN,
                             batchSize = 20000 :: INTEGER,
-                            bulkImport = true :: BOOLEAN,
+                            bulkImport = false :: BOOLEAN,
                             timeoutSeconds = 100 :: INTEGER,
                             compression = 'None' :: STRING,
                             charset = 'UTF_8' :: STRING,
@@ -231,7 +231,7 @@ public class ExportGraphML {
                     {
                             stream = false :: BOOLEAN,
                             batchSize = 20000 :: INTEGER,
-                            bulkImport = true :: BOOLEAN,
+                            bulkImport = false :: BOOLEAN,
                             timeoutSeconds = 100 :: INTEGER,
                             compression = 'None' :: STRING,
                             charset = 'UTF_8' :: STRING,

--- a/core/src/main/java/apoc/export/json/ExportJson.java
+++ b/core/src/main/java/apoc/export/json/ExportJson.java
@@ -77,7 +77,7 @@ public class ExportJson {
                     {
                             stream = false :: BOOLEAN,
                             batchSize = 20000 :: INTEGER,
-                            bulkImport = true :: BOOLEAN,
+                            bulkImport = false :: BOOLEAN,
                             timeoutSeconds = 100 :: INTEGER,
                             compression = 'None' :: STRING,
                             charset = 'UTF_8' :: STRING,
@@ -107,7 +107,7 @@ public class ExportJson {
                     {
                             stream = false :: BOOLEAN,
                             batchSize = 20000 :: INTEGER,
-                            bulkImport = true :: BOOLEAN,
+                            bulkImport = false :: BOOLEAN,
                             timeoutSeconds = 100 :: INTEGER,
                             compression = 'None' :: STRING,
                             charset = 'UTF_8' :: STRING,
@@ -139,7 +139,7 @@ public class ExportJson {
                     {
                             stream = false :: BOOLEAN,
                             batchSize = 20000 :: INTEGER,
-                            bulkImport = true :: BOOLEAN,
+                            bulkImport = false :: BOOLEAN,
                             timeoutSeconds = 100 :: INTEGER,
                             compression = 'None' :: STRING,
                             charset = 'UTF_8' :: STRING,
@@ -170,7 +170,7 @@ public class ExportJson {
                     {
                             stream = false :: BOOLEAN,
                             batchSize = 20000 :: INTEGER,
-                            bulkImport = true :: BOOLEAN,
+                            bulkImport = false :: BOOLEAN,
                             timeoutSeconds = 100 :: INTEGER,
                             compression = 'None' :: STRING,
                             charset = 'UTF_8' :: STRING,

--- a/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
@@ -369,7 +369,7 @@ public class ExportCsvNeo4jAdminTest {
         Throwable except = ExceptionUtils.getRootCause(e);
         assertTrue(except instanceof RuntimeException);
         assertEquals(
-                "You can use the `bulkImport` only with apoc.export.all and apoc.export.csv.graph",
+                "You can use the `bulkImport` only with apoc.export.csv.all and apoc.export.csv.graph",
                 except.getMessage());
     }
 

--- a/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
@@ -51,45 +51,46 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 public class ExportCsvNeo4jAdminTest {
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_TYPES_NODE = String.format(
-            ":ID;born_2D:point;born_3D:point;localtime:localtime;time:time;dateTime:datetime;localDateTime:localdatetime;date:date;duration:duration;:LABEL%n");
+            "\":ID\";\"born_2D:point\";\"born_3D:point\";\"localtime:localtime\";\"time:time\";\"dateTime:datetime\";\"localDateTime:localdatetime\";\"date:date\";\"duration:duration\";\":LABEL\"%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_TYPES_NODE = String.format(
-            "6;\"{\"\"crs\"\":\"\"cartesian\"\",\"\"x\"\":2.3,\"\"y\"\":4.5,\"\"z\"\":null}\";\"{\"\"crs\"\":\"\"wgs-84-3d\"\",\"\"latitude\"\":12.78,\"\"longitude\"\":56.7,\"\"height\"\":100.0}\";12:50:35.556;12:50:35.556+01:00;2018-10-30T12:50:35.556+01:00;2018-10-30T19:32:24;2018-10-30;P5M1DT12H;Types%n");
+            "\"6\";\"{\"\"crs\"\":\"\"cartesian\"\",\"\"x\"\":2.3,\"\"y\"\":4.5,\"\"z\"\":null}\";\"{\"\"crs\"\":\"\"wgs-84-3d\"\",\"\"latitude\"\":12.78,\"\"longitude\"\":56.7,\"\"height\"\":100.0}\";\"12:50:35.556\";\"12:50:35.556+01:00\";\"2018-10-30T12:50:35.556+01:00\";\"2018-10-30T19:32:24\";\"2018-10-30\";\"P5M1DT12H\";\"Types\"%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS =
-            String.format(":ID;name;street;:LABEL%n");
+            String.format("\":ID\";\"name\";\"street\";\":LABEL\"%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS1 =
-            String.format(":ID;street;name;city;:LABEL%n");
+            String.format("\":ID\";\"street\";\"name\";\"city\";\":LABEL\"%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER =
-            String.format(":ID;name;age:long;:LABEL%n");
+            String.format("\":ID\";\"name\";\"age:long\";\":LABEL\"%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER1 =
-            String.format(":ID;name;age:long;male:boolean;kids;:LABEL%n");
+            String.format("\":ID\";\"name\";\"age:long\";\"male:boolean\";\"kids\";\":LABEL\"%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_KNOWS =
-            String.format(":START_ID;:END_ID;:TYPE%n");
+            String.format("\":START_ID\";\":END_ID\";\":TYPE\"%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_NEXT_DELIVERY =
-            String.format(":START_ID;:END_ID;:TYPE%n");
+            String.format("\":START_ID\";\":END_ID\";\":TYPE\"%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS =
-            String.format("4;Bar Sport;;Address%n" + "5;;via Benni;Address%n");
+            String.format("\"4\";\"Bar Sport\";\"\";\"Address\"%n" + "\"5\";\"\";\"via Benni\";\"Address\"%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS1 =
-            String.format("3;Via Garibaldi, 7;Andrea;Milano;\"Address1;Address\"%n");
+            String.format("\"3\";\"Via Garibaldi, 7\";\"Andrea\";\"Milano\";\"Address1;Address\"%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER =
-            String.format("1;bar;42;User%n" + "2;;12;User%n");
+            String.format("\"1\";\"bar\";\"42\";\"User\"%n" + "\"2\";\"\";\"12\";\"User\"%n");
 
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER1 =
-            String.format("0;\"foo \"\"the\"\" bar\";42;true;\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\";\"User1;User\"%n");
+    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER1 = String.format(
+            "\"0\";\"foo \"\"the\"\" bar\";\"42\";\"true\";\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\";\"User1;User\"%n");
 
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_KNOWS = String.format("0;1;KNOWS%n");
+    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_KNOWS =
+            String.format("\"0\";\"1\";\"KNOWS\"%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_NEXT_DELIVERY =
-            String.format("3;4;NEXT_DELIVERY%n");
+            String.format("\"3\";\"4\";\"NEXT_DELIVERY\"%n");
 
     private static final String GZIP_EXT = ".foo";
 
@@ -412,11 +413,13 @@ public class ExportCsvNeo4jAdminTest {
 
                     String file = dir.getParent() + File.separator;
                     String expectedNodesLarus = String.format(
-                            ":ID,id:long,name,:LABEL%n" + "%s,1,Andrea,User;Larus%n", map.get("sourceId"));
+                            "\":ID\",\"id:long\",\"name\",\":LABEL\"%n" + "\"%s\",\"1\",\"Andrea\",\"User;Larus\"%n",
+                            map.get("sourceId"));
                     String expectedNodesNeo4j = String.format(
-                            ":ID,id:long,name,:LABEL%n" + "%s,2,Michael,User;Neo4j%n", map.get("targetId"));
+                            "\":ID\",\"id:long\",\"name\",\":LABEL\"%n" + "\"%s\",\"2\",\"Michael\",\"User;Neo4j\"%n",
+                            map.get("targetId"));
                     String expectedRelsNeo4j = String.format(
-                            ":START_ID,:END_ID,:TYPE,id:long%n" + "%s,%s,KNOWS,10%n",
+                            "\":START_ID\",\":END_ID\",\":TYPE\",\"id:long\"%n" + "\"%s\",\"%s\",\"KNOWS\",\"10\"%n",
                             map.get("sourceId"), map.get("targetId"));
 
                     assertFileEquals(file, expectedNodesLarus, fileName + ".nodes.User.Larus.csv");

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -115,6 +115,51 @@ public class ExportCsvTest {
             ,,,,,,,,"3","4","NEXT_DELIVERY","","",""
             ,,,,,,,,"8","9","REL","0"," ",""
             """;
+    private static final String EXPECTED_ALL_ALWAYS_USER =
+            """
+            ":ID","name","age:long",":LABEL"
+            "1","bar","42","User"
+            "2","","12","User"
+            """;
+    private static final String EXPECTED_ALL_ALWAYS_USER1 =
+            """
+            ":ID","name","age:long","male:boolean","kids",":LABEL"
+            "0","foo","42","true","[""a"",""b"",""c""]","User1;User"
+            """;
+    private static final String EXPECTED_ALL_ALWAYS_ADDRESS =
+            """
+            ":ID","name","street",":LABEL"
+            "4","Bar Sport","","Address"
+            "5","","via Benni","Address"
+            """;
+    private static final String EXPECTED_ALL_ALWAYS_ADDRESS1 =
+            """
+            ":ID","street","name","city",":LABEL"
+            "3","Via Garibaldi, 7","Andrea","Milano","Address1;Address"
+            """;
+    private static final String EXPECTED_ALL_ALWAYS_ESCAPING =
+            """
+            ":ID","age:long","name",":LABEL"
+            "6","1","I am ""groot"", and more ","ESCAPING"
+            "7","2"," ","ESCAPING"
+            "8","3","","ESCAPING"
+            "9","4","","ESCAPING"
+            """;
+    private static final String EXPECTED_ALL_ALWAYS_KNOWS =
+            """
+            ":START_ID",":END_ID",":TYPE"
+            "0","1","KNOWS"
+            """;
+    private static final String EXPECTED_ALL_ALWAYS_NEXT_DELIVERY =
+            """
+            ":START_ID",":END_ID",":TYPE"
+            "3","4","NEXT_DELIVERY"
+            """;
+    private static final String EXPECTED_ALL_ALWAYS_REL =
+            """
+            ":START_ID",":END_ID",":TYPE","value2","value1","id:long"
+            "8","9","REL",""," ","0"
+            """;
 
     private static final String EXP_SAMPLE =
             """
@@ -155,6 +200,26 @@ public class ExportCsvTest {
             ,,,,,,,,3,4,NEXT_DELIVERY,,,
             ,,,,,,,,8,9,REL,0, ,
             """;
+
+    private static final String EXPECTED_ALL_NONE_USER1 =
+            """
+            :ID,name,age:long,male:boolean,kids,:LABEL
+            0,foo,42,true,["a","b","c"],User1;User
+            """;
+    private static final String EXPECTED_ALL_NONE_ADDRESS1 =
+            """
+            :ID,street,name,city,:LABEL
+            3,Via Garibaldi, 7,Andrea,Milano,Address1;Address
+            """;
+    private static final String EXPECTED_ALL_NONE_ESCAPING =
+            """
+            :ID,age:long,name,:LABEL
+            6,1,I am "groot", and more ,ESCAPING
+            7,2, ,ESCAPING
+            8,3,,ESCAPING
+            9,4,,ESCAPING
+            """;
+
     private static final String EXPECTED_ALL_IF_NEEDED_RELS =
             """
             ,,,,,,,,0,1,KNOWS,,,
@@ -177,6 +242,52 @@ public class ExportCsvTest {
             ,,,,,,,,0,1,KNOWS,,,
             ,,,,,,,,3,4,NEXT_DELIVERY,,,
             ,,,,,,,,8,9,REL,0, ,
+            """;
+
+    private static final String EXPECTED_ALL_IF_NEEDED_USER =
+            """
+            :ID,name,age:long,:LABEL
+            1,bar,42,User
+            2,,12,User
+            """;
+    private static final String EXPECTED_ALL_IF_NEEDED_USER1 =
+            """
+            :ID,name,age:long,male:boolean,kids,:LABEL
+            0,foo,42,true,"[""a"",""b"",""c""]",User1;User
+            """;
+    private static final String EXPECTED_ALL_IF_NEEDED_ADDRESS =
+            """
+            :ID,name,street,:LABEL
+            4,Bar Sport,,Address
+            5,,via Benni,Address
+            """;
+    private static final String EXPECTED_ALL_IF_NEEDED_ADDRESS1 =
+            """
+            :ID,street,name,city,:LABEL
+            3,"Via Garibaldi, 7",Andrea,Milano,Address1;Address
+            """;
+    private static final String EXPECTED_ALL_IF_NEEDED_ESCAPING =
+            """
+            :ID,age:long,name,:LABEL
+            6,1,"I am ""groot"", and more ",ESCAPING
+            7,2, ,ESCAPING
+            8,3,,ESCAPING
+            9,4,,ESCAPING
+            """;
+    private static final String EXPECTED_ALL_IF_NEEDED_KNOWS =
+            """
+            :START_ID,:END_ID,:TYPE
+            0,1,KNOWS
+            """;
+    private static final String EXPECTED_ALL_IF_NEEDED_NEXT_DELIVERY =
+            """
+            :START_ID,:END_ID,:TYPE
+            3,4,NEXT_DELIVERY
+            """;
+    private static final String EXPECTED_ALL_IF_NEEDED_REL =
+            """
+            :START_ID,:END_ID,:TYPE,value2,value1,id:long
+            8,9,REL,, ,0
             """;
     private static final String EXPECTED_QUERY_DIFFERENTIATE_NULLS_NONE =
             """
@@ -273,6 +384,33 @@ public class ExportCsvTest {
                     9,:ESCAPING,4,,,,,,,,,,,
                     """
                     + EXPECTED_ALL_IF_NEEDED_RELS;
+
+    private static final String EXPECTED_ALL_DIFFERENTIATE_NULLS_IF_NEEDED_USER =
+            """
+            :ID,name,age:long,:LABEL
+            1,bar,42,User
+            2,,12,User
+            """;
+    private static final String EXPECTED_ALL_DIFFERENTIATE_NULLS_IF_NEEDED_ADDRESS =
+            """
+            :ID,name,street,:LABEL
+            4,Bar Sport,,Address
+            5,,via Benni,Address
+            """;
+    private static final String EXPECTED_ALL_DIFFERENTIATE_NULLS_IF_NEEDED_ESCAPING =
+            """
+            :ID,age:long,name,:LABEL
+            6,1,"I am ""groot"", and more ",ESCAPING
+            7,2, ,ESCAPING
+            8,3,"",ESCAPING
+            9,4,,ESCAPING
+            """;
+    private static final String EXPECTED_ALL_DIFFERENTIATE_NULLS_IF_NEEDED_REL =
+            """
+            :START_ID,:END_ID,:TYPE,value2,value1,id:long
+            8,9,REL,"", ,0
+            """;
+
     private static final String EXPECTED_ALL_DIFFERENTIATE_NULLS_ALWAYS =
             """
             "_id","_labels","age","city","kids","male","name","street","_start","_end","_type","id","value1","value2"
@@ -362,6 +500,155 @@ public class ExportCsvTest {
                 map("file", fileName, "config", map("compression", compressionAlgo.name())),
                 (r) -> assertResults(fileName, r, "database"));
         assertEquals(EXPECTED_ALL_ALWAYS, readFile(fileName, UTF_8, compressionAlgo));
+    }
+
+    @Test
+    public void testConsistentQuotingAlways() {
+        // All in one file
+        String fileName1 = "allOneFileAlways.csv";
+        TestUtil.testCall(
+                db,
+                "CALL apoc.export.csv.all($file,{bulkImport: false})",
+                map("file", fileName1),
+                (r) -> assertResults(fileName1, r, "database"));
+        assertEquals(EXPECTED_ALL_ALWAYS, readFile(fileName1));
+
+        // In separate files
+        String fileNameStart = "allBulkImportAlways";
+        String fileName2 = fileNameStart + ".csv";
+        TestUtil.testCall(
+                db,
+                "CALL apoc.export.csv.all($file,{bulkImport: true})",
+                map("file", fileName2),
+                (r) -> assertResults(fileName2, r, "database"));
+        assertEquals(EXPECTED_ALL_ALWAYS_USER, readFile(fileNameStart + ".nodes.User.csv"));
+        assertEquals(EXPECTED_ALL_ALWAYS_USER1, readFile(fileNameStart + ".nodes.User1.User.csv"));
+        assertEquals(EXPECTED_ALL_ALWAYS_ADDRESS, readFile(fileNameStart + ".nodes.Address.csv"));
+        assertEquals(EXPECTED_ALL_ALWAYS_ADDRESS1, readFile(fileNameStart + ".nodes.Address1.Address.csv"));
+        assertEquals(EXPECTED_ALL_ALWAYS_ESCAPING, readFile(fileNameStart + ".nodes.ESCAPING.csv"));
+        assertEquals(EXPECTED_ALL_ALWAYS_KNOWS, readFile(fileNameStart + ".relationships.KNOWS.csv"));
+        assertEquals(EXPECTED_ALL_ALWAYS_NEXT_DELIVERY, readFile(fileNameStart + ".relationships.NEXT_DELIVERY.csv"));
+        assertEquals(EXPECTED_ALL_ALWAYS_REL, readFile(fileNameStart + ".relationships.REL.csv"));
+
+        // Streaming
+        TestUtil.testCall(db, "CALL apoc.export.csv.all(null,{stream: true})", (r) -> {
+            String data = (String) r.get("data");
+            assertEquals(EXPECTED_ALL_ALWAYS, data);
+        });
+    }
+
+    @Test
+    public void testConsistentQuotingIfNeeded() {
+        // All in one file
+        String fileName1 = "allOneFileIfNeeded.csv";
+        TestUtil.testCall(
+                db,
+                "CALL apoc.export.csv.all($file,{bulkImport: false, quotes: 'ifNeeded'})",
+                map("file", fileName1),
+                (r) -> assertResults(fileName1, r, "database"));
+        assertEquals(EXPECTED_ALL_IF_NEEDED, readFile(fileName1));
+
+        // In separate files
+        String fileNameStart = "allBulkImportIfNeeded";
+        String fileName2 = fileNameStart + ".csv";
+        TestUtil.testCall(
+                db,
+                "CALL apoc.export.csv.all($file,{bulkImport: true, quotes: 'ifNeeded'})",
+                map("file", fileName2),
+                (r) -> assertResults(fileName2, r, "database"));
+        assertEquals(EXPECTED_ALL_IF_NEEDED_USER, readFile(fileNameStart + ".nodes.User.csv"));
+        assertEquals(EXPECTED_ALL_IF_NEEDED_USER1, readFile(fileNameStart + ".nodes.User1.User.csv"));
+        assertEquals(EXPECTED_ALL_IF_NEEDED_ADDRESS, readFile(fileNameStart + ".nodes.Address.csv"));
+        assertEquals(EXPECTED_ALL_IF_NEEDED_ADDRESS1, readFile(fileNameStart + ".nodes.Address1.Address.csv"));
+        assertEquals(EXPECTED_ALL_IF_NEEDED_ESCAPING, readFile(fileNameStart + ".nodes.ESCAPING.csv"));
+        assertEquals(EXPECTED_ALL_IF_NEEDED_KNOWS, readFile(fileNameStart + ".relationships.KNOWS.csv"));
+        assertEquals(
+                EXPECTED_ALL_IF_NEEDED_NEXT_DELIVERY, readFile(fileNameStart + ".relationships.NEXT_DELIVERY.csv"));
+        assertEquals(EXPECTED_ALL_IF_NEEDED_REL, readFile(fileNameStart + ".relationships.REL.csv"));
+
+        // Streaming
+        TestUtil.testCall(db, "CALL apoc.export.csv.all(null,{stream: true, quotes: 'ifNeeded'})", (r) -> {
+            String data = (String) r.get("data");
+            assertEquals(EXPECTED_ALL_IF_NEEDED, data);
+        });
+    }
+
+    @Test
+    public void testConsistentQuotingIfNeededDifferentiateNulls() {
+        // All in one file
+        String fileName1 = "allOneFileIfNeeded.csv";
+        TestUtil.testCall(
+                db,
+                "CALL apoc.export.csv.all($file,{bulkImport: false, quotes: 'ifNeeded', differentiateNulls: true})",
+                map("file", fileName1),
+                (r) -> assertResults(fileName1, r, "database"));
+        assertEquals(EXPECTED_ALL_DIFFERENTIATE_NULLS_IF_NEEDED, readFile(fileName1));
+
+        // In separate files
+        String fileNameStart = "allBulkImportIfNeeded";
+        String fileName2 = fileNameStart + ".csv";
+        TestUtil.testCall(
+                db,
+                "CALL apoc.export.csv.all($file,{bulkImport: true, quotes: 'ifNeeded', differentiateNulls: true})",
+                map("file", fileName2),
+                (r) -> assertResults(fileName2, r, "database"));
+        assertEquals(EXPECTED_ALL_DIFFERENTIATE_NULLS_IF_NEEDED_USER, readFile(fileNameStart + ".nodes.User.csv"));
+        assertEquals(EXPECTED_ALL_IF_NEEDED_USER1, readFile(fileNameStart + ".nodes.User1.User.csv"));
+        assertEquals(
+                EXPECTED_ALL_DIFFERENTIATE_NULLS_IF_NEEDED_ADDRESS, readFile(fileNameStart + ".nodes.Address.csv"));
+        assertEquals(EXPECTED_ALL_IF_NEEDED_ADDRESS1, readFile(fileNameStart + ".nodes.Address1.Address.csv"));
+        assertEquals(
+                EXPECTED_ALL_DIFFERENTIATE_NULLS_IF_NEEDED_ESCAPING, readFile(fileNameStart + ".nodes.ESCAPING.csv"));
+        assertEquals(EXPECTED_ALL_IF_NEEDED_KNOWS, readFile(fileNameStart + ".relationships.KNOWS.csv"));
+        assertEquals(
+                EXPECTED_ALL_IF_NEEDED_NEXT_DELIVERY, readFile(fileNameStart + ".relationships.NEXT_DELIVERY.csv"));
+        assertEquals(
+                EXPECTED_ALL_DIFFERENTIATE_NULLS_IF_NEEDED_REL, readFile(fileNameStart + ".relationships.REL.csv"));
+
+        // Streaming
+        TestUtil.testCall(
+                db,
+                "CALL apoc.export.csv.all(null,{stream: true, quotes: 'ifNeeded', differentiateNulls: true})",
+                (r) -> {
+                    String data = (String) r.get("data");
+                    assertEquals(EXPECTED_ALL_DIFFERENTIATE_NULLS_IF_NEEDED, data);
+                });
+    }
+
+    @Test
+    public void testConsistentQuotingNone() {
+        // All in one file
+        String fileName1 = "allOneFileNone.csv";
+        TestUtil.testCall(
+                db,
+                "CALL apoc.export.csv.all($file,{bulkImport: false, quotes: 'none'})",
+                map("file", fileName1),
+                (r) -> assertResults(fileName1, r, "database"));
+        assertEquals(EXPECTED_ALL_NONE, readFile(fileName1));
+
+        // In separate files
+        String fileNameStart = "allBulkImportIfNone";
+        String fileName2 = fileNameStart + ".csv";
+        TestUtil.testCall(
+                db,
+                "CALL apoc.export.csv.all($file,{bulkImport: true, quotes: 'none'})",
+                map("file", fileName2),
+                (r) -> assertResults(fileName2, r, "database"));
+        assertEquals(EXPECTED_ALL_IF_NEEDED_USER, readFile(fileNameStart + ".nodes.User.csv"));
+        assertEquals(EXPECTED_ALL_NONE_USER1, readFile(fileNameStart + ".nodes.User1.User.csv"));
+        assertEquals(EXPECTED_ALL_IF_NEEDED_ADDRESS, readFile(fileNameStart + ".nodes.Address.csv"));
+        assertEquals(EXPECTED_ALL_NONE_ADDRESS1, readFile(fileNameStart + ".nodes.Address1.Address.csv"));
+        assertEquals(EXPECTED_ALL_NONE_ESCAPING, readFile(fileNameStart + ".nodes.ESCAPING.csv"));
+        assertEquals(EXPECTED_ALL_IF_NEEDED_KNOWS, readFile(fileNameStart + ".relationships.KNOWS.csv"));
+        assertEquals(
+                EXPECTED_ALL_IF_NEEDED_NEXT_DELIVERY, readFile(fileNameStart + ".relationships.NEXT_DELIVERY.csv"));
+        assertEquals(EXPECTED_ALL_IF_NEEDED_REL, readFile(fileNameStart + ".relationships.REL.csv"));
+
+        // Streaming
+        TestUtil.testCall(db, "CALL apoc.export.csv.all(null,{stream: true, quotes: 'none'})", (r) -> {
+            String data = (String) r.get("data");
+            assertEquals(EXPECTED_ALL_NONE, data);
+        });
     }
 
     @Test

--- a/core/src/test/resources/procedures.json
+++ b/core/src/test/resources/procedures.json
@@ -2394,7 +2394,7 @@
     "type" : "STRING"
   }, {
     "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = true :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        differentiateNulls = false :: BOOLEAN,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        quotes = 'always' :: ['always', 'none', 'ifNeeded'],\n        differentiateNulls = false :: BOOLEAN,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
     "isDeprecated" : false,
     "type" : "MAP"
   } ]
@@ -2482,7 +2482,7 @@
     "type" : "STRING"
   }, {
     "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = true :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        differentiateNulls = false :: BOOLEAN,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        quotes = 'always' :: ['always', 'none', 'ifNeeded'],\n        differentiateNulls = false :: BOOLEAN,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
     "isDeprecated" : false,
     "type" : "MAP"
   } ]
@@ -2565,7 +2565,7 @@
     "type" : "STRING"
   }, {
     "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = true :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        differentiateNulls = false :: BOOLEAN,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        quotes = 'always' :: ['always', 'none', 'ifNeeded'],\n        differentiateNulls = false :: BOOLEAN,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
     "isDeprecated" : false,
     "type" : "MAP"
   } ]
@@ -2648,7 +2648,7 @@
     "type" : "STRING"
   }, {
     "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = true :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None':: STRING,\n        charset = 'UTF_8' :: STRING,\n        differentiateNulls = false :: BOOLEAN,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None':: STRING,\n        charset = 'UTF_8' :: STRING,\n        quotes = 'always' :: ['always', 'none', 'ifNeeded'],\n        differentiateNulls = false :: BOOLEAN,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
     "isDeprecated" : false,
     "type" : "MAP"
   } ]
@@ -2742,7 +2742,7 @@
     "type" : "STRING"
   }, {
     "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = true :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
     "isDeprecated" : false,
     "default" : "DefaultParameterValue{value={}, type=MAP}",
     "type" : "MAP"
@@ -2847,7 +2847,7 @@
     "type" : "STRING"
   }, {
     "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = true :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
     "isDeprecated" : false,
     "default" : "DefaultParameterValue{value={}, type=MAP}",
     "type" : "MAP"
@@ -2946,7 +2946,7 @@
     "type" : "STRING"
   }, {
     "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = true :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
     "isDeprecated" : false,
     "default" : "DefaultParameterValue{value={}, type=MAP}",
     "type" : "MAP"
@@ -3046,7 +3046,7 @@
     "type" : "STRING"
   }, {
     "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = true :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
     "isDeprecated" : false,
     "default" : "DefaultParameterValue{value={}, type=MAP}",
     "type" : "MAP"
@@ -3141,7 +3141,7 @@
     "type" : "STRING"
   }, {
     "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = true :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
     "isDeprecated" : false,
     "default" : "DefaultParameterValue{value={}, type=MAP}",
     "type" : "MAP"
@@ -3220,7 +3220,7 @@
     "type" : "STRING"
   }, {
     "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = true :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
     "isDeprecated" : false,
     "type" : "MAP"
   } ]
@@ -3308,7 +3308,7 @@
     "type" : "STRING"
   }, {
     "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = true :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
     "isDeprecated" : false,
     "type" : "MAP"
   } ]
@@ -3391,7 +3391,7 @@
     "type" : "STRING"
   }, {
     "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = true :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
     "isDeprecated" : false,
     "type" : "MAP"
   } ]
@@ -3474,7 +3474,7 @@
     "type" : "STRING"
   }, {
     "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = true :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
     "isDeprecated" : false,
     "type" : "MAP"
   } ]
@@ -3552,7 +3552,7 @@
     "type" : "STRING"
   }, {
     "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = true :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
     "isDeprecated" : false,
     "default" : "DefaultParameterValue{value={}, type=MAP}",
     "type" : "MAP"
@@ -3641,7 +3641,7 @@
     "type" : "STRING"
   }, {
     "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = true :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
     "isDeprecated" : false,
     "default" : "DefaultParameterValue{value={}, type=MAP}",
     "type" : "MAP"
@@ -3725,7 +3725,7 @@
     "type" : "STRING"
   }, {
     "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = true :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
     "isDeprecated" : false,
     "default" : "DefaultParameterValue{value={}, type=MAP}",
     "type" : "MAP"
@@ -3809,7 +3809,7 @@
     "type" : "STRING"
   }, {
     "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = true :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
     "isDeprecated" : false,
     "default" : "DefaultParameterValue{value={}, type=MAP}",
     "type" : "MAP"


### PR DESCRIPTION
When bulkImport was set to true, the quoting option the user input no longer worked. This PR makes the quoting work again and makes sure the defaults align with how it works for streaming and when bulkImport is false.