### PR TITLE
[NOID] show the :: without an irritating space in between

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -305,6 +305,7 @@ With gradle - ./gradlew test
 Or as normal, click the play button on the test you would like to run.
 // end::tests[]
 // tag::codestyle[]
+
 === Applying Code-style
 
 ----

--- a/readme.adoc
+++ b/readme.adoc
@@ -127,7 +127,7 @@ You can see the procedure's signature in the output of `CALL apoc.help("name")`
 CALL apoc.help("dijkstra")
 ----
 
-The signature is always `name : : TYPE`, so in this case:
+The signature is always `name +::+ TYPE`, so in this case:
 
 ----
 apoc.algo.dijkstra


### PR DESCRIPTION
The README shows `name : : TYPE` with an irritating space in between.

## Proposed Changes (Mandatory)

Get rid of the space and make the README show `name :: TYPE`.
