### PR TITLE
Add POINT value inference

### DIFF
--- a/core/src/test/resources/exportJSON/importPointValues.json
+++ b/core/src/test/resources/exportJSON/importPointValues.json
@@ -1,0 +1,4 @@
+{"id": 0,"type": "node","properties": {"orderID": 1, "coordinates": {"latitude": 38.8232,"longitude": -122.7955,"height": 3}},"labels": ["Earthquake"]}
+{"id": 1,"type": "node","properties": {"orderID": 2, "coordinates": {"latitude": 38.8232,"longitude": -122.7955}},"labels": ["Earthquake"]}
+{"id": 2,"type": "node","properties": {"orderID": 3, "coordinates": {"y": 38.8232,"x": -122.7955}},"labels": ["Earthquake"]}
+{"id": 3,"type": "node","properties": {"orderID": 4, "coordinates": {"y": 38.8232,"x": -122.7955,"z": 3}},"labels": ["Earthquake"]}

--- a/core/src/test/resources/exportJSON/invalidPointValues.json
+++ b/core/src/test/resources/exportJSON/invalidPointValues.json
@@ -1,0 +1,1 @@
+{"id": 0,"type": "node","properties": {"orderID": 1, "coordinates": {"lat": 38.8232,"long": -122.7955,"height": 3}},"labels": ["Earthquake"]}


### PR DESCRIPTION
A user found an issue that the POINT value fails if the CRS is not specified, but as Neo has set rules for determining the CRS, this doesn't make much sense. I added an inference step if no CRS is supplied, and a better error message if it can't be figured out.