### PR TITLE
[bkym7TcZ] Optimise apoc.refactor.cloneSubgraph

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     testImplementation group: 'org.neo4j.community', name: 'it-test-support', version: neo4jVersionEffective // , classifier: "tests"
     testImplementation group: 'org.neo4j', name: 'log-test-utils', version: neo4jVersionEffective // , classifier: "tests"
     testImplementation group: 'org.neo4j', name: 'neo4j-kernel', version: neo4jVersionEffective, classifier: "tests"
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.13.2'
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.26.3'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.2.0'
     testImplementation group: 'pl.pragmatists', name: 'JUnitParams', version: '1.1.1'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     testImplementation group: 'org.mock-server', name: 'mockserver-netty', version: '5.15.0', {
         exclude group: 'org.slf4j', module: 'slf4j-api'
     }
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'

--- a/core/src/test/resources/procedures.json
+++ b/core/src/test/resources/procedures.json
@@ -6477,7 +6477,7 @@
   } ]
 }, {
   "isDeprecated" : false,
-  "signature" : "apoc.refactor.cloneSubgraph(nodes :: LIST<NODE>, rels = [] :: LIST<RELATIONSHIP>, config = {} :: MAP) :: (input :: INTEGER, output :: NODE, error :: STRING)",
+  "signature" : "apoc.refactor.cloneSubgraph(nodes :: LIST<NODE>, rels = [] :: LIST<RELATIONSHIP>, config = {} :: MAP) :: (input :: INTEGER, output :: NODE, error :: STRING, createNodesInNewTransactions = false :: BOOLEAN)",
   "name" : "apoc.refactor.cloneSubgraph",
   "description" : "Clones the given `NODE` values with their labels and properties (optionally skipping any properties in the `skipProperties` `LIST<STRING>` via the config `MAP`), and clones the given `RELATIONSHIP` values.\nIf no `RELATIONSHIP` values are provided, all existing `RELATIONSHIP` values between the given `NODE` values will be cloned.",
   "returnDescription" : [ {

--- a/core/src/test/resources/procedures.json
+++ b/core/src/test/resources/procedures.json
@@ -6477,7 +6477,7 @@
   } ]
 }, {
   "isDeprecated" : false,
-  "signature" : "apoc.refactor.cloneSubgraph(nodes :: LIST<NODE>, rels = [] :: LIST<RELATIONSHIP>, config = {} :: MAP) :: (input :: INTEGER, output :: NODE, error :: STRING, createNodesInNewTransactions = false :: BOOLEAN)",
+  "signature" : "apoc.refactor.cloneSubgraph(nodes :: LIST<NODE>, rels = [] :: LIST<RELATIONSHIP>, config = {} :: MAP) :: (input :: INTEGER, output :: NODE, error :: STRING)",
   "name" : "apoc.refactor.cloneSubgraph",
   "description" : "Clones the given `NODE` values with their labels and properties (optionally skipping any properties in the `skipProperties` `LIST<STRING>` via the config `MAP`), and clones the given `RELATIONSHIP` values.\nIf no `RELATIONSHIP` values are provided, all existing `RELATIONSHIP` values between the given `NODE` values will be cloned.",
   "returnDescription" : [ {
@@ -6510,7 +6510,7 @@
     "type" : "LIST<RELATIONSHIP>"
   }, {
     "name" : "config",
-    "description" : "{\n    standinNodes :: LIST<LIST<NODE>>,\n    skipProperties :: LIST<STRING>\n}\n",
+    "description" : "{\n    standinNodes :: LIST<LIST<NODE>>,\n    skipProperties :: LIST<STRING>,\n    createNodesInNewTransactions = false :: BOOLEAN\n}\n",
     "isDeprecated" : false,
     "default" : "DefaultParameterValue{value={}, type=MAP}",
     "type" : "MAP"

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     api 'com.squareup:javapoet:1.13.0'
     testImplementation 'com.google.testing.compile:compile-testing:0.19'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation 'org.assertj:assertj-core:3.19.0'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.mockito:mockito-core:4.2.0'
 }
 


### PR DESCRIPTION
Add option `createNodesInNewTransactions` to `apoc.refactor.cloneSubgraph` that let's you control if nodes are created in inner transactions. Previous behavior was to create each node in a new transaction (relationships were not though, surprisingly). New default behavior is to use the outer transaction for all writes (`createNodesInNewTransactions = true` gives the old behavior still).