### PR TITLE
Fix apoc.meta.subgraph for non-existing labels and types

### DIFF
--- a/common/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
+++ b/common/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
@@ -142,24 +142,39 @@ class CountOptimisedDatabaseSubGraph extends DatabaseSubGraph {
 
     @Override
     public long countsForNode(Label label) {
-        return read.countsForNode(tokenRead.nodeLabel(label.name()));
+        int nodeLabelID = tokenRead.nodeLabel(label.name());
+        if (nodeLabelID < 0) {
+            return 0;
+        }
+        return read.countsForNode(nodeLabelID);
     }
 
     @Override
     public long countsForRelationship(RelationshipType type, Label end) {
-        return read.countsForRelationship(
-                TokenConstants.ANY_LABEL, tokenRead.relationshipType(type.name()), tokenRead.nodeLabel(end.name()));
+        int relTypeID = tokenRead.relationshipType(type.name());
+        int nodeLabelID = tokenRead.nodeLabel(end.name());
+        if (nodeLabelID < 0 || relTypeID < 0) {
+            return 0;
+        }
+        return read.countsForRelationship(TokenConstants.ANY_LABEL, relTypeID, nodeLabelID);
     }
 
     @Override
     public long countsForRelationship(Label start, RelationshipType type) {
-        return read.countsForRelationship(
-                tokenRead.nodeLabel(start.name()), tokenRead.relationshipType(type.name()), TokenConstants.ANY_LABEL);
+        int relTypeID = tokenRead.relationshipType(type.name());
+        int nodeLabelID = tokenRead.nodeLabel(start.name());
+        if (nodeLabelID < 0 || relTypeID < 0) {
+            return 0;
+        }
+        return read.countsForRelationship(tokenRead.nodeLabel(start.name()), relTypeID, TokenConstants.ANY_LABEL);
     }
 
     @Override
     public long countsForRelationship(RelationshipType type) {
-        return read.countsForRelationship(
-                TokenConstants.ANY_LABEL, tokenRead.relationshipType(type.name()), TokenConstants.ANY_LABEL);
+        int relTypeID = tokenRead.relationshipType(type.name());
+        if (relTypeID < 0) {
+            return 0;
+        }
+        return read.countsForRelationship(TokenConstants.ANY_LABEL, relTypeID, TokenConstants.ANY_LABEL);
     }
 }

--- a/common/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
+++ b/common/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
@@ -166,7 +166,7 @@ class CountOptimisedDatabaseSubGraph extends DatabaseSubGraph {
         if (nodeLabelID < 0 || relTypeID < 0) {
             return 0;
         }
-        return read.countsForRelationship(tokenRead.nodeLabel(start.name()), relTypeID, TokenConstants.ANY_LABEL);
+        return read.countsForRelationship(nodeLabelID, relTypeID, TokenConstants.ANY_LABEL);
     }
 
     @Override


### PR DESCRIPTION
A non-existing label or type has the id of -1, which so happens to be the id of the constant for "ANY_LABEL" and "ANY_TYPE" which meant giving non-existing ones in would return the count of the db 😅

Fixes: https://github.com/neo4j/apoc/issues/68