### PR TITLE
Fix handling of constraints in refactor procedures

### DIFF
--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -913,21 +913,22 @@ public class GraphRefactoring {
 
     private void copyRelationships(Node source, Node target, boolean delete, boolean createNewSelfRel) {
         for (Relationship rel : source.getRelationships()) {
-            final var type = rel.getType();
             var startNode = rel.getStartNode();
-            if (startNode.getElementId().equals(source.getElementId())) startNode = target;
             var endNode = rel.getEndNode();
+
+            if (!createNewSelfRel && startNode.getElementId().equals(endNode.getElementId())) continue;
+
+            if (startNode.getElementId().equals(source.getElementId())) startNode = target;
             if (endNode.getElementId().equals(source.getElementId())) endNode = target;
 
+            final var type = rel.getType();
             final var properties = rel.getAllProperties();
 
             // Delete first to avoid breaking constraints.
             if (delete) rel.delete();
 
-            if (createNewSelfRel || !startNode.getElementId().equals(endNode.getElementId())) {
-                final var newRel = startNode.createRelationshipTo(endNode, type);
-                properties.forEach(newRel::setProperty);
-            }
+            final var newRel = startNode.createRelationshipTo(endNode, type);
+            properties.forEach(newRel::setProperty);
         }
     }
 }

--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -916,19 +916,21 @@ public class GraphRefactoring {
             var startNode = rel.getStartNode();
             var endNode = rel.getEndNode();
 
-            if (!createNewSelfRel && startNode.getElementId().equals(endNode.getElementId())) continue;
+            if (!createNewSelfRel && startNode.getElementId().equals(endNode.getElementId()))  {
+                if (delete) rel.delete();
+            } else {
+                if (startNode.getElementId().equals(source.getElementId())) startNode = target;
+                if (endNode.getElementId().equals(source.getElementId())) endNode = target;
 
-            if (startNode.getElementId().equals(source.getElementId())) startNode = target;
-            if (endNode.getElementId().equals(source.getElementId())) endNode = target;
+                final var type = rel.getType();
+                final var properties = rel.getAllProperties();
 
-            final var type = rel.getType();
-            final var properties = rel.getAllProperties();
+                // Delete first to avoid breaking constraints.
+                if (delete) rel.delete();
 
-            // Delete first to avoid breaking constraints.
-            if (delete) rel.delete();
-
-            final var newRel = startNode.createRelationshipTo(endNode, type);
-            properties.forEach(newRel::setProperty);
+                final var newRel = startNode.createRelationshipTo(endNode, type);
+                properties.forEach(newRel::setProperty);
+            }
         }
     }
 }

--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -916,7 +916,7 @@ public class GraphRefactoring {
             var startNode = rel.getStartNode();
             var endNode = rel.getEndNode();
 
-            if (!createNewSelfRel && startNode.getElementId().equals(endNode.getElementId()))  {
+            if (!createNewSelfRel && startNode.getElementId().equals(endNode.getElementId())) {
                 if (delete) rel.delete();
             } else {
                 if (startNode.getElementId().equals(source.getElementId())) startNode = target;

--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -510,8 +510,8 @@ public class GraphRefactoring {
             if (failOnErrors) {
                 throw e;
             } else {
-                // Note! We might now have half applied the changes, not sure why we would want to do this instead of
-                // just failing.
+                // Note! We might now have half applied the changes,
+                // not sure why we would ever want to do this instead of just failing.
                 // I guess it's up to the user to explicitly rollback at this point ¯\_(ツ)_/¯.
                 return Stream.of(result.withError(e));
             }
@@ -555,8 +555,8 @@ public class GraphRefactoring {
             if (failOnErrors) {
                 throw e;
             } else {
-                // Note! We might now have half applied the changes, not sure why we would want to do this instead of
-                // just failing.
+                // Note! We might now have half applied the changes,
+                // not sure why we would ever want to do this instead of just failing.
                 // I guess it's up to the user to explicitly rollback at this point ¯\_(ツ)_/¯.
                 return Stream.of(result.withError(e));
             }
@@ -603,8 +603,8 @@ public class GraphRefactoring {
             if (failOnErrors) {
                 throw e;
             } else {
-                // Note! We might now have half applied the changes, not sure why we would want to do this instead of
-                // just failing.
+                // Note! We might now have half applied the changes,
+                // not sure why we would ever want to do this instead of just failing.
                 // I guess it's up to the user to explicitly rollback at this point ¯\_(ツ)_/¯.
                 return Stream.of(result.withError(e));
             }

--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -913,37 +913,21 @@ public class GraphRefactoring {
 
     private void copyRelationships(Node source, Node target, boolean delete, boolean createNewSelfRel) {
         for (Relationship rel : source.getRelationships()) {
-            copyRelationship(rel, source, target, createNewSelfRel);
-            if (delete) rel.delete();
-        }
-    }
+            final var type = rel.getType();
+            var startNode = rel.getStartNode();
+            if (startNode.getElementId().equals(source.getElementId())) startNode = target;
+            var endNode = rel.getEndNode();
+            if (endNode.getElementId().equals(source.getElementId())) endNode = target;
 
-    private Node copyLabels(Node source, Node target) {
-        for (Label label : source.getLabels()) {
-            if (!target.hasLabel(label)) {
-                target.addLabel(label);
+            final var properties = rel.getAllProperties();
+
+            // Delete first to avoid breaking constraints.
+            if (delete) rel.delete();
+
+            if (createNewSelfRel || !startNode.getElementId().equals(endNode.getElementId())) {
+                final var newRel = startNode.createRelationshipTo(endNode, type);
+                properties.forEach(newRel::setProperty);
             }
         }
-        return target;
-    }
-
-    private void copyRelationship(Relationship rel, Node source, Node target, boolean createNewSelfRelf) {
-        Node startNode = rel.getStartNode();
-        Node endNode = rel.getEndNode();
-
-        if (startNode.getElementId().equals(endNode.getElementId()) && !createNewSelfRelf) {
-            return;
-        }
-
-        if (startNode.getElementId().equals(source.getElementId())) {
-            startNode = target;
-        }
-
-        if (endNode.getElementId().equals(source.getElementId())) {
-            endNode = target;
-        }
-
-        Relationship newrel = startNode.createRelationshipTo(endNode, rel.getType());
-        copyProperties(rel, newrel);
     }
 }

--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -521,16 +521,45 @@ public class GraphRefactoring {
     @Procedure(name = "apoc.refactor.invert", mode = Mode.WRITE, eager = true)
     @Description("Inverts the direction of the given `RELATIONSHIP`.")
     public Stream<RefactorRelationshipResult> invert(
-            @Name(value = "rel", description = "The relationship to reverse.") Relationship rel) {
+            @Name(value = "rel", description = "The relationship to reverse.") Relationship rel,
+            @Name(
+                            value = "config",
+                            defaultValue = "{}",
+                            description =
+                                    """
+                    {
+                        failOnErrors = false :: BOOLEAN
+                    }
+                    """)
+                    Map<String, Object> config) {
+        if (config == null) config = Map.of();
         if (rel == null) return Stream.empty();
-        RefactorRelationshipResult result = new RefactorRelationshipResult(rel.getId());
+
+        final var failOnErrors = Boolean.TRUE.equals(config.getOrDefault("failOnErrors", false));
+        final var result = new RefactorRelationshipResult(rel.getId());
+
         try {
-            Relationship newRel = rel.getEndNode().createRelationshipTo(rel.getStartNode(), rel.getType());
-            copyProperties(rel, newRel);
+            final var type = rel.getType();
+            final var properties = rel.getAllProperties();
+            final var startNode = rel.getStartNode();
+            final var endNode = rel.getEndNode();
+
+            // Delete first to not break constraints.
             rel.delete();
+
+            final var newRel = endNode.createRelationshipTo(startNode, type);
+            properties.forEach(newRel::setProperty);
+
             return Stream.of(result.withOther(newRel));
         } catch (Exception e) {
-            return Stream.of(result.withError(e));
+            if (failOnErrors) {
+                throw e;
+            } else {
+                // Note! We might now have half applied the changes, not sure why we would want to do this instead of
+                // just failing.
+                // I guess it's up to the user to explicitly rollback at this point ¯\_(ツ)_/¯.
+                return Stream.of(result.withError(e));
+            }
         }
     }
 

--- a/core/src/test/java/apoc/ArgumentDescriptionsTest.java
+++ b/core/src/test/java/apoc/ArgumentDescriptionsTest.java
@@ -20,6 +20,7 @@ package apoc;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 import apoc.agg.CollAggregation;
 import apoc.agg.Graph;
@@ -329,7 +330,10 @@ public class ArgumentDescriptionsTest {
         System.out.println("common:");
         System.out.println(writer.writeValueAsString(commonJson));
         System.out.println();
+        System.out.println("=".repeat(80));
+        System.out.println();
         System.out.println("cypher %s specific:".formatted(version.versionName));
         System.out.println(writer.writeValueAsString(specificJson));
+        fail("Remove call to generate");
     }
 }

--- a/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
+++ b/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
@@ -1808,6 +1808,88 @@ public class GraphRefactoringTest {
     }
 
     @Test
+    public void refactorFromWithConstraints() {
+        db.executeTransactionally("CREATE CONSTRAINT id_unique FOR ()-[r:R]-() REQUIRE r.id IS UNIQUE");
+        db.executeTransactionally("CREATE (a:A {id:'A'})-[r:R {id:'R'}]->(b:B {id:'B'}), (c:C {id:'C'})");
+        db.executeTransactionally("CALL db.awaitIndexes()");
+
+        try (final var tx = db.beginTx()) {
+            assertThat(tx
+                            .execute(
+                                    "MATCH (a:A)-[r:R]->(), (c:C) CALL apoc.refactor.from(r, c) YIELD error RETURN error")
+                            .stream())
+                    .singleElement(InstanceOfAssertFactories.map(String.class, Object.class))
+                    .containsEntry("error", null);
+            tx.commit();
+        }
+        try (final var tx = db.beginTx()) {
+            final var query =
+                    """
+                    MATCH (a)
+                    OPTIONAL MATCH (a)-[r]->(b)
+                    RETURN
+                      a.id,
+                      CASE WHEN r.id IS NULL THEN 'null' ELSE r.id END AS `r.id`,
+                      CASE WHEN b.id IS NULL THEN 'null' ELSE b.id END AS `b.id`
+                    ORDER BY `a.id`, `r.id`, `b.id`
+                    """;
+            assertThat(tx.execute(query).stream())
+                    .containsExactly(
+                            Map.of("a.id", "A", "r.id", "null", "b.id", "null"),
+                            Map.of("a.id", "B", "r.id", "null", "b.id", "null"),
+                            Map.of("a.id", "C", "r.id", "R", "b.id", "B"));
+            tx.commit();
+        }
+    }
+
+    @Test
+    public void refactorFromWithErrorHandling() {
+        db.executeTransactionally("CREATE (a:A {id:'A'})-[r:R {id:'R'}]->(b:B {id:'B'}), (c:C {id:'C'})");
+
+        final var refactorQuery =
+                """
+                   MATCH (a:A)-[r:R]->(), (c:C)
+                   DELETE r WITH r, c
+                   CALL apoc.refactor.from(r, c, $conf) YIELD error
+                   RETURN error""";
+        try (final var tx = db.beginTx()) {
+            final var params = Map.<String, Object>of("conf", Map.of("failOnErrors", true));
+            assertThatThrownBy(() -> tx.execute(refactorQuery, params).resultAsString())
+                    .hasMessageContaining(
+                            "Failed to invoke procedure `apoc.refactor.from`: Caused by: org.neo4j.internal.kernel.api.exceptions.EntityNotFoundException")
+                    .hasRootCauseExactlyInstanceOf(
+                            org.neo4j.internal.kernel.api.exceptions.EntityNotFoundException.class);
+            tx.rollback();
+        }
+
+        try (final var tx = db.beginTx()) {
+            final var query =
+                    """
+                    MATCH (a)
+                    OPTIONAL MATCH (a)-[r]->(b)
+                    RETURN
+                      a.id,
+                      CASE WHEN r.id IS NULL THEN 'null' ELSE r.id END AS `r.id`,
+                      CASE WHEN b.id IS NULL THEN 'null' ELSE b.id END AS `b.id`
+                    ORDER BY `a.id`, `r.id`, `b.id`
+                    """;
+            assertThat(tx.execute(query).stream())
+                    .containsExactly(
+                            Map.of("a.id", "A", "r.id", "R", "b.id", "B"),
+                            Map.of("a.id", "B", "r.id", "null", "b.id", "null"),
+                            Map.of("a.id", "C", "r.id", "null", "b.id", "null"));
+            tx.commit();
+        }
+
+        try (final var tx = db.beginTx()) {
+            assertThat(tx.execute(refactorQuery, Map.of("conf", Map.of())).stream())
+                    .singleElement(InstanceOfAssertFactories.map(String.class, Object.class))
+                    .hasEntrySatisfying("error", e -> assertThat(e).asString().contains("EntityNotFoundException"));
+            tx.rollback();
+        }
+    }
+
+    @Test
     public void invertWithConstraints() {
         db.executeTransactionally("CREATE CONSTRAINT id_unique FOR ()-[r:R]-() REQUIRE r.id IS UNIQUE");
         db.executeTransactionally("CREATE (a:A {id:'A'})-[r:R {id:'R'}]->(b:B {id:'B'})");

--- a/core/src/test/resources/procedures/common/procedures.json
+++ b/core/src/test/resources/procedures/common/procedures.json
@@ -6138,7 +6138,7 @@
   } ]
 }, {
   "isDeprecated" : false,
-  "signature" : "apoc.refactor.from(rel :: RELATIONSHIP, newNode :: NODE) :: (input :: INTEGER, output :: RELATIONSHIP, error :: STRING)",
+  "signature" : "apoc.refactor.from(rel :: RELATIONSHIP, newNode :: NODE, config = {} :: MAP) :: (input :: INTEGER, output :: RELATIONSHIP, error :: STRING)",
   "name" : "apoc.refactor.from",
   "description" : "Redirects the given `RELATIONSHIP` to the given start `NODE`.",
   "returnDescription" : [ {
@@ -6168,10 +6168,16 @@
     "description" : "The node to redirect the given relationship to.",
     "isDeprecated" : false,
     "type" : "NODE"
+  }, {
+    "name" : "config",
+    "description" : "{\n    failOnErrors = false :: BOOLEAN\n}\n",
+    "isDeprecated" : false,
+    "default" : "DefaultParameterValue{value={}, type=MAP}",
+    "type" : "MAP"
   } ]
 }, {
   "isDeprecated" : false,
-  "signature" : "apoc.refactor.invert(rel :: RELATIONSHIP) :: (input :: INTEGER, output :: RELATIONSHIP, error :: STRING)",
+  "signature" : "apoc.refactor.invert(rel :: RELATIONSHIP, config = {} :: MAP) :: (input :: INTEGER, output :: RELATIONSHIP, error :: STRING)",
   "name" : "apoc.refactor.invert",
   "description" : "Inverts the direction of the given `RELATIONSHIP`.",
   "returnDescription" : [ {
@@ -6196,6 +6202,12 @@
     "description" : "The relationship to reverse.",
     "isDeprecated" : false,
     "type" : "RELATIONSHIP"
+  }, {
+    "name" : "config",
+    "description" : "{\n    failOnErrors = false :: BOOLEAN\n}\n",
+    "isDeprecated" : false,
+    "default" : "DefaultParameterValue{value={}, type=MAP}",
+    "type" : "MAP"
   } ]
 }, {
   "isDeprecated" : false,
@@ -6662,7 +6674,7 @@
   } ]
 }, {
   "isDeprecated" : false,
-  "signature" : "apoc.refactor.to(rel :: RELATIONSHIP, endNode :: NODE) :: (input :: INTEGER, output :: RELATIONSHIP, error :: STRING)",
+  "signature" : "apoc.refactor.to(rel :: RELATIONSHIP, endNode :: NODE, config = {} :: MAP) :: (input :: INTEGER, output :: RELATIONSHIP, error :: STRING)",
   "name" : "apoc.refactor.to",
   "description" : "Redirects the given `RELATIONSHIP` to the given end `NODE`.",
   "returnDescription" : [ {
@@ -6692,6 +6704,12 @@
     "description" : "The new end node the relationship should point to.",
     "isDeprecated" : false,
     "type" : "NODE"
+  }, {
+    "name" : "config",
+    "description" : "{\n    failOnErrors = false :: BOOLEAN\n}\n",
+    "isDeprecated" : false,
+    "default" : "DefaultParameterValue{value={}, type=MAP}",
+    "type" : "MAP"
   } ]
 }, {
   "isDeprecated" : false,


### PR DESCRIPTION
Fixes #699

- Better handling of constraints in `apoc.refactor.to`, `apoc.refactor.from`, `apoc.refactor.invert` and `apoc.refactor.mergeNodes`.
- Add option to fail on errors in `apoc.refactor.to`, `apoc.refactor.from` and `apoc.refactor.invert`.