### PR TITLE
testTerminateCommit: stop test going out of memory

### DIFF
--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -281,8 +281,8 @@ public class PeriodicTest {
     public void testTerminateCommit() {
         PeriodicTestUtils.testTerminateWithCommand(
                 db,
-                "CALL apoc.periodic.commit('UNWIND range(0,1000) as id WITH id CREATE (n:Foo {id: id}) WITH n limit 1000 RETURN COUNT(n)', {})",
-                "UNWIND range(0,1000) as id WITH id CREATE (n:Foo {id: id}) WITH n limit 1000 RETURN COUNT(n)");
+                "CALL apoc.periodic.commit('UNWIND range(0,1000) as id WITH id MERGE (n:Foo {id: id}) WITH n limit 1000 RETURN COUNT(n)', {})",
+                "UNWIND range(0,1000) as id WITH id MERGE (n:Foo {id: id}) WITH n limit 1000 RETURN COUNT(n)");
     }
 
     @Test


### PR DESCRIPTION
This test was running continuously 1000 creates, using a MERGE instead it hopefully won't run out of memory as often