### PR TITLE
Add close() method to `LimitedSizeInputStream`

### DIFF
--- a/common/src/main/java/apoc/export/util/LimitedSizeInputStream.java
+++ b/common/src/main/java/apoc/export/util/LimitedSizeInputStream.java
@@ -58,6 +58,13 @@ public class LimitedSizeInputStream extends InputStream {
         return i;
     }
 
+    @Override
+    public void close() throws IOException
+    {
+        stream.close();
+        super.close();
+    }
+
     private void incrementCounter(int size) throws IOException {
         // in some test cases, e.g. UtilIT.redirectShouldWorkWhenProtocolNotChangesWithUrlLocation,
         // the StreamConnection.getLength() returns `-1` because of content length not known,

--- a/common/src/main/java/apoc/export/util/LimitedSizeInputStream.java
+++ b/common/src/main/java/apoc/export/util/LimitedSizeInputStream.java
@@ -59,8 +59,7 @@ public class LimitedSizeInputStream extends InputStream {
     }
 
     @Override
-    public void close() throws IOException
-    {
+    public void close() throws IOException {
         stream.close();
         super.close();
     }


### PR DESCRIPTION
Fixes "graphml import query is locking the graphml file after execution"

`LimitedSizeInputStream` misses a close method causing file handles on imports to remain open (until collected by GC).

This PR adds the missing close method, which fixes the problem.