### PR TITLE
Set up more robust virtual entities for deleted nodes and relationships

### DIFF
--- a/common/src/main/java/apoc/result/VirtualNode.java
+++ b/common/src/main/java/apoc/result/VirtualNode.java
@@ -58,6 +58,13 @@ public class VirtualNode implements Node {
         this.elementId = null;
     }
 
+    public VirtualNode(long nodeId, String elementId, Label[] labels, Map<String, Object> props) {
+        this.id = nodeId;
+        this.elementId = elementId;
+        addLabels(asList(labels));
+        this.props.putAll(props);
+    }
+
     public VirtualNode(long nodeId) {
         this.id = nodeId;
         this.elementId = null;

--- a/common/src/main/java/apoc/result/VirtualRelationship.java
+++ b/common/src/main/java/apoc/result/VirtualRelationship.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -43,6 +44,7 @@ public class VirtualRelationship implements Relationship {
     private final Node endNode;
     private final RelationshipType type;
     private final long id;
+    private final String elementId;
     private final Map<String, Object> props = new HashMap<>();
 
     public VirtualRelationship(Node startNode, Node endNode, RelationshipType type, Map<String, Object> props) {
@@ -50,9 +52,21 @@ public class VirtualRelationship implements Relationship {
         this.props.putAll(props);
     }
 
+    public VirtualRelationship(
+            long id, String elementId, Node startNode, Node endNode, RelationshipType type, Map<String, Object> props) {
+        validateNodes(startNode, endNode);
+        this.id = id;
+        this.elementId = elementId;
+        this.startNode = startNode;
+        this.endNode = endNode;
+        this.type = type;
+        this.props.putAll(props);
+    }
+
     public VirtualRelationship(Node startNode, Node endNode, RelationshipType type) {
         validateNodes(startNode, endNode);
         this.id = MIN_ID.getAndDecrement();
+        this.elementId = UUID.randomUUID().toString();
         this.startNode = startNode;
         this.endNode = endNode;
         this.type = type;
@@ -63,6 +77,7 @@ public class VirtualRelationship implements Relationship {
             long id, Node startNode, Node endNode, RelationshipType type, Map<String, Object> props) {
         validateNodes(startNode, endNode);
         this.id = id;
+        this.elementId = UUID.randomUUID().toString();
         this.startNode = startNode;
         this.endNode = endNode;
         this.type = type;
@@ -85,7 +100,7 @@ public class VirtualRelationship implements Relationship {
 
     @Override
     public String getElementId() {
-        return String.valueOf(id);
+        return elementId;
     }
 
     @Override

--- a/common/src/test/java/apoc/result/VirtualNodeTest.java
+++ b/common/src/test/java/apoc/result/VirtualNodeTest.java
@@ -49,7 +49,7 @@ public class VirtualNodeTest {
         Map<String, Object> props = Util.map("key", "value");
         Label[] labels = {Label.label("Test")};
         VirtualNode vn = new VirtualNode(labels, props);
-        assertTrue("the id should be < 0", Integer.parseInt(vn.getElementId()) < 0);
+        assertTrue("the id should be < 0", vn.getId() < 0);
         assertEquals(props, vn.getAllProperties());
         Iterator<Label> it = vn.getLabels().iterator();
         assertEquals(labels[0], it.next());
@@ -61,7 +61,7 @@ public class VirtualNodeTest {
         Map<String, Object> startProps = Util.map("key", "value");
         Label[] startLabels = {Label.label("Test")};
         VirtualNode start = new VirtualNode(startLabels, startProps);
-        assertTrue("the node id should be < 0", Integer.parseInt(start.getElementId()) < 0);
+        assertTrue("the node id should be < 0", start.getId() < 0);
         assertEquals(startProps, start.getAllProperties());
         Iterator<Label> startLabelIt = start.getLabels().iterator();
         assertEquals(startLabels[0], startLabelIt.next());
@@ -70,7 +70,7 @@ public class VirtualNodeTest {
         Map<String, Object> endProps = Util.map("key", "value");
         Label[] endLabels = {Label.label("Test")};
         VirtualNode end = new VirtualNode(endLabels, endProps);
-        assertTrue("the node id should be < 0", Integer.parseInt(end.getElementId()) < 0);
+        assertTrue("the node id should be < 0", end.getId() < 0);
         assertEquals(endProps, end.getAllProperties());
         Iterator<Label> endLabelIt = end.getLabels().iterator();
         assertEquals(endLabels[0], endLabelIt.next());
@@ -79,7 +79,7 @@ public class VirtualNodeTest {
         RelationshipType relationshipType = RelationshipType.withName("TYPE");
         Relationship rel = start.createRelationshipTo(end, relationshipType);
         // Virtual Nodes/Relationships element ids are just String versions of ints.
-        assertTrue("the rel id should be < 0", rel.getElementId().startsWith("-"));
+        assertTrue("the rel id should be < 0", rel.getId() < 0);
 
         assertEquals(1, Iterables.count(start.getRelationships()));
         assertEquals(0, Iterables.count(start.getRelationships(Direction.INCOMING)));
@@ -99,7 +99,7 @@ public class VirtualNodeTest {
         Map<String, Object> startProps = Util.map("key", "value");
         Label[] startLabels = {Label.label("Test")};
         VirtualNode start = new VirtualNode(startLabels, startProps);
-        assertTrue("the node id should be < 0", Integer.parseInt(start.getElementId()) < 0);
+        assertTrue("the node id should be < 0", start.getId() < 0);
         assertEquals(startProps, start.getAllProperties());
         Iterator<Label> startLabelIt = start.getLabels().iterator();
         assertEquals(startLabels[0], startLabelIt.next());
@@ -108,7 +108,7 @@ public class VirtualNodeTest {
         Map<String, Object> endProps = Util.map("key", "value");
         Label[] endLabels = {Label.label("Test")};
         VirtualNode end = new VirtualNode(endLabels, endProps);
-        assertTrue("the node id should be < 0", Integer.parseInt(end.getElementId()) < 0);
+        assertTrue("the node id should be < 0", end.getId() < 0);
         assertEquals(endProps, end.getAllProperties());
         Iterator<Label> endLabelIt = end.getLabels().iterator();
         assertEquals(endLabels[0], endLabelIt.next());
@@ -117,7 +117,7 @@ public class VirtualNodeTest {
         RelationshipType relationshipType = RelationshipType.withName("TYPE");
         Relationship rel = end.createRelationshipFrom(start, relationshipType);
         // Virtual Nodes/Relationships element ids are just String versions of ints.
-        assertTrue("the rel id should be < 0", rel.getElementId().startsWith("-"));
+        assertTrue("the rel id should be < 0", rel.getId() < 0);
 
         assertEquals(1, Iterables.count(start.getRelationships()));
         assertEquals(0, Iterables.count(start.getRelationships(Direction.INCOMING)));

--- a/core/src/main/java/apoc/trigger/TriggerMetadata.java
+++ b/core/src/main/java/apoc/trigger/TriggerMetadata.java
@@ -156,11 +156,14 @@ public class TriggerMetadata {
                     .map(LabelEntry::label)
                     .toArray(Label[]::new);
             final Map<String, Object> props = getProps(txData.removedNodeProperties(), node);
-            return new VirtualNode(labels, props);
+            return new VirtualNode(node.getId(), node.getElementId(), labels, props);
         } else {
             Relationship rel = (Relationship) e;
             final Map<String, Object> props = getProps(txData.removedRelationshipProperties(), rel);
-            return new VirtualRelationship(rel.getStartNode(), rel.getEndNode(), rel.getType(), props);
+            // Note; We can't access the full node as that relies on database access, so all we can get is the id
+            var startNode = new VirtualNode(rel.getStartNodeId());
+            var endNode = new VirtualNode(rel.getEndNodeId());
+            return new VirtualRelationship(rel.getId(), rel.getElementId(), startNode, endNode, rel.getType(), props);
         }
     }
 
@@ -174,8 +177,6 @@ public class TriggerMetadata {
     public TriggerMetadata rebind(Transaction tx) {
         final List<Node> createdNodes = Util.rebind(this.createdNodes, tx);
         final List<Relationship> createdRelationships = Util.rebind(this.createdRelationships, tx);
-        //        final List<Node> deletedNodes = Util.rebind(this.deletedNodes, tx);
-        //        final List<Relationship> deletedRelationships = Util.rebind(this.deletedRelationships, tx);
         final Map<String, List<Node>> removedLabels = rebindMap(this.removedLabels, tx);
         final Map<String, List<Node>> assignedLabels = rebindMap(this.assignedLabels, tx);
         final Map<String, List<PropertyEntryContainer<Node>>> removedNodeProperties =

--- a/core/src/test/java/apoc/graph/GraphsTest.java
+++ b/core/src/test/java/apoc/graph/GraphsTest.java
@@ -76,11 +76,11 @@ public class GraphsTest {
     private static final Map<String, Object> graph = map("name", "test", "properties", map("answer", 42L));
 
     boolean nonVirtual(Entity entity) {
-        return !NumberUtils.isCreatable(entity.getElementId()) || Integer.parseInt(entity.getElementId()) > 0;
+        return !NumberUtils.isCreatable(entity.getElementId()) || entity.getId() > 0;
     }
 
     boolean virtual(Entity entity) {
-        return Integer.parseInt(entity.getElementId()) < 0;
+        return entity.getId() < 0;
     }
 
     @Rule

--- a/core/src/test/java/apoc/trigger/TriggerNewProceduresTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerNewProceduresTest.java
@@ -156,14 +156,17 @@ public class TriggerNewProceduresTest {
         awaitTriggerDiscovered(db, name, query);
 
         db.executeTransactionally("MATCH (f:Foo) DETACH DELETE f");
-        Util.sleep(500);
-        testCall(db, "MATCH (g:TEST) RETURN g.data AS data", (row) -> {
-            String data = (String) row.get("data");
-            assertTrue(data.contains("\"labels\":[\"Foo\"]"));
-            assertTrue(data.contains("\"properties\":{\"prop\":1}"));
-            // The id is not negative
-            assertFalse(data.contains("\"id\":\"-"));
-        });
+        testCallEventually(
+                db,
+                "MATCH (g:TEST) RETURN g.data AS data",
+                (row) -> {
+                    String data = (String) row.get("data");
+                    assertTrue(data.contains("\"labels\":[\"Foo\"]"));
+                    assertTrue(data.contains("\"properties\":{\"prop\":1}"));
+                    // The id is not negative
+                    assertFalse(data.contains("\"id\":\"-"));
+                },
+                TIMEOUT);
     }
 
     @Test


### PR DESCRIPTION
When accessing a deleted relationship or node from a trigger, rel start and end node references still held onto the hold tx which caused errors and neither contained real ids and element ids which is unexpected behaviour