### PR TITLE
Fixed issue with properties in CloneSubgraph

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,7 +170,7 @@ apply from: "licenses-source-header.gradle"
 
 ext {
     publicDir = "${project.rootDir}"
-    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : "2025.01.0-SNAPSHOT"
+    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : "2025.01.0"
     testContainersVersion = '1.20.2'
     apacheArrowVersion = '15.0.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -170,7 +170,7 @@ apply from: "licenses-source-header.gradle"
 
 ext {
     publicDir = "${project.rootDir}"
-    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : "2025.01.0"
+    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : "2025.01.0-SNAPSHOT"
     testContainersVersion = '1.20.2'
     apacheArrowVersion = '15.0.0'
 }

--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -323,7 +323,7 @@ public class GraphRefactoring {
 
     private static void cloneRel(Relationship base, Node from, Node to, final Set<String> skipProps) {
         final var rel = from.createRelationshipTo(to, base.getType());
-        rel.getAllProperties().forEach((k, v) -> {
+        base.getAllProperties().forEach((k, v) -> {
             if (skipProps.isEmpty() || !skipProps.contains(k)) rel.setProperty(k, v);
         });
     }


### PR DESCRIPTION
Fixes bug introduced in [PR](https://github.com/neo4j/apoc/pull/674) were properties on relationships are lost when using `cloneSubgraph`.