### PR TITLE
Make periodic procedures safe to call concurrently

### DIFF
--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -103,6 +103,7 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.ResultTransformer;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionTerminatedException;
 import org.neo4j.graphdb.schema.ConstraintType;
@@ -1493,4 +1494,11 @@ public class Util {
             case Cypher25 -> "25";
         };
     }
+
+    public static final Result.ResultVisitor<RuntimeException> CONSUME = row -> true;
+
+    public static final ResultTransformer<Void> CONSUME_VOID = result -> {
+        result.accept(CONSUME);
+        return null;
+    };
 }

--- a/test-utils/src/main/java/apoc/periodic/PeriodicTestUtils.java
+++ b/test-utils/src/main/java/apoc/periodic/PeriodicTestUtils.java
@@ -31,11 +31,10 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.impl.api.KernelTransactions;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
-import org.neo4j.test.rule.DbmsRule;
 
 public class PeriodicTestUtils {
 
-    public static void killPeriodicQueryAsync(DbmsRule db) {
+    public static void killPeriodicQueryAsync(GraphDatabaseAPI db) {
         new Thread(() -> {
                     int retries = 10;
                     try {
@@ -63,7 +62,8 @@ public class PeriodicTestUtils {
         return numberOfKilledTransactions > 0;
     }
 
-    public static void testTerminateInnerPeriodicQuery(DbmsRule db, String periodicQuery, String iterateQueryContains) {
+    public static void testTerminateInnerPeriodicQuery(
+            GraphDatabaseService db, String periodicQuery, String iterateQueryContains) {
         assertThat(periodicQuery).contains(iterateQueryContains);
 
         final var executor = Executors.newCachedThreadPool();


### PR DESCRIPTION
https://trello.com/c/Vi3h8rVw/2396-we-should-not-allow-concurrent-execution-of-apocperiodicrepeat