### PR TITLE
Fix virtual entities hashCode

### DIFF
--- a/common/src/main/java/apoc/result/VirtualNode.java
+++ b/common/src/main/java/apoc/result/VirtualNode.java
@@ -302,7 +302,7 @@ public class VirtualNode implements Node {
 
     @Override
     public int hashCode() {
-        return (int) (id ^ (id >>> 32));
+        return Objects.hashCode(elementId);
     }
 
     @Override

--- a/common/src/main/java/apoc/result/VirtualRelationship.java
+++ b/common/src/main/java/apoc/result/VirtualRelationship.java
@@ -190,7 +190,7 @@ public class VirtualRelationship implements Relationship {
 
     @Override
     public int hashCode() {
-        return (int) (id ^ (id >>> 32));
+        return Objects.hashCode(elementId);
     }
 
     public Relationship withProperties(Map<String, Object> props) {


### PR DESCRIPTION
NOTE: I put it in to keep track of it, but probably, to make the CI work, a PR should be done by pushing against upstream, instead of my fork ?
Because I don't have access at the moment, unfortunately :(

---
Fixes https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/4378

In APOC Extended there are some procedures that use VirtualNode Sets (i.e. some of the  `apoc.nlp.*`) e.g. [at this point](https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/dev/extended/src/main/kotlin/apoc/nlp/aws/AWSVirtualSentimentVirtualGraph.kt#L18).
However, via [this change](https://github.com/neo4j/apoc/commit/51d13ee49980def7557c6ac4a987843439825a92#diff-144887c5edacf927d08fe68a4e09e316e793b867034fecc7190897805e6d94f4R69-R70), 
they currently no longer work (e.g.[ here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/13584474176/job/38226625332?pr=4371#step:10:11367)) 
because the `int hashCode()` method still refers to the `id`, whereas they should refer to the `elementId`, both because it is unique and for consistency with the `boolean equals(Object o)` which execute
```
return this == o || o instanceof Node && Objects.equals(getElementId(), ((Node) o).getElementId());
```

Seems to work even without changing `VirtualRelationship` in the same way, 
but I think it is better to make the change there for consistency as well.
