### PR TITLE
Deprecate conditional based procedures in Cypher 25 and recommend Conditional queries instead

### DIFF
--- a/core/src/main/java/apoc/cypher/Cypher.java
+++ b/core/src/main/java/apoc/cypher/Cypher.java
@@ -48,6 +48,8 @@ import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.internal.kernel.api.procs.ProcedureCallContext;
+import org.neo4j.kernel.api.QueryLanguage;
+import org.neo4j.kernel.api.procedure.QueryLanguageScope;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Mode;
@@ -216,6 +218,28 @@ public class Cypher {
 
     @NotThreadSafe
     @Procedure("apoc.when")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description(
+            "This procedure will run the read-only `ifQuery` if the conditional has evaluated to true, otherwise the `elseQuery` will run.")
+    public Stream<CaseMapResult> whenCypher5(
+            @Name(value = "condition", description = "The predicate deciding if to run the `ifQuery`or not.")
+                    boolean condition,
+            @Name(value = "ifQuery", description = "The Cypher statement to run if the condition is true.")
+                    String ifQuery,
+            @Name(
+                            value = "elseQuery",
+                            defaultValue = "",
+                            description = "The Cypher statement to run if the condition is false.")
+                    String elseQuery,
+            @Name(value = "params", defaultValue = "{}", description = "The parameters for the given Cypher statement.")
+                    Map<String, Object> params) {
+        return when(condition, ifQuery, elseQuery, params);
+    }
+
+    @NotThreadSafe
+    @Deprecated
+    @Procedure(value = "apoc.when", deprecatedBy = "Cypher's conditional queries; WHEN ... THEN.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description(
             "This procedure will run the read-only `ifQuery` if the conditional has evaluated to true, otherwise the `elseQuery` will run.")
     public Stream<CaseMapResult> when(
@@ -243,6 +267,24 @@ public class Cypher {
     }
 
     @Procedure(value = "apoc.do.when", mode = Mode.WRITE)
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description(
+            "Runs the given read/write `ifQuery` if the conditional has evaluated to true, otherwise the `elseQuery` will run.")
+    public Stream<CaseMapResult> doWhenCypher5(
+            @Name(value = "condition", description = "The predicate that determines whether to execute the `ifQuery`.")
+                    boolean condition,
+            @Name(value = "ifQuery", description = "The Cypher statement to run if the condition is true.")
+                    String ifQuery,
+            @Name(value = "elseQuery", description = "The Cypher statement to run if the condition is false.")
+                    String elseQuery,
+            @Name(value = "params", defaultValue = "{}", description = "The parameters for the given Cypher statement.")
+                    Map<String, Object> params) {
+        return when(condition, ifQuery, elseQuery, params);
+    }
+
+    @Deprecated
+    @Procedure(value = "apoc.do.when", mode = Mode.WRITE, deprecatedBy = "Cypher's conditional queries; WHEN ... THEN.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description(
             "Runs the given read/write `ifQuery` if the conditional has evaluated to true, otherwise the `elseQuery` will run.")
     public Stream<CaseMapResult> doWhen(
@@ -268,6 +310,32 @@ public class Cypher {
 
     @NotThreadSafe
     @Procedure("apoc.case")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description(
+            "For each pair of conditional and read-only queries in the given `LIST<ANY>`, this procedure will run the first query for which the conditional is evaluated to true. If none of the conditionals are true, the `ELSE` query will run instead.")
+    public Stream<CaseMapResult> whenCaseCypher5(
+            @Name(
+                            value = "conditionals",
+                            description =
+                                    "A list of conditionals, where each conditional is a pair: the first element is a predicate, and the second is a Cypher query to be executed based on that predicate.")
+                    List<Object> conditionals,
+            @Name(
+                            value = "elseQuery",
+                            defaultValue = "",
+                            description = "A Cypher query to evaluate if all conditionals evaluate to false.")
+                    String elseQuery,
+            @Name(
+                            value = "params",
+                            defaultValue = "{}",
+                            description = "A map of parameters to be used in the executed Cypher query.")
+                    Map<String, Object> params) {
+        return whenCase(conditionals, elseQuery, params);
+    }
+
+    @NotThreadSafe
+    @Deprecated
+    @Procedure(value = "apoc.case", deprecatedBy = "Cypher's conditional queries; WHEN ... THEN.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description(
             "For each pair of conditional and read-only queries in the given `LIST<ANY>`, this procedure will run the first query for which the conditional is evaluated to true. If none of the conditionals are true, the `ELSE` query will run instead.")
     public Stream<CaseMapResult> whenCase(
@@ -316,6 +384,32 @@ public class Cypher {
     }
 
     @Procedure(name = "apoc.do.case", mode = Mode.WRITE)
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description(
+            "For each pair of conditional queries in the given `LIST<ANY>`, this procedure will run the first query for which the conditional is evaluated to true.\n"
+                    + "If none of the conditionals are true, the `ELSE` query will run instead.")
+    public Stream<CaseMapResult> doWhenCaseCypher5(
+            @Name(
+                            value = "conditionals",
+                            description =
+                                    "A list of conditionals, where each conditional is a pair: the first element is a predicate, and the second is a Cypher query to be executed based on that predicate.")
+                    List<Object> conditionals,
+            @Name(
+                            value = "elseQuery",
+                            defaultValue = "",
+                            description = "A Cypher query to evaluate if all conditionals evaluate to false.")
+                    String elseQuery,
+            @Name(
+                            value = "params",
+                            defaultValue = "{}",
+                            description = "A map of parameters to be used in the executed Cypher query.")
+                    Map<String, Object> params) {
+        return whenCase(conditionals, elseQuery, params);
+    }
+
+    @Deprecated
+    @Procedure(name = "apoc.do.case", mode = Mode.WRITE, deprecatedBy = "Cypher's conditional queries; WHEN ... THEN.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description(
             "For each pair of conditional queries in the given `LIST<ANY>`, this procedure will run the first query for which the conditional is evaluated to true.\n"
                     + "If none of the conditionals are true, the `ELSE` query will run instead.")

--- a/core/src/test/resources/procedures/common/procedures.json
+++ b/core/src/test/resources/procedures/common/procedures.json
@@ -486,36 +486,6 @@
   } ]
 }, {
   "isDeprecated" : false,
-  "signature" : "apoc.case(conditionals :: LIST<ANY>, elseQuery =  :: STRING, params = {} :: MAP) :: (value :: MAP)",
-  "name" : "apoc.case",
-  "description" : "For each pair of conditional and read-only queries in the given `LIST<ANY>`, this procedure will run the first query for which the conditional is evaluated to true. If none of the conditionals are true, the `ELSE` query will run instead.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "The result returned from the evaluated Cypher query.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "conditionals",
-    "description" : "A list of conditionals, where each conditional is a pair: the first element is a predicate, and the second is a Cypher query to be executed based on that predicate.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "elseQuery",
-    "description" : "A Cypher query to evaluate if all conditionals evaluate to false.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=, type=STRING}",
-    "type" : "STRING"
-  }, {
-    "name" : "params",
-    "description" : "A map of parameters to be used in the executed Cypher query.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
   "signature" : "apoc.coll.elements(coll :: LIST<ANY>, limit = -1 :: INTEGER, offset = 0 :: INTEGER) :: (_1 :: ANY, _2 :: ANY, _3 :: ANY, _4 :: ANY, _5 :: ANY, _6 :: ANY, _7 :: ANY, _8 :: ANY, _9 :: ANY, _10 :: ANY, _1s :: STRING, _2s :: STRING, _3s :: STRING, _4s :: STRING, _5s :: STRING, _6s :: STRING, _7s :: STRING, _8s :: STRING, _9s :: STRING, _10s :: STRING, _1i :: INTEGER, _2i :: INTEGER, _3i :: INTEGER, _4i :: INTEGER, _5i :: INTEGER, _6i :: INTEGER, _7i :: INTEGER, _8i :: INTEGER, _9i :: INTEGER, _10i :: INTEGER, _1f :: FLOAT, _2f :: FLOAT, _3f :: FLOAT, _4f :: FLOAT, _5f :: FLOAT, _6f :: FLOAT, _7f :: FLOAT, _8f :: FLOAT, _9f :: FLOAT, _10f :: FLOAT, _1b :: BOOLEAN, _2b :: BOOLEAN, _3b :: BOOLEAN, _4b :: BOOLEAN, _5b :: BOOLEAN, _6b :: BOOLEAN, _7b :: BOOLEAN, _8b :: BOOLEAN, _9b :: BOOLEAN, _10b :: BOOLEAN, _1l :: LIST<ANY>, _2l :: LIST<ANY>, _3l :: LIST<ANY>, _4l :: LIST<ANY>, _5l :: LIST<ANY>, _6l :: LIST<ANY>, _7l :: LIST<ANY>, _8l :: LIST<ANY>, _9l :: LIST<ANY>, _10l :: LIST<ANY>, _1m :: MAP, _2m :: MAP, _3m :: MAP, _4m :: MAP, _5m :: MAP, _6m :: MAP, _7m :: MAP, _8m :: MAP, _9m :: MAP, _10m :: MAP, _1n :: NODE, _2n :: NODE, _3n :: NODE, _4n :: NODE, _5n :: NODE, _6n :: NODE, _7n :: NODE, _8n :: NODE, _9n :: NODE, _10n :: NODE, _1r :: RELATIONSHIP, _2r :: RELATIONSHIP, _3r :: RELATIONSHIP, _4r :: RELATIONSHIP, _5r :: RELATIONSHIP, _6r :: RELATIONSHIP, _7r :: RELATIONSHIP, _8r :: RELATIONSHIP, _9r :: RELATIONSHIP, _10r :: RELATIONSHIP, _1p :: PATH, _2p :: PATH, _3p :: PATH, _4p :: PATH, _5p :: PATH, _6p :: PATH, _7p :: PATH, _8p :: PATH, _9p :: PATH, _10p :: PATH, elements :: INTEGER)",
   "name" : "apoc.coll.elements",
   "description" : "Deconstructs a `LIST<ANY>` into identifiers indicating their specific type.",
@@ -1791,70 +1761,6 @@
     "name" : "params",
     "description" : "The parameters for the given Cypher statement.",
     "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.do.case(conditionals :: LIST<ANY>, elseQuery =  :: STRING, params = {} :: MAP) :: (value :: MAP)",
-  "name" : "apoc.do.case",
-  "description" : "For each pair of conditional queries in the given `LIST<ANY>`, this procedure will run the first query for which the conditional is evaluated to true.\nIf none of the conditionals are true, the `ELSE` query will run instead.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "The result returned from the evaluated Cypher query.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "conditionals",
-    "description" : "A list of conditionals, where each conditional is a pair: the first element is a predicate, and the second is a Cypher query to be executed based on that predicate.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "elseQuery",
-    "description" : "A Cypher query to evaluate if all conditionals evaluate to false.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=, type=STRING}",
-    "type" : "STRING"
-  }, {
-    "name" : "params",
-    "description" : "A map of parameters to be used in the executed Cypher query.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.do.when(condition :: BOOLEAN, ifQuery :: STRING, elseQuery :: STRING, params = {} :: MAP) :: (value :: MAP)",
-  "name" : "apoc.do.when",
-  "description" : "Runs the given read/write `ifQuery` if the conditional has evaluated to true, otherwise the `elseQuery` will run.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "The result returned from the evaluated Cypher query.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "condition",
-    "description" : "The predicate that determines whether to execute the `ifQuery`.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "ifQuery",
-    "description" : "The Cypher statement to run if the condition is true.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "elseQuery",
-    "description" : "The Cypher statement to run if the condition is false.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "params",
-    "description" : "The parameters for the given Cypher statement.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
     "type" : "MAP"
   } ]
 }, {
@@ -7721,39 +7627,4 @@
     "isDeprecated" : false,
     "type" : "LIST<ANY>"
   } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.when(condition :: BOOLEAN, ifQuery :: STRING, elseQuery =  :: STRING, params = {} :: MAP) :: (value :: MAP)",
-  "name" : "apoc.when",
-  "description" : "This procedure will run the read-only `ifQuery` if the conditional has evaluated to true, otherwise the `elseQuery` will run.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "The result returned from the evaluated Cypher query.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "condition",
-    "description" : "The predicate deciding if to run the `ifQuery`or not.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "ifQuery",
-    "description" : "The Cypher statement to run if the condition is true.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "elseQuery",
-    "description" : "The Cypher statement to run if the condition is false.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=, type=STRING}",
-    "type" : "STRING"
-  }, {
-    "name" : "params",
-    "description" : "The parameters for the given Cypher statement.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-} ]
+}]

--- a/core/src/test/resources/procedures/cypher25/procedures.json
+++ b/core/src/test/resources/procedures/cypher25/procedures.json
@@ -1,5 +1,42 @@
 [
   {
+    "isDeprecated": true,
+    "signature": "apoc.case(conditionals :: LIST<ANY>, elseQuery =  :: STRING, params = {} :: MAP) :: (value :: MAP)",
+    "name": "apoc.case",
+    "description": "For each pair of conditional and read-only queries in the given `LIST<ANY>`, this procedure will run the first query for which the conditional is evaluated to true. If none of the conditionals are true, the `ELSE` query will run instead.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The result returned from the evaluated Cypher query.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": "Cypher's conditional queries; WHEN ... THEN.",
+    "argumentDescription": [
+      {
+        "name": "conditionals",
+        "description": "A list of conditionals, where each conditional is a pair: the first element is a predicate, and the second is a Cypher query to be executed based on that predicate.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "elseQuery",
+        "description": "A Cypher query to evaluate if all conditionals evaluate to false.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "params",
+        "description": "A map of parameters to be used in the executed Cypher query.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
     "isDeprecated": false,
     "signature": "apoc.cypher.runTimeboxed(statement :: STRING, params :: MAP, timeout :: INTEGER, config = {} :: MAP) :: (value :: MAP)",
     "name": "apoc.cypher.runTimeboxed",
@@ -43,6 +80,85 @@
   },
   {
     "isDeprecated": true,
+    "signature": "apoc.do.case(conditionals :: LIST<ANY>, elseQuery =  :: STRING, params = {} :: MAP) :: (value :: MAP)",
+    "name": "apoc.do.case",
+    "description": "For each pair of conditional queries in the given `LIST<ANY>`, this procedure will run the first query for which the conditional is evaluated to true.\nIf none of the conditionals are true, the `ELSE` query will run instead.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The result returned from the evaluated Cypher query.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": "Cypher's conditional queries; WHEN ... THEN.",
+    "argumentDescription": [
+      {
+        "name": "conditionals",
+        "description": "A list of conditionals, where each conditional is a pair: the first element is a predicate, and the second is a Cypher query to be executed based on that predicate.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "elseQuery",
+        "description": "A Cypher query to evaluate if all conditionals evaluate to false.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "params",
+        "description": "A map of parameters to be used in the executed Cypher query.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.do.when(condition :: BOOLEAN, ifQuery :: STRING, elseQuery :: STRING, params = {} :: MAP) :: (value :: MAP)",
+    "name": "apoc.do.when",
+    "description": "Runs the given read/write `ifQuery` if the conditional has evaluated to true, otherwise the `elseQuery` will run.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The result returned from the evaluated Cypher query.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": "Cypher's conditional queries; WHEN ... THEN.",
+    "argumentDescription": [
+      {
+        "name": "condition",
+        "description": "The predicate that determines whether to execute the `ifQuery`.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "ifQuery",
+        "description": "The Cypher statement to run if the condition is true.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "elseQuery",
+        "description": "The Cypher statement to run if the condition is false.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statement.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
     "signature": "apoc.refactor.deleteAndReconnect(path :: PATH, nodes :: LIST<NODE>, config = {} :: MAP) :: (nodes :: LIST<NODE>, relationships :: LIST<RELATIONSHIP>)",
     "name": "apoc.refactor.deleteAndReconnect",
     "description": "Removes the given `NODE` values from the `PATH` (and graph, including all of its relationships) and reconnects the remaining `NODE` values.\nNote, undefined behaviour for paths that visits the same node multiple times.\nNote, nodes that are not connected in the same direction as the path will not be reconnected, for example `MATCH p=(:A)-->(b:B)<--(:C) CALL apoc.refactor.deleteAndReconnect(p, [b]) ...` will not reconnect the :A and :C nodes.",
@@ -77,6 +193,49 @@
       {
         "name": "config",
         "description": "{\n    relationshipSelectionStrategy = \"incoming\" :: [\"incoming\", \"outgoing\", \"merge\"]\n    properties :: [\"overwrite\", \"discard\", \"combine\"]\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.when(condition :: BOOLEAN, ifQuery :: STRING, elseQuery =  :: STRING, params = {} :: MAP) :: (value :: MAP)",
+    "name": "apoc.when",
+    "description": "This procedure will run the read-only `ifQuery` if the conditional has evaluated to true, otherwise the `elseQuery` will run.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The result returned from the evaluated Cypher query.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": "Cypher's conditional queries; WHEN ... THEN.",
+    "argumentDescription": [
+      {
+        "name": "condition",
+        "description": "The predicate deciding if to run the `ifQuery`or not.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "ifQuery",
+        "description": "The Cypher statement to run if the condition is true.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "elseQuery",
+        "description": "The Cypher statement to run if the condition is false.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statement.",
         "isDeprecated": false,
         "default": "DefaultParameterValue{value={}, type=MAP}",
         "type": "MAP"

--- a/core/src/test/resources/procedures/cypher5/procedures.json
+++ b/core/src/test/resources/procedures/cypher5/procedures.json
@@ -1,5 +1,42 @@
 [
   {
+    "isDeprecated": false,
+    "signature": "apoc.case(conditionals :: LIST<ANY>, elseQuery =  :: STRING, params = {} :: MAP) :: (value :: MAP)",
+    "name": "apoc.case",
+    "description": "For each pair of conditional and read-only queries in the given `LIST<ANY>`, this procedure will run the first query for which the conditional is evaluated to true. If none of the conditionals are true, the `ELSE` query will run instead.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The result returned from the evaluated Cypher query.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "conditionals",
+        "description": "A list of conditionals, where each conditional is a pair: the first element is a predicate, and the second is a Cypher query to be executed based on that predicate.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "elseQuery",
+        "description": "A Cypher query to evaluate if all conditionals evaluate to false.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "params",
+        "description": "A map of parameters to be used in the executed Cypher query.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
     "isDeprecated": true,
     "signature": "apoc.convert.toTree(paths :: LIST<PATH>, lowerCaseRels = true :: BOOLEAN, config = {} :: MAP) :: (value :: MAP)",
     "name": "apoc.convert.toTree",
@@ -97,6 +134,85 @@
         "description": "The maximum time, in milliseconds, the statement can run for.",
         "isDeprecated": false,
         "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.do.case(conditionals :: LIST<ANY>, elseQuery =  :: STRING, params = {} :: MAP) :: (value :: MAP)",
+    "name": "apoc.do.case",
+    "description": "For each pair of conditional queries in the given `LIST<ANY>`, this procedure will run the first query for which the conditional is evaluated to true.\nIf none of the conditionals are true, the `ELSE` query will run instead.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The result returned from the evaluated Cypher query.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "conditionals",
+        "description": "A list of conditionals, where each conditional is a pair: the first element is a predicate, and the second is a Cypher query to be executed based on that predicate.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "elseQuery",
+        "description": "A Cypher query to evaluate if all conditionals evaluate to false.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "params",
+        "description": "A map of parameters to be used in the executed Cypher query.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.do.when(condition :: BOOLEAN, ifQuery :: STRING, elseQuery :: STRING, params = {} :: MAP) :: (value :: MAP)",
+    "name": "apoc.do.when",
+    "description": "Runs the given read/write `ifQuery` if the conditional has evaluated to true, otherwise the `elseQuery` will run.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The result returned from the evaluated Cypher query.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "condition",
+        "description": "The predicate that determines whether to execute the `ifQuery`.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "ifQuery",
+        "description": "The Cypher statement to run if the condition is true.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "elseQuery",
+        "description": "The Cypher statement to run if the condition is false.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statement.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
       }
     ]
   },
@@ -1175,6 +1291,49 @@
         "isDeprecated": false,
         "default": "DefaultParameterValue{value=false, type=BOOLEAN}",
         "type": "BOOLEAN"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.when(condition :: BOOLEAN, ifQuery :: STRING, elseQuery =  :: STRING, params = {} :: MAP) :: (value :: MAP)",
+    "name": "apoc.when",
+    "description": "This procedure will run the read-only `ifQuery` if the conditional has evaluated to true, otherwise the `elseQuery` will run.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The result returned from the evaluated Cypher query.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "condition",
+        "description": "The predicate deciding if to run the `ifQuery`or not.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "ifQuery",
+        "description": "The Cypher statement to run if the condition is true.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "elseQuery",
+        "description": "The Cypher statement to run if the condition is false.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statement.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
       }
     ]
   }


### PR DESCRIPTION
When using Cypher 25, APOC should give a warning about deprecation on the conditional based procedures, the docs will also be updated to show the deprecation as well as give examples on how to actually use the new conditional queries