### PR TITLE
Add option to wrap a nodes id to the apoc.create.virtual.fromNode

### DIFF
--- a/common/src/main/java/apoc/result/VirtualNode.java
+++ b/common/src/main/java/apoc/result/VirtualNode.java
@@ -63,17 +63,21 @@ public class VirtualNode implements Node {
         this.elementId = null;
     }
 
-    public VirtualNode(Node node, List<String> propertyNames) {
+    public VirtualNode(Node node, List<String> propertyNames, boolean wrapNodeIDs) {
         Objects.requireNonNull(node, ERROR_NODE_NULL);
         final long id = node.getId();
         // if node is already virtual, we return the same id
-        this.id = id < 0 ? id : -id - 1;
-        // to not overlap this ids with ids from VirtualNode(Label[] labels, Map<String, Object> props)
+        this.id = id < 0 || wrapNodeIDs ? id : -id - 1;
+        // to not overlap this nodes ids with ids from VirtualNode(Label[] labels, Map<String, Object> props)
         MIN_ID.updateAndGet(x -> Math.min(x, this.id));
         this.labels.addAll(Util.labelStrings(node));
         String[] keys = propertyNames.toArray(new String[propertyNames.size()]);
         this.props.putAll(node.getProperties(keys));
         this.elementId = node.getElementId();
+    }
+
+    public VirtualNode(Node node, List<String> propertyNames) {
+        this(node, propertyNames, false);
     }
 
     public static VirtualNode from(Node node) {

--- a/core/src/main/java/apoc/create/Create.java
+++ b/core/src/main/java/apoc/create/Create.java
@@ -232,8 +232,10 @@ public class Create {
     public Node virtualFromNodeFunction(
             @Name(value = "node", description = "The node to generate a virtual node from.") Node node,
             @Name(value = "propertyNames", description = "The properties to copy to the virtual node.")
-                    List<String> propertyNames) {
-        return new VirtualNode(node, propertyNames);
+                    List<String> propertyNames,
+            @Name(value = "config", defaultValue = "{}", description = "{ wrapNodeIds = false :: BOOLEAN }")
+                    Map<String, Object> config) {
+        return new VirtualNode(node, propertyNames, Util.toBoolean(config.get("wrapNodeIds")));
     }
 
     @Procedure("apoc.create.vNodes")

--- a/core/src/test/java/apoc/create/CreateTest.java
+++ b/core/src/test/java/apoc/create/CreateTest.java
@@ -409,6 +409,25 @@ public class CreateTest {
                     Node node = (Node) row.get("node");
 
                     assertTrue(node.hasLabel(label("Person")));
+                    assertTrue(node.getId() < 0);
+                    assertEquals("Vincent", node.getProperty("name"));
+                    assertNull(node.getProperty("born"));
+                });
+    }
+
+    @Test
+    public void testVirtualFromNodeFunctionWithWrapping() {
+        testCall(
+                db,
+                """
+                        CREATE (n:Person{name:'Vincent', born: 1974} )
+                        RETURN apoc.create.virtual.fromNode(n, ['name'], { wrapNodeIds : true }) AS node
+                        """,
+                (row) -> {
+                    Node node = (Node) row.get("node");
+
+                    assertTrue(node.hasLabel(label("Person")));
+                    assertTrue(node.getId() >= 0);
                     assertEquals("Vincent", node.getProperty("name"));
                     assertNull(node.getProperty("born"));
                 });

--- a/core/src/test/resources/functions/common/functions.json
+++ b/core/src/test/resources/functions/common/functions.json
@@ -1643,7 +1643,7 @@
 }, {
   "isDeprecated" : false,
   "aggregating" : false,
-  "signature" : "apoc.create.virtual.fromNode(node :: NODE, propertyNames :: LIST<STRING>) :: NODE",
+  "signature" : "apoc.create.virtual.fromNode(node :: NODE, propertyNames :: LIST<STRING>, config = {} :: MAP) :: NODE",
   "name" : "apoc.create.virtual.fromNode",
   "description" : "Returns a virtual `NODE` from the given existing `NODE`. The virtual `NODE` only contains the requested properties.",
   "returnDescription" : "NODE",
@@ -1660,6 +1660,12 @@
     "description" : "The properties to copy to the virtual node.",
     "isDeprecated" : false,
     "type" : "LIST<STRING>"
+  }, {
+    "name" : "config",
+    "description" : "{ wrapNodeIds = false :: BOOLEAN }",
+    "isDeprecated" : false,
+    "default" : "DefaultParameterValue{value={}, type=MAP}",
+    "type" : "MAP"
   } ]
 }, {
   "isDeprecated" : false,


### PR DESCRIPTION
Apparently the original idea of this function was to just wrap real nodes aka keep their ids, to not break any existing behaviour I have added that as a config option instead

docs: https://github.com/neo4j/docs-apoc/pull/363