### PR TITLE
Fix integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,13 @@ plugins {
     id("com.diffplug.spotless") version "6.22.0"
 }
 
+ext {
+    publicDir = "${project.rootDir}"
+    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : "2025.03.0"
+    testContainersVersion = '1.20.2'
+    apacheArrowVersion = '15.0.0'
+}
+
 downloadLicenses {
     excludeDependencies = [
             'org.neo4j.*'
@@ -167,10 +174,3 @@ subprojects {
 
 apply from: "licenses-3rdparties.gradle"
 apply from: "licenses-source-header.gradle"
-
-ext {
-    publicDir = "${project.rootDir}"
-    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : "2025.03.0"
-    testContainersVersion = '1.20.2'
-    apacheArrowVersion = '15.0.0'
-}

--- a/it/build.gradle
+++ b/it/build.gradle
@@ -1,9 +1,5 @@
 description = 'APOC :: Integration Tests Module'
 
-test {
-    maxParallelForks = 1
-}
-
 dependencies {
     testImplementation project(':common')
     testImplementation project(':core')
@@ -17,5 +13,21 @@ dependencies {
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'
         exclude group: 'ch.qos.logback', module: 'logback-classic'
+    }
+}
+
+
+tasks.register('copyApocJar', Copy) {
+    dependsOn(':core:shadowJar')
+    from project(':core').tasks.shadowJar.archiveFile into layout.buildDirectory.dir('test/jar')
+}
+
+test {
+    dependsOn(copyApocJar)
+    maxParallelForks = 1
+    doFirst {
+        var apocJarPath = layout.buildDirectory.file("test/jar/apoc-${version}-core.jar").get().asFile.absolutePath
+        println("apoc-core.test.jar.path=$apocJarPath")
+        systemProperty 'apoc-core.test.jar.path', apocJarPath
     }
 }


### PR DESCRIPTION
Make `:it:test` depend on `:core:shadowJar` and copy the apoc jar from the build instead of trying to invoke gradle programatically from the test code. Attempt to fix issue with the build where the wrong version of apoc is used in docker based tests.