### PR TITLE
Fix unsafe use of transactions in Cypher export

### DIFF
--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -1545,10 +1545,11 @@ public class ExportCypherTest {
         try (final var tx = db.beginTx()) {
             assertThat(tx.execute("CREATE (:`UNCOMITTED_NODE` {p: 'node not committed'})").stream())
                     .isEmpty();
-            final var exportQuery = "CALL apoc.export.cypher.all(null, {stream: true})";
+            final var exportQuery = "CALL apoc.export.cypher.all(null, {stream: true}) YIELD cypherStatements AS s";
 
-            // This is a weird behaviour, not sure if it's a bug.
-            assertThat(tx.execute(exportQuery).stream()).isEmpty();
+            assertThat(tx.execute(exportQuery).<String>columnAs("s").stream())
+                    .anySatisfy(s -> assertThat(s).contains("COMMITED_NODE"))
+                    .allSatisfy(s -> assertThat(s).doesNotContain("UNCOMITTED_NODE"));
         }
     }
 


### PR DESCRIPTION
Fix unsafe use of transactions. Attempt to fix:

- https://trello.com/c/gRSYmlRs/2615-nightly-test-failure-apocexportcypherexportcyphermultireltestcreateoptimizationnone-is-failing-in-a-pipeline-run
- https://trello.com/c/Il7Rm3eN/2605-nightly-test-failure-apocexportcypherexportcyphermultireltestaddstructurewithoptimization-is-failing-in-a-pipeline-run
- https://trello.com/c/OwcxoHDR/2612-merge-test-failure-apocexportcypherexportcyphermultireltestupdatestructurewithoptimization-is-failing-in-a-pipeline-run
- https://trello.com/c/XpmvYy8q/2613-merge-test-failure-apocexportcypherexportcyphermultireltestcreatewithoptimization-is-failing-in-a-pipeline-run
- https://trello.com/c/uHttAONj/2614-merge-test-failure-apocrefactorgraphrefactoringtestshouldalwaysoverridenodepropsifnotsetandcombinerelpropsifpropertyisnull-is-fa
- https://trello.com/c/gXx1BFjd/2606-nightly-test-failure-apocexportcypherexportcyphermultireltestaddstructureoptimizationnone-is-failing-in-a-pipeline-run
- https://trello.com/c/wwnm2ff0/2609-nightly-test-failure-apocexportcypherexportcyphermultireltestaddstructurewithoptimizationandwithoutnodecleanup-is-failing-in-a-p
- https://trello.com/c/kItzqAwx/2611-nightly-test-failure-apocexportcypherexportcyphermultireltestupdateallwithoptimization-is-failing-in-a-pipeline-run
- https://trello.com/c/7F3kPehS/2610-nightly-test-failure-apocexportcypherexportcyphermultireltestupdatestructureoptimizationnone-is-failing-in-a-pipeline-run
- https://trello.com/c/UlIzEz4s/2607-nightly-test-failure-apocexportcypherexportcyphermultireltestupdatealloptimizationnone-is-failing-in-a-pipeline-run