### PR TITLE
Fix virtual node id working

### DIFF
--- a/common/src/main/java/apoc/result/VirtualNode.java
+++ b/common/src/main/java/apoc/result/VirtualNode.java
@@ -67,9 +67,8 @@ public class VirtualNode implements Node {
         Objects.requireNonNull(node, ERROR_NODE_NULL);
         final long id = node.getId();
         // if node is already virtual, we return the same id
-        this.id = id < 0 || wrapNodeIDs ? id : -id - 1;
+        this.id = id < 0 || wrapNodeIDs ? id : MIN_ID.decrementAndGet();
         // to not overlap this nodes ids with ids from VirtualNode(Label[] labels, Map<String, Object> props)
-        MIN_ID.updateAndGet(x -> Math.min(x, this.id));
         this.labels.addAll(Util.labelStrings(node));
         String[] keys = propertyNames.toArray(new String[propertyNames.size()]);
         this.props.putAll(node.getProperties(keys));

--- a/core/src/test/java/apoc/create/CreateTest.java
+++ b/core/src/test/java/apoc/create/CreateTest.java
@@ -416,6 +416,35 @@ public class CreateTest {
     }
 
     @Test
+    public void test2VirtualFromNodesHaveUniqueIDs() {
+        testCall(
+                db,
+                """
+                        CREATE (n1:Cat { name:'Maja', born: 2023 } ), (n2:Cat { name:'Pelle', born: 2023 } )
+                        RETURN apoc.create.virtual.fromNode(n1, ['name']) AS node1, apoc.create.virtual.fromNode(n2, ['name']) AS node2
+                        """,
+                (row) -> {
+                    Node node1 = (Node) row.get("node1");
+
+                    assertTrue(node1.hasLabel(label("Cat")));
+                    var firstNodeID = node1.getId();
+                    assertTrue(node1.getId() < 0);
+                    assertEquals("Maja", node1.getProperty("name"));
+                    assertNull(node1.getProperty("born"));
+
+                    Node node2 = (Node) row.get("node2");
+
+                    assertTrue(node2.hasLabel(label("Cat")));
+                    var secondNodeID = node2.getId();
+                    assertTrue(node2.getId() < 0);
+                    assertEquals("Pelle", node2.getProperty("name"));
+                    assertNull(node2.getProperty("born"));
+
+                    assertNotEquals(firstNodeID, secondNodeID);
+                });
+    }
+
+    @Test
     public void testVirtualFromNodeFunctionWithWrapping() {
         testCall(
                 db,


### PR DESCRIPTION
Fixes https://github.com/neo4j/apoc/issues/721.

If it isn't specified that the virtual node should keep the original id, the new virtual nodes will get new negative ids (unique)