### PR TITLE
[yVM4sJbH]  Dev fix round trip for csv loading

### DIFF
--- a/common/src/main/java/apoc/load/Mapping.java
+++ b/common/src/main/java/apoc/load/Mapping.java
@@ -110,8 +110,10 @@ public class Mapping {
                 return DateValue.parse(value).asObjectCopy();
             case DURATION:
                 return DurationValue.parse(value);
+            case LONG:
             case INTEGER:
                 return Util.toLong(value);
+            case DOUBLE:
             case FLOAT:
                 return Util.toDouble(value);
             case BOOLEAN:

--- a/common/src/main/java/apoc/meta/Types.java
+++ b/common/src/main/java/apoc/meta/Types.java
@@ -41,6 +41,8 @@ import org.neo4j.graphdb.spatial.Point;
 import org.neo4j.values.storable.DurationValue;
 
 public enum Types {
+    LONG,
+    DOUBLE,
     INTEGER,
     FLOAT,
     STRING,


### PR DESCRIPTION
Long and Double types can be exported but not imported, so this PR allows for them to be imported (if CSV header says prop:long or prop:double for example).

This PR builds on top of https://github.com/neo4j/apoc/pull/665