### PR TITLE
Error on typos for uniqueness

### DIFF
--- a/core/src/main/java/apoc/path/PathExplorer.java
+++ b/core/src/main/java/apoc/path/PathExplorer.java
@@ -282,7 +282,13 @@ public class PathExplorer {
         for (Uniqueness u : Uniqueness.values()) {
             if (u.name().equalsIgnoreCase(uniqueness)) return u;
         }
-        return UNIQUENESS;
+        throw new RuntimeException("Invalid uniqueness: '" + uniqueness + "'. Must be one of: "
+                + String.join(
+                        ", ",
+                        java.util.Arrays.stream(Uniqueness.values())
+                                .map(Enum::name)
+                                .toArray(String[]::new))
+                + ".");
     }
 
     private Stream<Path> expandConfigPrivate(@Name("start") Object start, @Name("config") Map<String, Object> config) {

--- a/core/src/test/java/apoc/path/ExpandPathTest.java
+++ b/core/src/test/java/apoc/path/ExpandPathTest.java
@@ -21,6 +21,7 @@ package apoc.path;
 import static apoc.util.Util.labelStrings;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import apoc.util.MapUtil;
@@ -694,6 +695,22 @@ public class ExpandPathTest {
 
                     assertFalse(iterator.hasNext());
                 });
+    }
+
+    @Test
+    public void testShouldFailOnInvalidUniqueness() {
+        String statement =
+                """
+                                MATCH (k:Person {name:'Keanu Reeves'})
+                                CALL apoc.path.expandConfig(k, {uniqueness: 'NODE_GLOBALS'})
+                                YIELD path
+                                RETURN path
+                        """;
+
+        RuntimeException e = assertThrows(RuntimeException.class, () -> TestUtil.testCall(db, statement, (res) -> {}));
+        String expectedMessage =
+                "Failed to invoke procedure `apoc.path.expandConfig`: Caused by: java.lang.RuntimeException: Invalid uniqueness: 'NODE_GLOBALS'. Must be one of: NODE_GLOBAL, NODE_PATH, NODE_RECENT, NODE_LEVEL, RELATIONSHIP_GLOBAL, RELATIONSHIP_PATH, RELATIONSHIP_RECENT, RELATIONSHIP_LEVEL, NONE.";
+        assertEquals(expectedMessage, e.getMessage());
     }
 
     private void specialCharAssertions(Result result) {


### PR DESCRIPTION
If a user types in the an invalid uniqueness value, they wouldn't know, so this will now error; https://github.com/neo4j/apoc/issues/85 