### PR TITLE
Update test folder to match Neo's new naming

### DIFF
--- a/common/src/main/java/apoc/ApocConfig.java
+++ b/common/src/main/java/apoc/ApocConfig.java
@@ -345,7 +345,7 @@ public class ApocConfig extends LifecycleAdapter {
         if (importFolder == null) {
             return false;
         } else {
-            return !"/target/test data/neo4j".equals(importFolder);
+            return !importFolder.startsWith("/target/test data/neo4j");
         }
     }
 


### PR DESCRIPTION
A bunch of tests started failing due to an update in Neo to do with the naming of import folders for tests, this fixes it