### PR TITLE
Fixed batches being shifted by one in arrow.export

### DIFF
--- a/common/src/main/java/apoc/export/util/ProgressReporter.java
+++ b/common/src/main/java/apoc/export/util/ProgressReporter.java
@@ -95,7 +95,7 @@ public class ProgressReporter implements Reporter {
 
     @Override
     public void done() {
-        if (totalEntities / batchSize == lastBatch) lastBatch++;
+        if (totalEntities % batchSize != 0) lastBatch++;
         updateRunningBatch(progressInfo);
         progressInfo.done(start);
         if (consumer != null) {


### PR DESCRIPTION
Ensure that the number of batches are only shifted when needed due to uneven last batch. 