### PR TITLE
Update description of apoc.load.jsonParams

### DIFF
--- a/core/src/main/java/apoc/load/LoadJson.java
+++ b/core/src/main/java/apoc/load/LoadJson.java
@@ -112,9 +112,8 @@ public class LoadJson {
     @Procedure(name = "apoc.load.jsonParams", deprecatedBy = "This procedure is being moved to APOC Extended.")
     @Deprecated
     @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
-    @Description(
-            "Loads a JSON document from a URL (e.g. web-API) as a stream of values if the given JSON document is a `LIST<ANY>`.\n"
-                    + "If the given JSON file is a `MAP`, this procedure imports a single value instead.")
+    @Description("Loads a JSON document from a URL (e.g. web-API) as a stream of values if the given JSON document is a `LIST<ANY>`.\n"
+            + "If the given JSON file is a `MAP`, this procedure imports a single value instead.")
     public Stream<LoadDataMapResult> jsonParams(
             @Name(
                             value = "urlOrKeyOrBinary",

--- a/core/src/main/java/apoc/load/LoadJson.java
+++ b/core/src/main/java/apoc/load/LoadJson.java
@@ -113,12 +113,12 @@ public class LoadJson {
     @Deprecated
     @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
     @Description(
-            "Loads parameters from a JSON URL (e.g. web-API) as a stream of values if the given JSON file is a `LIST<ANY>`.\n"
+            "Loads a JSON document from a URL (e.g. web-API) as a stream of values if the given JSON document is a `LIST<ANY>`.\n"
                     + "If the given JSON file is a `MAP`, this procedure imports a single value instead.")
     public Stream<LoadDataMapResult> jsonParams(
             @Name(
                             value = "urlOrKeyOrBinary",
-                            description = "The name of the file or binary data to import the data from.")
+                            description = "The name of the file or binary data to import the data from. Note that a URL needs to be properly encoded to conform with the URI standard.")
                     Object urlOrKeyOrBinary,
             @Name(value = "headers", description = "Headers to be used when connecting to the given URL.")
                     Map<String, Object> headers,
@@ -127,7 +127,9 @@ public class LoadJson {
             @Name(
                             value = "path",
                             defaultValue = "",
-                            description = "A JSON path expression used to extract a certain part from the list.")
+                            description = "A JSON path expression used to extract specific subparts of the JSON document " +
+                                          "(extracted by a link:https://en.wikipedia.org/wiki/JSONPath[JSONPath] expression). " +
+                                          "The default is: ``.")
                     String path,
             @Name(
                             value = "config",

--- a/core/src/main/java/apoc/load/LoadJson.java
+++ b/core/src/main/java/apoc/load/LoadJson.java
@@ -118,7 +118,8 @@ public class LoadJson {
     public Stream<LoadDataMapResult> jsonParams(
             @Name(
                             value = "urlOrKeyOrBinary",
-                            description = "The name of the file or binary data to import the data from. Note that a URL needs to be properly encoded to conform with the URI standard.")
+                            description = "The name of the file or binary data to import the data from. " +
+                                          "Note that a URL needs to be properly encoded to conform with the URI standard.")
                     Object urlOrKeyOrBinary,
             @Name(value = "headers", description = "Headers to be used when connecting to the given URL.")
                     Map<String, Object> headers,

--- a/core/src/main/java/apoc/load/LoadJson.java
+++ b/core/src/main/java/apoc/load/LoadJson.java
@@ -112,13 +112,14 @@ public class LoadJson {
     @Procedure(name = "apoc.load.jsonParams", deprecatedBy = "This procedure is being moved to APOC Extended.")
     @Deprecated
     @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
-    @Description("Loads a JSON document from a URL (e.g. web-API) as a stream of values if the given JSON document is a `LIST<ANY>`.\n"
-            + "If the given JSON file is a `MAP`, this procedure imports a single value instead.")
+    @Description(
+            "Loads a JSON document from a URL (e.g. web-API) as a stream of values if the given JSON document is a `LIST<ANY>`.\n"
+                    + "If the given JSON file is a `MAP`, this procedure imports a single value instead.")
     public Stream<LoadDataMapResult> jsonParams(
             @Name(
                             value = "urlOrKeyOrBinary",
-                            description = "The name of the file or binary data to import the data from. " +
-                                          "Note that a URL needs to be properly encoded to conform with the URI standard.")
+                            description = "The name of the file or binary data to import the data from. "
+                                    + "Note that a URL needs to be properly encoded to conform with the URI standard.")
                     Object urlOrKeyOrBinary,
             @Name(value = "headers", description = "Headers to be used when connecting to the given URL.")
                     Map<String, Object> headers,
@@ -127,9 +128,10 @@ public class LoadJson {
             @Name(
                             value = "path",
                             defaultValue = "",
-                            description = "A JSON path expression used to extract specific subparts of the JSON document " +
-                                          "(extracted by a link:https://en.wikipedia.org/wiki/JSONPath[JSONPath] expression). " +
-                                          "The default is: ``.")
+                            description =
+                                    "A JSON path expression used to extract specific subparts of the JSON document "
+                                            + "(extracted by a link:https://en.wikipedia.org/wiki/JSONPath[JSONPath] expression). "
+                                            + "The default is: ``.")
                     String path,
             @Name(
                             value = "config",

--- a/core/src/test/resources/procedures.json
+++ b/core/src/test/resources/procedures.json
@@ -4464,7 +4464,7 @@
   "isDeprecated" : true,
   "signature" : "apoc.load.jsonParams(urlOrKeyOrBinary :: ANY, headers :: MAP, payload :: STRING, path =  :: STRING, config = {} :: MAP) :: (value :: MAP)",
   "name" : "apoc.load.jsonParams",
-  "description" : "Loads parameters from a JSON URL (e.g. web-API) as a stream of values if the given JSON file is a `LIST<ANY>`.\nIf the given JSON file is a `MAP`, this procedure imports a single value instead.",
+  "description" : "Loads a JSON document from a URL (e.g. web-API) as a stream of values if the given JSON document is a `LIST<ANY>`.\nIf the given JSON file is a `MAP`, this procedure imports a single value instead.",
   "returnDescription" : [ {
     "name" : "value",
     "description" : "A map of data loaded from the given file.",
@@ -4474,7 +4474,7 @@
   "deprecatedBy" : "This procedure is being moved to APOC Extended.",
   "argumentDescription" : [ {
     "name" : "urlOrKeyOrBinary",
-    "description" : "The name of the file or binary data to import the data from.",
+    "description" : "The name of the file or binary data to import the data from. Note that a URL needs to be properly encoded to conform with the URI standard.",
     "isDeprecated" : false,
     "type" : "ANY"
   }, {
@@ -4489,7 +4489,7 @@
     "type" : "STRING"
   }, {
     "name" : "path",
-    "description" : "A JSON path expression used to extract a certain part from the list.",
+    "description" : "A JSON path expression used to extract specific subparts of the JSON document (extracted by a link:https://en.wikipedia.org/wiki/JSONPath[JSONPath] expression). The default is: ``.",
     "isDeprecated" : false,
     "default" : "DefaultParameterValue{value=, type=STRING}",
     "type" : "STRING"


### PR DESCRIPTION
To align with https://github.com/neo4j/docs-apoc/pull/345 

This fixes the description, which was wrong.

It mentions url encoding as a reaction to https://github.com/neo4j/apoc/issues/65

