### PR TITLE
Deprecate procedures and functions that are easy to do in Cypher and are more performant in Cypher as well.

### DIFF
--- a/core/src/main/java/apoc/agg/Graph.java
+++ b/core/src/main/java/apoc/agg/Graph.java
@@ -27,6 +27,8 @@ import java.util.Set;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.kernel.api.QueryLanguage;
+import org.neo4j.kernel.api.procedure.QueryLanguageScope;
 import org.neo4j.procedure.*;
 
 /**
@@ -35,6 +37,16 @@ import org.neo4j.procedure.*;
  */
 public class Graph {
     @UserAggregationFunction("apoc.agg.graph")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description(
+            "Returns all distinct `NODE` and `RELATIONSHIP` values collected into a `MAP` with the keys `nodes` and `relationships`.")
+    public GraphAggregation graphCypher5() {
+        return new GraphAggregation();
+    }
+
+    @Deprecated
+    @UserAggregationFunction(name = "apoc.agg.graph", deprecatedBy = "Cypher's `COLLECT {}` expression.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description(
             "Returns all distinct `NODE` and `RELATIONSHIP` values collected into a `MAP` with the keys `nodes` and `relationships`.")
     public GraphAggregation graph() {

--- a/core/src/main/java/apoc/agg/Product.java
+++ b/core/src/main/java/apoc/agg/Product.java
@@ -18,6 +18,8 @@
  */
 package apoc.agg;
 
+import org.neo4j.kernel.api.QueryLanguage;
+import org.neo4j.kernel.api.procedure.QueryLanguageScope;
 import org.neo4j.procedure.*;
 
 /**
@@ -26,6 +28,17 @@ import org.neo4j.procedure.*;
  */
 public class Product {
     @UserAggregationFunction("apoc.agg.product")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns the product of all non-null `INTEGER` and `FLOAT` values in the collection.")
+    public ProductFunction productCypher5() {
+        return new ProductFunction();
+    }
+
+    @Deprecated
+    @UserAggregationFunction(
+            name = "apoc.agg.product",
+            deprecatedBy = "Cypher's `reduce()`: `RETURN reduce(x = 1, i IN values | x * i)`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns the product of all non-null `INTEGER` and `FLOAT` values in the collection.")
     public ProductFunction product() {
         return new ProductFunction();

--- a/core/src/main/java/apoc/algo/Cover.java
+++ b/core/src/main/java/apoc/algo/Cover.java
@@ -29,6 +29,8 @@ import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.api.QueryLanguage;
+import org.neo4j.kernel.api.procedure.QueryLanguageScope;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
@@ -44,6 +46,17 @@ public class Cover {
             @Description("The relationships connected to the given nodes.") Relationship rel) {}
 
     @Procedure("apoc.algo.cover")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns all `RELATIONSHIP` values connecting the given set of `NODE` values.")
+    public Stream<AlgoCoverRelationshipResult> coverCypher5(
+            @Name(value = "nodes", description = "The nodes to look for connected relationships on.") Object nodes) {
+        Set<Node> nodeSet = Util.nodeStream((InternalTransaction) tx, nodes).collect(Collectors.toSet());
+        return coverNodes(nodeSet).map(AlgoCoverRelationshipResult::new);
+    }
+
+    @Deprecated
+    @Procedure(name = "apoc.algo.cover", deprecatedBy = "Cypher's `MATCH` and `IN` clauses.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns all `RELATIONSHIP` values connecting the given set of `NODE` values.")
     public Stream<AlgoCoverRelationshipResult> cover(
             @Name(value = "nodes", description = "The nodes to look for connected relationships on.") Object nodes) {

--- a/core/src/main/java/apoc/coll/Coll.java
+++ b/core/src/main/java/apoc/coll/Coll.java
@@ -54,6 +54,8 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.kernel.api.procs.ProcedureCallContext;
+import org.neo4j.kernel.api.QueryLanguage;
+import org.neo4j.kernel.api.procedure.QueryLanguageScope;
 import org.neo4j.kernel.impl.util.ValueUtils;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
@@ -74,6 +76,22 @@ public class Coll {
     public ProcedureCallContext procedureCallContext;
 
     @UserFunction("apoc.coll.stdev")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns sample or population standard deviation with `isBiasCorrected` true or false respectively.")
+    public Number stdevCypher5(
+            @Name(value = "list", description = "A list to collect the standard deviation from.") List<Number> list,
+            @Name(
+                            value = "isBiasCorrected",
+                            defaultValue = "true",
+                            description =
+                                    "Will perform a sample standard deviation if `isBiasCorrected`, otherwise a population standard deviation is performed.")
+                    boolean isBiasCorrected) {
+        return stdev(list, isBiasCorrected);
+    }
+
+    @Deprecated
+    @UserFunction(name = "apoc.coll.stdev", deprecatedBy = "Cypher's `stDev()` and `stDevP()` functions.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns sample or population standard deviation with `isBiasCorrected` true or false respectively.")
     public Number stdev(
             @Name(value = "list", description = "A list to collect the standard deviation from.") List<Number> list,
@@ -108,6 +126,20 @@ public class Coll {
     public record ZipToRowsListResult(@Description("A zipped pair.") List<Object> value) {}
 
     @Procedure("apoc.coll.zipToRows")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns the two `LIST<ANY>` values zipped together, with one row per zipped pair.")
+    public Stream<ZipToRowsListResult> zipToRowsCypher5(
+            @Name(value = "list1", description = "The list to zip together with `list2`.") List<Object> list1,
+            @Name(value = "list2", description = "The list to zip together with `list1`.") List<Object> list2) {
+        return zipToRows(list1, list2);
+    }
+
+    @Deprecated
+    @Procedure(
+            name = "apoc.coll.zipToRows",
+            deprecatedBy =
+                    "Cypher's `UNWIND` and `range()` function; `UNWIND range(0, size(list1) - 1) AS i RETURN [list1[i], list2[i]]`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns the two `LIST<ANY>` values zipped together, with one row per zipped pair.")
     public Stream<ZipToRowsListResult> zipToRows(
             @Name(value = "list1", description = "The list to zip together with `list2`.") List<Object> list1,
@@ -118,6 +150,20 @@ public class Coll {
     }
 
     @UserFunction("apoc.coll.zip")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns the two given `LIST<ANY>` values zipped together as a `LIST<LIST<ANY>>`.")
+    public List<List<Object>> zipCypher5(
+            @Name(value = "list1", description = "The list to zip together with `list2`.") List<Object> list1,
+            @Name(value = "list2", description = "The list to zip together with `list1`.") List<Object> list2) {
+        return zip(list1, list2);
+    }
+
+    @Deprecated
+    @UserFunction(
+            name = "apoc.coll.zip",
+            deprecatedBy =
+                    "Cypher's `UNWIND` and `range()` function; `UNWIND range(0, size(list1) - 1) AS i RETURN [list1[i], list2[i]]`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns the two given `LIST<ANY>` values zipped together as a `LIST<LIST<ANY>>`.")
     public List<List<Object>> zip(
             @Name(value = "list1", description = "The list to zip together with `list2`.") List<Object> list1,
@@ -133,6 +179,19 @@ public class Coll {
     }
 
     @UserFunction("apoc.coll.pairs")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns a `LIST<ANY>` of adjacent elements in the `LIST<ANY>` ([1,2],[2,3],[3,null]).")
+    public List<List<Object>> pairsCypher5(
+            @Name(value = "list", description = "The list to create pairs from.") List<Object> list) {
+        return pairs(list);
+    }
+
+    @Deprecated
+    @UserFunction(
+            name = "apoc.coll.pairs",
+            deprecatedBy =
+                    "Cypher's list comprehension: `RETURN [i IN range(0, size(list) - 1) | [list[i], list[i + 1]]]`")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns a `LIST<ANY>` of adjacent elements in the `LIST<ANY>` ([1,2],[2,3],[3,null]).")
     public List<List<Object>> pairs(
             @Name(value = "list", description = "The list to create pairs from.") List<Object> list) {
@@ -142,6 +201,20 @@ public class Coll {
     }
 
     @UserFunction("apoc.coll.pairsMin")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description(
+            "Returns `LIST<ANY>` values of adjacent elements in the `LIST<ANY>` ([1,2],[2,3]), skipping the final element.")
+    public List<List<Object>> pairsMinCypher5(
+            @Name(value = "list", description = "The list to create pairs from.") List<Object> list) {
+        return pairsMin(list);
+    }
+
+    @Deprecated
+    @UserFunction(
+            name = "apoc.coll.pairsMin",
+            deprecatedBy =
+                    "Cypher's list comprehension: `RETURN [i IN range(0, size(list) - 2) | [list[i], list[i + 1]]]`")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description(
             "Returns `LIST<ANY>` values of adjacent elements in the `LIST<ANY>` ([1,2],[2,3]), skipping the final element.")
     public List<List<Object>> pairsMin(
@@ -152,6 +225,18 @@ public class Coll {
     }
 
     @UserFunction("apoc.coll.sum")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns the sum of all the `INTEGER | FLOAT` in the `LIST<INTEGER | FLOAT>`.")
+    public Double sumCypher5(
+            @Name(value = "coll", description = "The list of numbers to create a sum from.") List<Number> list) {
+        return sum(list);
+    }
+
+    @Deprecated
+    @UserFunction(
+            name = "apoc.coll.sum",
+            deprecatedBy = "Cypher's `reduce()` function: `RETURN reduce(sum = 0.0, x IN list | sum + x)`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns the sum of all the `INTEGER | FLOAT` in the `LIST<INTEGER | FLOAT>`.")
     public Double sum(
             @Name(value = "coll", description = "The list of numbers to create a sum from.") List<Number> list) {
@@ -176,6 +261,19 @@ public class Coll {
 
     @NotThreadSafe
     @UserFunction("apoc.coll.min")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns the minimum of all values in the given `LIST<ANY>`.")
+    public Object minCypher5(
+            @Name(value = "values", description = "The list to find the minimum in.") List<Object> list) {
+        return min(list);
+    }
+
+    @NotThreadSafe
+    @Deprecated
+    @UserFunction(
+            name = "apoc.coll.min",
+            deprecatedBy = "Cypher's `min()` function: `UNWIND values AS value RETURN min(value)`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns the minimum of all values in the given `LIST<ANY>`.")
     public Object min(@Name(value = "values", description = "The list to find the minimum in.") List<Object> list) {
         if (list == null || list.isEmpty()) return null;
@@ -192,6 +290,19 @@ public class Coll {
 
     @NotThreadSafe
     @UserFunction("apoc.coll.max")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns the maximum of all values in the given `LIST<ANY>`.")
+    public Object maxCypher5(
+            @Name(value = "values", description = "The list to find the maximum in.") List<Object> list) {
+        return max(list);
+    }
+
+    @NotThreadSafe
+    @Deprecated
+    @UserFunction(
+            name = "apoc.coll.max",
+            deprecatedBy = "Cypher's `max()` function: `UNWIND values AS value RETURN max(value)`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns the maximum of all values in the given `LIST<ANY>`.")
     public Object max(@Name(value = "values", description = "The list to find the maximum in.") List<Object> list) {
         if (list == null || list.isEmpty()) return null;
@@ -781,6 +892,21 @@ public class Coll {
     public record PartitionListResult(@Description("The partitioned list.") List<Object> value) {}
 
     @Procedure("apoc.coll.partition")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Partitions the original `LIST<ANY>` into a new `LIST<ANY>` of the given batch size.\n"
+            + "The final `LIST<ANY>` may be smaller than the given batch size.")
+    public Stream<PartitionListResult> partitionCypher5(
+            @Name(value = "coll", description = "The list to partition into smaller sublists.") List<Object> list,
+            @Name(value = "batchSize", description = "The max size of each partitioned sublist.") long batchSize) {
+        return partition(list, batchSize);
+    }
+
+    @Deprecated
+    @Procedure(
+            name = "apoc.coll.partition",
+            deprecatedBy =
+                    "Cypher's list comprehension: `RETURN [i IN range(0, size(list), offset) | list[i..i + offset]] AS value`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Partitions the original `LIST<ANY>` into a new `LIST<ANY>` of the given batch size.\n"
             + "The final `LIST<ANY>` may be smaller than the given batch size.")
     public Stream<PartitionListResult> partition(
@@ -791,6 +917,21 @@ public class Coll {
     }
 
     @UserFunction("apoc.coll.partition")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Partitions the original `LIST<ANY>` into a new `LIST<ANY>` of the given batch size.\n"
+            + "The final `LIST<ANY>` may be smaller than the given batch size.")
+    public List<Object> partitionFnCypher5(
+            @Name(value = "coll", description = "The list to partition into smaller sublists.") List<Object> list,
+            @Name(value = "batchSize", description = "The max size of each partitioned sublist.") long batchSize) {
+        return partitionFn(list, batchSize);
+    }
+
+    @Deprecated
+    @UserFunction(
+            name = "apoc.coll.partition",
+            deprecatedBy =
+                    "Cypher's list comprehension: `RETURN [i IN range(0, size(list), offset) | list[i..i + offset]] AS value`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Partitions the original `LIST<ANY>` into a new `LIST<ANY>` of the given batch size.\n"
             + "The final `LIST<ANY>` may be smaller than the given batch size.")
     public List<Object> partitionFn(
@@ -832,6 +973,17 @@ public class Coll {
     }
 
     @UserFunction("apoc.coll.contains")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns whether or not the given value exists in the given collection.")
+    public boolean containsCypher5(
+            @Name(value = "coll", description = "The list to search for the given value.") List<Object> coll,
+            @Name(value = "value", description = "The value in the list to check for the existence of.") Object value) {
+        return contains(coll, value);
+    }
+
+    @Deprecated
+    @UserFunction(name = "apoc.coll.contains", deprecatedBy = "Cypher's `IN`: `value IN coll`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns whether or not the given value exists in the given collection.")
     public boolean contains(
             @Name(value = "coll", description = "The list to search for the given value.") List<Object> coll,
@@ -914,6 +1066,18 @@ public class Coll {
     }
 
     @UserFunction("apoc.coll.containsAll")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns whether or not all of the given values exist in the given collection.")
+    public boolean containsAllCypher5(
+            @Name(value = "coll1", description = "The list to search for the given values in.") List<Object> coll,
+            @Name(value = "coll2", description = "The list of values in the given list to check for the existence of.")
+                    List<Object> values) {
+        return containsAll(coll, values);
+    }
+
+    @Deprecated
+    @UserFunction(name = "apoc.coll.containsAll", deprecatedBy = "Cypher's `all()`: `all(x IN coll2 WHERE x IN coll1)`")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns whether or not all of the given values exist in the given collection.")
     public boolean containsAll(
             @Name(value = "coll1", description = "The list to search for the given values in.") List<Object> coll,
@@ -980,6 +1144,23 @@ public class Coll {
     }
 
     @UserFunction("apoc.coll.sumLongs")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns the sum of all the `INTEGER | FLOAT` in the `LIST<INTEGER | FLOAT>`.")
+    public Long sumLongsCypher5(
+            @Name(
+                            value = "coll",
+                            description =
+                                    "The list of numbers to create a sum from after each is cast to a java Long value.")
+                    List<Number> list) {
+        return sumLongs(list);
+    }
+
+    @Deprecated
+    @UserFunction(
+            name = "apoc.coll.sumLongs",
+            deprecatedBy =
+                    "Cypher's `reduce()` function: `RETURN reduce(sum = 0.0, x IN toIntegerList(list) | sum + x)`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns the sum of all the `INTEGER | FLOAT` in the `LIST<INTEGER | FLOAT>`.")
     public Long sumLongs(
             @Name(
@@ -1005,6 +1186,21 @@ public class Coll {
     }
 
     @UserFunction("apoc.coll.sortNodes")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Sorts the given `LIST<NODE>` by the property of the nodes into descending order.")
+    public List<Node> sortNodesCypher5(
+            @Name(value = "coll", description = "The list of nodes to be sorted.") List<Node> coll,
+            @Name(value = "prop", description = "The property key on the node to be used to sort the list by.")
+                    String prop) {
+        return sortNodes(coll, prop);
+    }
+
+    @Deprecated
+    @UserFunction(
+            name = "apoc.coll.sortNodes",
+            deprecatedBy =
+                    "Cypher's COLLECT {} and ORDER BY: `RETURN COLLECT { MATCH (n) RETURN n ORDER BY n.prop DESC }`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Sorts the given `LIST<NODE>` by the property of the nodes into descending order.")
     public List<Node> sortNodes(
             @Name(value = "coll", description = "The list of nodes to be sorted.") List<Node> coll,
@@ -1151,6 +1347,19 @@ public class Coll {
     }
 
     @UserFunction("apoc.coll.unionAll")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns the full union of the two given `LIST<ANY>` values (duplicates included).")
+    public List<Object> unionAllCypher5(
+            @Name(value = "list1", description = "The list of values to compare against `list2` and form a union from.")
+                    List<Object> first,
+            @Name(value = "list2", description = "The list of values to compare against `list1` and form a union from.")
+                    List<Object> second) {
+        return unionAll(first, second);
+    }
+
+    @Deprecated
+    @UserFunction(name = "apoc.coll.unionAll", deprecatedBy = "Cypher's list concatenation: `list1 + list2`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns the full union of the two given `LIST<ANY>` values (duplicates included).")
     public List<Object> unionAll(
             @Name(value = "list1", description = "The list of values to compare against `list2` and form a union from.")
@@ -1179,6 +1388,18 @@ public class Coll {
     }
 
     @UserFunction("apoc.coll.randomItem")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns a random item from the `LIST<ANY>`, or null on `LIST<NOTHING>` or `LIST<NULL>`.")
+    public Object randomItemCypher5(
+            @Name(value = "coll", description = "The list to return a random item from.") List<Object> coll) {
+        return randomItem(coll);
+    }
+
+    @Deprecated
+    @UserFunction(
+            name = "apoc.coll.randomItem",
+            deprecatedBy = "Cypher's `rand()` function: `RETURN list[toInteger(rand() * size(list))]`")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns a random item from the `LIST<ANY>`, or null on `LIST<NOTHING>` or `LIST<NULL>`.")
     public Object randomItem(
             @Name(value = "coll", description = "The list to return a random item from.") List<Object> coll) {
@@ -1340,6 +1561,21 @@ public class Coll {
     }
 
     @UserFunction("apoc.coll.occurrences")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns the count of the given item in the collection.")
+    public long occurrencesCypher5(
+            @Name(value = "coll", description = "The list to collect the count of the given value from.")
+                    List<Object> coll,
+            @Name(value = "item", description = "The value to count in the given list.") Object item) {
+        return occurrences(coll, item);
+    }
+
+    @Deprecated
+    @UserFunction(
+            name = "apoc.coll.occurrences",
+            deprecatedBy =
+                    "Cypher's reduce() and `CASE` expression: `RETURN reduce(count = 0, x IN coll | count + CASE WHEN x = item THEN 1 ELSE 0 END)`")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns the count of the given item in the collection.")
     public long occurrences(
             @Name(value = "coll", description = "The list to collect the count of the given value from.")
@@ -1530,6 +1766,22 @@ public class Coll {
     }
 
     @UserFunction("apoc.coll.fill")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns a `LIST<ANY>` with the given count of items.")
+    public List<Object> fillCypher5(
+            @Name(value = "item", description = "The item to be present in the returned list.") String item,
+            @Name(
+                            value = "count",
+                            description = "The number of times the given item should appear in the returned list.")
+                    long count) {
+        return Collections.nCopies((int) count, item);
+    }
+
+    @Deprecated
+    @UserFunction(
+            name = "apoc.coll.fill",
+            deprecatedBy = "Cypher's list comprehension: `RETURN [i IN range(1, count) | item]`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns a `LIST<ANY>` with the given count of items.")
     public List<Object> fill(
             @Name(value = "item", description = "The item to be present in the returned list.") String item,
@@ -1561,6 +1813,21 @@ public class Coll {
     }
 
     @UserFunction("apoc.coll.pairWithOffset")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns a `LIST<ANY>` of pairs defined by the offset.")
+    public List<List<Object>> pairWithOffsetFnCypher5(
+            @Name(value = "coll", description = "The list to create pairs from.") List<Object> values,
+            @Name(value = "offset", description = "The offset to make each pair with from the given list.")
+                    long offset) {
+        return pairWithOffsetFn(values, offset);
+    }
+
+    @Deprecated
+    @UserFunction(
+            name = "apoc.coll.pairWithOffset",
+            deprecatedBy =
+                    "Cyphers list comprehension: `RETURN [i IN range(0, size(list) - 1) | [list[i], list[i + offset]]] AS value`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns a `LIST<ANY>` of pairs defined by the offset.")
     public List<List<Object>> pairWithOffsetFn(
             @Name(value = "coll", description = "The list to create pairs from.") List<Object> values,
@@ -1582,6 +1849,21 @@ public class Coll {
     public record PairWithOffsetListResult(@Description("The created pair.") List<Object> value) {}
 
     @Procedure("apoc.coll.pairWithOffset")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns a `LIST<ANY>` of pairs defined by the offset.")
+    public Stream<PairWithOffsetListResult> pairWithOffsetCypher5(
+            @Name(value = "coll", description = "The list to create pairs from.") List<Object> values,
+            @Name(value = "offset", description = "The offset to make each pair with from the given list.")
+                    long offset) {
+        return pairWithOffsetFn(values, offset).stream().map(PairWithOffsetListResult::new);
+    }
+
+    @Deprecated
+    @Procedure(
+            name = "apoc.coll.pairWithOffset",
+            deprecatedBy =
+                    "Cypher's list comprehension: `RETURN [i IN range(0, size(list) - 1) | [list[i], list[i + offset]]] AS value`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns a `LIST<ANY>` of pairs defined by the offset.")
     public Stream<PairWithOffsetListResult> pairWithOffset(
             @Name(value = "coll", description = "The list to create pairs from.") List<Object> values,

--- a/core/src/main/java/apoc/coll/Coll.java
+++ b/core/src/main/java/apoc/coll/Coll.java
@@ -162,7 +162,7 @@ public class Coll {
     @UserFunction(
             name = "apoc.coll.zip",
             deprecatedBy =
-                    "Cypher's `UNWIND` and `range()` function; `UNWIND range(0, size(list1) - 1) AS i RETURN [list1[i], list2[i]]`.")
+                    "Cypher's `UNWIND` and `range()` function; `COLLECT { UNWIND range(0, size(list1) - 1) AS i RETURN [list1[i], list2[i]] }`.")
     @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns the two given `LIST<ANY>` values zipped together as a `LIST<LIST<ANY>>`.")
     public List<List<Object>> zip(

--- a/core/src/main/java/apoc/convert/Convert.java
+++ b/core/src/main/java/apoc/convert/Convert.java
@@ -29,6 +29,8 @@ import java.util.stream.Stream;
 import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.kernel.api.QueryLanguage;
+import org.neo4j.kernel.api.procedure.QueryLanguageScope;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.UserFunction;
@@ -54,6 +56,18 @@ public class Convert {
     }
 
     @UserFunction("apoc.convert.toList")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Converts the given value into a `LIST<ANY>`.")
+    public List<Object> toListCypher5(
+            @Name(value = "value", description = "The value to convert into a list.") Object list) {
+        return ConvertUtils.convertToList(list);
+    }
+
+    @Deprecated
+    @UserFunction(
+            name = "apoc.convert.toList",
+            deprecatedBy = "Cypher's conversion functions, see the docs for more information.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Converts the given value into a `LIST<ANY>`.")
     public List<Object> toList(@Name(value = "value", description = "The value to convert into a list.") Object list) {
         return ConvertUtils.convertToList(list);

--- a/core/src/main/java/apoc/create/Create.java
+++ b/core/src/main/java/apoc/create/Create.java
@@ -45,6 +45,21 @@ public class Create {
     public Transaction tx;
 
     @Procedure(name = "apoc.create.node", mode = Mode.WRITE)
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Creates a `NODE` with the given dynamic labels.")
+    public Stream<CreatedNodeResult> nodeCypher5(
+            @Name(value = "labels", description = "The labels to assign to the new node.") List<String> labelNames,
+            @Name(value = "props", description = "The properties to assign to the new node.")
+                    Map<String, Object> props) {
+        return node(labelNames, props);
+    }
+
+    @Deprecated
+    @Procedure(
+            name = "apoc.create.node",
+            mode = Mode.WRITE,
+            deprecatedBy = "Cypher's dynamic labels: `CREATE (n:$(labels)) SET n = props`")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Creates a `NODE` with the given dynamic labels.")
     public Stream<CreatedNodeResult> node(
             @Name(value = "labels", description = "The labels to assign to the new node.") List<String> labelNames,
@@ -54,6 +69,20 @@ public class Create {
     }
 
     @Procedure(name = "apoc.create.addLabels", mode = Mode.WRITE)
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Adds the given labels to the given `NODE` values.")
+    public Stream<UpdatedNodeResult> addLabelsCypher5(
+            @Name(value = "nodes", description = "The nodes to add labels to.") Object nodes,
+            @Name(value = "labels", description = "The labels to add to the nodes.") List<String> labelNames) {
+        return addLabels(nodes, labelNames);
+    }
+
+    @Deprecated
+    @Procedure(
+            name = "apoc.create.addLabels",
+            mode = Mode.WRITE,
+            deprecatedBy = "Cypher's dynamic labels; `SET n:$(labels)`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Adds the given labels to the given `NODE` values.")
     public Stream<UpdatedNodeResult> addLabels(
             @Name(value = "nodes", description = "The nodes to add labels to.") Object nodes,
@@ -69,6 +98,21 @@ public class Create {
     }
 
     @Procedure(name = "apoc.create.setProperty", mode = Mode.WRITE)
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Sets the given property to the given `NODE` values.")
+    public Stream<UpdatedNodeResult> setPropertyCypher5(
+            @Name(value = "nodes", description = "The nodes to set a property on.") Object nodes,
+            @Name(value = "key", description = "The name of the property key to set.") String key,
+            @Name(value = "value", description = "The value of the property to set.") Object value) {
+        return setProperty(nodes, key, value);
+    }
+
+    @Deprecated
+    @Procedure(
+            name = "apoc.create.setProperty",
+            mode = Mode.WRITE,
+            deprecatedBy = "Cypher's dynamic properties: `SET node[key] = value`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Sets the given property to the given `NODE` values.")
     public Stream<UpdatedNodeResult> setProperty(
             @Name(value = "nodes", description = "The nodes to set a property on.") Object nodes,
@@ -81,6 +125,21 @@ public class Create {
     }
 
     @Procedure(name = "apoc.create.setRelProperty", mode = Mode.WRITE)
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Sets the given property on the `RELATIONSHIP` values.")
+    public Stream<UpdatedRelationshipResult> setRelPropertyCypher5(
+            @Name(value = "rels", description = "The relationships to set a property on.") Object rels,
+            @Name(value = "key", description = "The name of the property key to set.") String key,
+            @Name(value = "value", description = "The value of the property to set.") Object value) {
+        return setRelProperty(rels, key, value);
+    }
+
+    @Deprecated
+    @Procedure(
+            name = "apoc.create.setRelProperty",
+            mode = Mode.WRITE,
+            deprecatedBy = "Cypher's dynamic properties: `SET rel[key] = value`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Sets the given property on the `RELATIONSHIP` values.")
     public Stream<UpdatedRelationshipResult> setRelProperty(
             @Name(value = "rels", description = "The relationships to set a property on.") Object rels,
@@ -93,6 +152,22 @@ public class Create {
     }
 
     @Procedure(name = "apoc.create.setProperties", mode = Mode.WRITE)
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Sets the given properties to the given `NODE` values.")
+    public Stream<UpdatedNodeResult> setPropertiesCypher5(
+            @Name(value = "nodes", description = "The nodes to set properties on.") Object nodes,
+            @Name(value = "keys", description = "The property keys to set on the given nodes.") List<String> keys,
+            @Name(value = "values", description = "The values to assign to the properties on the given nodes.")
+                    List<Object> values) {
+        return setProperties(nodes, keys, values);
+    }
+
+    @Deprecated
+    @Procedure(
+            name = "apoc.create.setProperties",
+            mode = Mode.WRITE,
+            deprecatedBy = "Cypher's dynamic properties: `SET node[key] = value`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Sets the given properties to the given `NODE` values.")
     public Stream<UpdatedNodeResult> setProperties(
             @Name(value = "nodes", description = "The nodes to set properties on.") Object nodes,
@@ -106,6 +181,21 @@ public class Create {
     }
 
     @Procedure(name = "apoc.create.removeProperties", mode = Mode.WRITE)
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Removes the given properties from the given `NODE` values.")
+    public Stream<UpdatedNodeResult> removePropertiesCypher5(
+            @Name(value = "nodes", description = "The nodes to remove properties from.") Object nodes,
+            @Name(value = "keys", description = "The property keys to remove from the given nodes.")
+                    List<String> keys) {
+        return removeProperties(nodes, keys);
+    }
+
+    @Deprecated
+    @Procedure(
+            name = "apoc.create.removeProperties",
+            mode = Mode.WRITE,
+            deprecatedBy = "Cypher's dynamic properties: `REMOVE node[key]`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Removes the given properties from the given `NODE` values.")
     public Stream<UpdatedNodeResult> removeProperties(
             @Name(value = "nodes", description = "The nodes to remove properties from.") Object nodes,
@@ -118,6 +208,23 @@ public class Create {
     }
 
     @Procedure(name = "apoc.create.setRelProperties", mode = Mode.WRITE)
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Sets the given properties on the `RELATIONSHIP` values.")
+    public Stream<UpdatedRelationshipResult> setRelPropertiesCypher5(
+            @Name(value = "rels", description = "The relationships to set properties on.") Object rels,
+            @Name(value = "keys", description = "The keys of the properties to set on the given relationships.")
+                    List<String> keys,
+            @Name(value = "values", description = "The values of the properties to set on the given relationships.")
+                    List<Object> values) {
+        return setRelProperties(rels, keys, values);
+    }
+
+    @Deprecated
+    @Procedure(
+            name = "apoc.create.setRelProperties",
+            mode = Mode.WRITE,
+            deprecatedBy = "Cypher's dynamic properties: `SET rel[key] = value`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Sets the given properties on the `RELATIONSHIP` values.")
     public Stream<UpdatedRelationshipResult> setRelProperties(
             @Name(value = "rels", description = "The relationships to set properties on.") Object rels,
@@ -132,6 +239,21 @@ public class Create {
     }
 
     @Procedure(name = "apoc.create.removeRelProperties", mode = Mode.WRITE)
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Removes the given properties from the given `RELATIONSHIP` values.")
+    public Stream<UpdatedRelationshipResult> removeRelPropertiesCypher5(
+            @Name(value = "rels", description = "The relationships to remove properties from.") Object rels,
+            @Name(value = "keys", description = "The property keys to remove from the given nodes.")
+                    List<String> keys) {
+        return removeRelProperties(rels, keys);
+    }
+
+    @Deprecated
+    @Procedure(
+            name = "apoc.create.removeRelProperties",
+            mode = Mode.WRITE,
+            deprecatedBy = "Cypher's dynamic properties: `REMOVE rel[key]`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Removes the given properties from the given `RELATIONSHIP` values.")
     public Stream<UpdatedRelationshipResult> removeRelProperties(
             @Name(value = "rels", description = "The relationships to remove properties from.") Object rels,
@@ -144,6 +266,20 @@ public class Create {
     }
 
     @Procedure(name = "apoc.create.setLabels", mode = Mode.WRITE)
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Sets the given labels to the given `NODE` values. Non-matching labels are removed from the nodes.")
+    public Stream<UpdatedNodeResult> setLabelsCypher5(
+            @Name(value = "nodes", description = "The nodes to set labels on.") Object nodes,
+            @Name(value = "labels", description = "The labels to set on the given nodes.") List<String> labelNames) {
+        return setLabels(nodes, labelNames);
+    }
+
+    @Deprecated
+    @Procedure(
+            name = "apoc.create.setLabels",
+            mode = Mode.WRITE,
+            deprecatedBy = "Cypher's dynamic labels; `SET n:$(labels)`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Sets the given labels to the given `NODE` values. Non-matching labels are removed from the nodes.")
     public Stream<UpdatedNodeResult> setLabels(
             @Name(value = "nodes", description = "The nodes to set labels on.") Object nodes,
@@ -164,6 +300,21 @@ public class Create {
     }
 
     @Procedure(name = "apoc.create.removeLabels", mode = Mode.WRITE)
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Removes the given labels from the given `NODE` values.")
+    public Stream<UpdatedNodeResult> removeLabelsCypher(
+            @Name(value = "nodes", description = "The node to remove labels from.") Object nodes,
+            @Name(value = "labels", description = "The labels to remove from the given node.")
+                    List<String> labelNames) {
+        return removeLabels(nodes, labelNames);
+    }
+
+    @Deprecated
+    @Procedure(
+            name = "apoc.create.removeLabels",
+            mode = Mode.WRITE,
+            deprecatedBy = "Cypher's dynamic labels: `REMOVE node:$(labels)`")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Removes the given labels from the given `NODE` values.")
     public Stream<UpdatedNodeResult> removeLabels(
             @Name(value = "nodes", description = "The node to remove labels from.") Object nodes,
@@ -180,6 +331,21 @@ public class Create {
     }
 
     @Procedure(name = "apoc.create.nodes", mode = Mode.WRITE)
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Creates `NODE` values with the given dynamic labels.")
+    public Stream<CreatedNodeResult> nodesCypher5(
+            @Name(value = "labels", description = "The labels to assign to the new nodes.") List<String> labelNames,
+            @Name(value = "props", description = "The properties to assign to the new nodes.")
+                    List<Map<String, Object>> props) {
+        return nodes(labelNames, props);
+    }
+
+    @Deprecated
+    @Procedure(
+            name = "apoc.create.nodes",
+            mode = Mode.WRITE,
+            deprecatedBy = "Cypher's dynamic labels: `UNWIND props AS p CREATE (n:$(labels)) SET n = p`")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Creates `NODE` values with the given dynamic labels.")
     public Stream<CreatedNodeResult> nodes(
             @Name(value = "labels", description = "The labels to assign to the new nodes.") List<String> labelNames,
@@ -190,6 +356,24 @@ public class Create {
     }
 
     @Procedure(name = "apoc.create.relationship", mode = Mode.WRITE)
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Creates a `RELATIONSHIP` with the given dynamic relationship type.")
+    public Stream<CreatedRelationshipResult> relationshipCypher5(
+            @Name(value = "from", description = "The node from which the outgoing relationship will start.") Node from,
+            @Name(value = "relType", description = "The type to assign to the new relationship.") String relType,
+            @Name(value = "props", description = "The properties to assign to the new relationship.")
+                    Map<String, Object> props,
+            @Name(value = "to", description = "The node to which the incoming relationship will be connected.")
+                    Node to) {
+        return relationship(from, relType, props, to);
+    }
+
+    @Deprecated
+    @Procedure(
+            name = "apoc.create.relationship",
+            mode = Mode.WRITE,
+            deprecatedBy = "Cypher's dynamic types: `CREATE (from)-[n:$(relType)]->(to) SET n = props`")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Creates a `RELATIONSHIP` with the given dynamic relationship type.")
     public Stream<CreatedRelationshipResult> relationship(
             @Name(value = "from", description = "The node from which the outgoing relationship will start.") Node from,

--- a/core/src/main/java/apoc/date/Date.java
+++ b/core/src/main/java/apoc/date/Date.java
@@ -39,6 +39,8 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.commons.lang3.StringUtils;
+import org.neo4j.kernel.api.QueryLanguage;
+import org.neo4j.kernel.api.procedure.QueryLanguageScope;
 import org.neo4j.procedure.*;
 
 /**
@@ -108,6 +110,21 @@ public class Date {
     }
 
     @UserFunction("apoc.date.field")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns the value of one field from the given date time.")
+    public Long fieldCypher5(
+            final @Name(value = "time", description = "The timestamp in ms since epoch to return a field from.") Long
+                            time,
+            @Name(value = "unit", defaultValue = "d", description = "The unit of the field to return the value of.")
+                    String unit,
+            @Name(value = "timezone", defaultValue = "UTC", description = "The timezone the given timestamp is in.")
+                    String timezone) {
+        return field(time, unit, timezone);
+    }
+
+    @Deprecated
+    @UserFunction(name = "apoc.date.field", deprecatedBy = "Cypher's `instance.field` component access.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns the value of one field from the given date time.")
     public Long field(
             final @Name(value = "time", description = "The timestamp in ms since epoch to return a field from.") Long
@@ -123,6 +140,15 @@ public class Date {
     }
 
     @UserFunction("apoc.date.currentTimestamp")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns the current Unix epoch timestamp in milliseconds.")
+    public long currentTimestampCypher5() {
+        return System.currentTimeMillis();
+    }
+
+    @Deprecated
+    @UserFunction(name = "apoc.date.currentTimestamp", deprecatedBy = "Cypher's `datetime.realtime().epochMillis`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns the current Unix epoch timestamp in milliseconds.")
     public long currentTimestamp() {
         return System.currentTimeMillis();
@@ -195,6 +221,17 @@ public class Date {
     }
 
     @UserFunction("apoc.date.toISO8601")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns a `STRING` representation of a specified time value in the ISO8601 format.")
+    public String toISO8601Cypher5(
+            final @Name(value = "time", description = "The timestamp since epoch to format.") Long time,
+            @Name(value = "unit", defaultValue = "ms", description = "The unit of the given timestamp.") String unit) {
+        return time == null ? null : parse(unit(unit).toMillis(time), "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", null);
+    }
+
+    @Deprecated
+    @UserFunction(name = "apoc.date.toISO8601", deprecatedBy = "Cypher's `toString()`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns a `STRING` representation of a specified time value in the ISO8601 format.")
     public String toISO8601(
             final @Name(value = "time", description = "The timestamp since epoch to format.") Long time,
@@ -203,6 +240,17 @@ public class Date {
     }
 
     @UserFunction("apoc.date.fromISO8601")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description(
+            "Converts the given date `STRING` (ISO8601) to an `INTEGER` representing the time value in milliseconds.")
+    public Long fromISO8601Cypher5(
+            final @Name(value = "time", description = "The datetime to convert to ms.") String time) {
+        return time == null ? null : Instant.parse(time).toEpochMilli();
+    }
+
+    @Deprecated
+    @UserFunction(name = "apoc.date.fromISO8601", deprecatedBy = "Cypher's `datetime()`")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description(
             "Converts the given date `STRING` (ISO8601) to an `INTEGER` representing the time value in milliseconds.")
     public Long fromISO8601(final @Name(value = "time", description = "The datetime to convert to ms.") String time) {

--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -73,6 +73,8 @@ import org.neo4j.internal.kernel.api.Read;
 import org.neo4j.internal.kernel.api.TokenRead;
 import org.neo4j.internal.kernel.api.procs.ProcedureCallContext;
 import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.QueryLanguage;
+import org.neo4j.kernel.api.procedure.QueryLanguageScope;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
@@ -217,6 +219,19 @@ public class Meta {
     }
 
     @UserFunction("apoc.meta.cypher.isType")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns true if the given value matches the given type.")
+    public boolean isTypeCypherCypher5(
+            @Name(value = "value", description = "An object to check the type of.") Object value,
+            @Name(value = "type", description = "The verification type.") String type) {
+        return type.equalsIgnoreCase(typeCypher(value));
+    }
+
+    @Deprecated
+    @UserFunction(
+            name = "apoc.meta.cypher.isType",
+            deprecatedBy = "Cypher's type predicate expressions: `value IS :: <TYPE>`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns true if the given value matches the given type.")
     public boolean isTypeCypher(
             @Name(value = "value", description = "An object to check the type of.") Object value,
@@ -225,6 +240,16 @@ public class Meta {
     }
 
     @UserFunction("apoc.meta.cypher.type")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Returns the type name of the given value.")
+    public String typeCypherCypher5(
+            @Name(value = "value", description = "An object to get the type of.") Object value) {
+        return typeCypher(value);
+    }
+
+    @Deprecated
+    @UserFunction(name = "apoc.meta.cypher.type", deprecatedBy = "Cypher's `valueType()` function.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Returns the type name of the given value.")
     public String typeCypher(@Name(value = "value", description = "An object to get the type of.") Object value) {
         Types type = Types.of(value);

--- a/core/src/main/java/apoc/nodes/Nodes.java
+++ b/core/src/main/java/apoc/nodes/Nodes.java
@@ -223,6 +223,7 @@ public class Nodes {
         return delete(nodes, batchSize);
     }
 
+    @Deprecated
     @Procedure(name = "apoc.nodes.delete", mode = Mode.WRITE, deprecatedBy = "Cypher's `CALL {...} IN TRANSACTIONS`.")
     @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Deletes all `NODE` values with the given ids.")

--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -457,6 +457,21 @@ public class GraphRefactoring {
      * and deleting the old.
      */
     @Procedure(name = "apoc.refactor.setType", mode = Mode.WRITE)
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description("Changes the type of the given `RELATIONSHIP`.")
+    public Stream<UpdatedRelationshipResult> setTypeCypher5(
+            @Name(value = "rel", description = "The relationship to change the type of.") Relationship rel,
+            @Name(value = "newType", description = "The new type for the relationship.") String newType) {
+        return setType(rel, newType);
+    }
+
+    @Deprecated
+    @Procedure(
+            name = "apoc.refactor.setType",
+            mode = Mode.WRITE,
+            deprecatedBy =
+                    "Cypher's dynamic types: `CREATE (from)-[newRel:$(newType)]->(to) SET newRel = properties(oldRel) DELETE oldRel`.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description("Changes the type of the given `RELATIONSHIP`.")
     public Stream<UpdatedRelationshipResult> setType(
             @Name(value = "rel", description = "The relationship to change the type of.") Relationship rel,
@@ -652,6 +667,37 @@ public class GraphRefactoring {
      * Create category nodes from unique property values
      */
     @Procedure(name = "apoc.refactor.categorize", mode = Mode.WRITE)
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    @Description(
+            "Creates new category `NODE` values from `NODE` values in the graph with the specified `sourceKey` as one of its property keys.\n"
+                    + "The new category `NODE` values are then connected to the original `NODE` values with a `RELATIONSHIP` of the given type.")
+    public void categorizeCypher5(
+            @Name(value = "sourceKey", description = "The property key to add to the on the new node.")
+                    String sourceKey,
+            @Name(value = "type", description = "The relationship type to connect to the new node.")
+                    String relationshipType,
+            @Name(value = "outgoing", description = "Whether the relationship should be outgoing or not.")
+                    Boolean outgoing,
+            @Name(value = "label", description = "The label of the new node.") String label,
+            @Name(
+                            value = "targetKey",
+                            description = "The name by which the source key value will be referenced on the new node.")
+                    String targetKey,
+            @Name(
+                            value = "copiedKeys",
+                            description = "A list of additional property keys to be copied to the new node.")
+                    List<String> copiedKeys,
+            @Name(value = "batchSize", description = "The max size of each batch.") long batchSize)
+            throws ExecutionException {
+        categorize(sourceKey, relationshipType, outgoing, label, targetKey, copiedKeys, batchSize);
+    }
+
+    @Deprecated
+    @Procedure(
+            name = "apoc.refactor.categorize",
+            mode = Mode.WRITE,
+            deprecatedBy = "Cypher's CALL {} IN TRANSACTIONS and dynamic labels, see the docs for more information.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     @Description(
             "Creates new category `NODE` values from `NODE` values in the graph with the specified `sourceKey` as one of its property keys.\n"
                     + "The new category `NODE` values are then connected to the original `NODE` values with a `RELATIONSHIP` of the given type.")

--- a/core/src/test/resources/functions/common/functions.json
+++ b/core/src/test/resources/functions/common/functions.json
@@ -21,25 +21,6 @@
   {
     "isDeprecated": false,
     "aggregating": true,
-    "signature": "apoc.agg.graph(path :: ANY) :: MAP",
-    "name": "apoc.agg.graph",
-    "description": "Returns all distinct `NODE` and `RELATIONSHIP` values collected into a `MAP` with the keys `nodes` and `relationships`.",
-    "returnDescription": "MAP",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "path",
-        "description": "A path to return nodes and relationships from.",
-        "isDeprecated": false,
-        "type": "ANY"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": true,
     "signature": "apoc.agg.last(value :: ANY) :: ANY",
     "name": "apoc.agg.last",
     "description": "Returns the last value from the given collection.",
@@ -187,25 +168,6 @@
         "isDeprecated": false,
         "default": "DefaultParameterValue{value=[0.5, 0.75, 0.9, 0.95, 0.99], type=LIST<FLOAT>}",
         "type": "LIST<FLOAT>"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": true,
-    "signature": "apoc.agg.product(value :: INTEGER | FLOAT) :: INTEGER | FLOAT",
-    "name": "apoc.agg.product",
-    "description": "Returns the product of all non-null `INTEGER` and `FLOAT` values in the collection.",
-    "returnDescription": "INTEGER | FLOAT",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "value",
-        "description": "A value to be multiplied in the aggregate.",
-        "isDeprecated": false,
-        "type": "INTEGER | FLOAT"
       }
     ]
   },
@@ -423,56 +385,6 @@
   {
     "isDeprecated": false,
     "aggregating": false,
-    "signature": "apoc.coll.contains(coll :: LIST<ANY>, value :: ANY) :: BOOLEAN",
-    "name": "apoc.coll.contains",
-    "description": "Returns whether or not the given value exists in the given collection.",
-    "returnDescription": "BOOLEAN",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "coll",
-        "description": "The list to search for the given value.",
-        "isDeprecated": false,
-        "type": "LIST<ANY>"
-      },
-      {
-        "name": "value",
-        "description": "The value in the list to check for the existence of.",
-        "isDeprecated": false,
-        "type": "ANY"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.coll.containsAll(coll1 :: LIST<ANY>, coll2 :: LIST<ANY>) :: BOOLEAN",
-    "name": "apoc.coll.containsAll",
-    "description": "Returns whether or not all of the given values exist in the given collection.",
-    "returnDescription": "BOOLEAN",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "coll1",
-        "description": "The list to search for the given values in.",
-        "isDeprecated": false,
-        "type": "LIST<ANY>"
-      },
-      {
-        "name": "coll2",
-        "description": "The list of values in the given list to check for the existence of.",
-        "isDeprecated": false,
-        "type": "LIST<ANY>"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
     "signature": "apoc.coll.containsAllSorted(coll1 :: LIST<ANY>, coll2 :: LIST<ANY>) :: BOOLEAN",
     "name": "apoc.coll.containsAllSorted",
     "description": "Returns whether or not all of the given values in the second `LIST<ANY>` exist in an already sorted collection (using a binary search).",
@@ -637,31 +549,6 @@
         "description": "The list to collect duplicate values and their count from.",
         "isDeprecated": false,
         "type": "LIST<ANY>"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.coll.fill(item :: STRING, count :: INTEGER) :: LIST<ANY>",
-    "name": "apoc.coll.fill",
-    "description": "Returns a `LIST<ANY>` with the given count of items.",
-    "returnDescription": "LIST<ANY>",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "item",
-        "description": "The item to be present in the returned list.",
-        "isDeprecated": false,
-        "type": "STRING"
-      },
-      {
-        "name": "count",
-        "description": "The number of times the given item should appear in the returned list.",
-        "isDeprecated": false,
-        "type": "INTEGER"
       }
     ]
   },
@@ -861,176 +748,6 @@
       {
         "name": "values",
         "description": "The list of values to compare against `list1` and check for equality.",
-        "isDeprecated": false,
-        "type": "LIST<ANY>"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.coll.max(values :: LIST<ANY>) :: ANY",
-    "name": "apoc.coll.max",
-    "description": "Returns the maximum of all values in the given `LIST<ANY>`.",
-    "returnDescription": "ANY",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "values",
-        "description": "The list to find the maximum in.",
-        "isDeprecated": false,
-        "type": "LIST<ANY>"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.coll.min(values :: LIST<ANY>) :: ANY",
-    "name": "apoc.coll.min",
-    "description": "Returns the minimum of all values in the given `LIST<ANY>`.",
-    "returnDescription": "ANY",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "values",
-        "description": "The list to find the minimum in.",
-        "isDeprecated": false,
-        "type": "LIST<ANY>"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.coll.occurrences(coll :: LIST<ANY>, item :: ANY) :: INTEGER",
-    "name": "apoc.coll.occurrences",
-    "description": "Returns the count of the given item in the collection.",
-    "returnDescription": "INTEGER",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "coll",
-        "description": "The list to collect the count of the given value from.",
-        "isDeprecated": false,
-        "type": "LIST<ANY>"
-      },
-      {
-        "name": "item",
-        "description": "The value to count in the given list.",
-        "isDeprecated": false,
-        "type": "ANY"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.coll.pairWithOffset(coll :: LIST<ANY>, offset :: INTEGER) :: LIST<ANY>",
-    "name": "apoc.coll.pairWithOffset",
-    "description": "Returns a `LIST<ANY>` of pairs defined by the offset.",
-    "returnDescription": "LIST<ANY>",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "coll",
-        "description": "The list to create pairs from.",
-        "isDeprecated": false,
-        "type": "LIST<ANY>"
-      },
-      {
-        "name": "offset",
-        "description": "The offset to make each pair with from the given list.",
-        "isDeprecated": false,
-        "type": "INTEGER"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.coll.pairs(list :: LIST<ANY>) :: LIST<ANY>",
-    "name": "apoc.coll.pairs",
-    "description": "Returns a `LIST<ANY>` of adjacent elements in the `LIST<ANY>` ([1,2],[2,3],[3,null]).",
-    "returnDescription": "LIST<ANY>",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "list",
-        "description": "The list to create pairs from.",
-        "isDeprecated": false,
-        "type": "LIST<ANY>"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.coll.pairsMin(list :: LIST<ANY>) :: LIST<ANY>",
-    "name": "apoc.coll.pairsMin",
-    "description": "Returns `LIST<ANY>` values of adjacent elements in the `LIST<ANY>` ([1,2],[2,3]), skipping the final element.",
-    "returnDescription": "LIST<ANY>",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "list",
-        "description": "The list to create pairs from.",
-        "isDeprecated": false,
-        "type": "LIST<ANY>"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.coll.partition(coll :: LIST<ANY>, batchSize :: INTEGER) :: LIST<ANY>",
-    "name": "apoc.coll.partition",
-    "description": "Partitions the original `LIST<ANY>` into a new `LIST<ANY>` of the given batch size.\nThe final `LIST<ANY>` may be smaller than the given batch size.",
-    "returnDescription": "LIST<ANY>",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "coll",
-        "description": "The list to partition into smaller sublists.",
-        "isDeprecated": false,
-        "type": "LIST<ANY>"
-      },
-      {
-        "name": "batchSize",
-        "description": "The max size of each partitioned sublist.",
-        "isDeprecated": false,
-        "type": "INTEGER"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.coll.randomItem(coll :: LIST<ANY>) :: ANY",
-    "name": "apoc.coll.randomItem",
-    "description": "Returns a random item from the `LIST<ANY>`, or null on `LIST<NOTHING>` or `LIST<NULL>`.",
-    "returnDescription": "ANY",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "coll",
-        "description": "The list to return a random item from.",
         "isDeprecated": false,
         "type": "LIST<ANY>"
       }
@@ -1281,31 +998,6 @@
   {
     "isDeprecated": false,
     "aggregating": false,
-    "signature": "apoc.coll.sortNodes(coll :: LIST<NODE>, prop :: STRING) :: LIST<ANY>",
-    "name": "apoc.coll.sortNodes",
-    "description": "Sorts the given `LIST<NODE>` by the property of the nodes into descending order.",
-    "returnDescription": "LIST<ANY>",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "coll",
-        "description": "The list of nodes to be sorted.",
-        "isDeprecated": false,
-        "type": "LIST<NODE>"
-      },
-      {
-        "name": "prop",
-        "description": "The property key on the node to be used to sort the list by.",
-        "isDeprecated": false,
-        "type": "STRING"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
     "signature": "apoc.coll.sortText(coll :: LIST<STRING>, conf = {} :: MAP) :: LIST<ANY>",
     "name": "apoc.coll.sortText",
     "description": "Sorts the given `LIST<STRING>` into ascending order.",
@@ -1332,32 +1024,6 @@
   {
     "isDeprecated": false,
     "aggregating": false,
-    "signature": "apoc.coll.stdev(list :: LIST<INTEGER | FLOAT>, isBiasCorrected = true :: BOOLEAN) :: INTEGER | FLOAT",
-    "name": "apoc.coll.stdev",
-    "description": "Returns sample or population standard deviation with `isBiasCorrected` true or false respectively.",
-    "returnDescription": "INTEGER | FLOAT",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "list",
-        "description": "A list to collect the standard deviation from.",
-        "isDeprecated": false,
-        "type": "LIST<INTEGER | FLOAT>"
-      },
-      {
-        "name": "isBiasCorrected",
-        "description": "Will perform a sample standard deviation if `isBiasCorrected`, otherwise a population standard deviation is performed.",
-        "isDeprecated": false,
-        "default": "DefaultParameterValue{value=true, type=BOOLEAN}",
-        "type": "BOOLEAN"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
     "signature": "apoc.coll.subtract(list1 :: LIST<ANY>, list2 :: LIST<ANY>) :: LIST<ANY>",
     "name": "apoc.coll.subtract",
     "description": "Returns the first `LIST<ANY>` as a set with all the elements of the second `LIST<ANY>` removed.",
@@ -1377,44 +1043,6 @@
         "description": "The list of values to be removed from `list1`.",
         "isDeprecated": false,
         "type": "LIST<ANY>"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.coll.sum(coll :: LIST<INTEGER | FLOAT>) :: FLOAT",
-    "name": "apoc.coll.sum",
-    "description": "Returns the sum of all the `INTEGER | FLOAT` in the `LIST<INTEGER | FLOAT>`.",
-    "returnDescription": "FLOAT",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "coll",
-        "description": "The list of numbers to create a sum from.",
-        "isDeprecated": false,
-        "type": "LIST<INTEGER | FLOAT>"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.coll.sumLongs(coll :: LIST<INTEGER | FLOAT>) :: INTEGER",
-    "name": "apoc.coll.sumLongs",
-    "description": "Returns the sum of all the `INTEGER | FLOAT` in the `LIST<INTEGER | FLOAT>`.",
-    "returnDescription": "INTEGER",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "coll",
-        "description": "The list of numbers to create a sum from after each is cast to a java Long value.",
-        "isDeprecated": false,
-        "type": "LIST<INTEGER | FLOAT>"
       }
     ]
   },
@@ -1457,56 +1085,6 @@
       {
         "name": "list2",
         "description": "The list of values to compare against `list1` and form a distinct union from.",
-        "isDeprecated": false,
-        "type": "LIST<ANY>"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.coll.unionAll(list1 :: LIST<ANY>, list2 :: LIST<ANY>) :: LIST<ANY>",
-    "name": "apoc.coll.unionAll",
-    "description": "Returns the full union of the two given `LIST<ANY>` values (duplicates included).",
-    "returnDescription": "LIST<ANY>",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "list1",
-        "description": "The list of values to compare against `list2` and form a union from.",
-        "isDeprecated": false,
-        "type": "LIST<ANY>"
-      },
-      {
-        "name": "list2",
-        "description": "The list of values to compare against `list1` and form a union from.",
-        "isDeprecated": false,
-        "type": "LIST<ANY>"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.coll.zip(list1 :: LIST<ANY>, list2 :: LIST<ANY>) :: LIST<ANY>",
-    "name": "apoc.coll.zip",
-    "description": "Returns the two given `LIST<ANY>` values zipped together as a `LIST<LIST<ANY>>`.",
-    "returnDescription": "LIST<ANY>",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "list1",
-        "description": "The list to zip together with `list2`.",
-        "isDeprecated": false,
-        "type": "LIST<ANY>"
-      },
-      {
-        "name": "list2",
-        "description": "The list to zip together with `list1`.",
         "isDeprecated": false,
         "type": "LIST<ANY>"
       }
@@ -1670,25 +1248,6 @@
       {
         "name": "value",
         "description": "The value to serialize.",
-        "isDeprecated": false,
-        "type": "ANY"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.convert.toList(value :: ANY) :: LIST<ANY>",
-    "name": "apoc.convert.toList",
-    "description": "Converts the given value into a `LIST<ANY>`.",
-    "returnDescription": "LIST<ANY>",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "value",
-        "description": "The value to convert into a list.",
         "isDeprecated": false,
         "type": "ANY"
       }
@@ -2151,51 +1710,6 @@
   {
     "isDeprecated": false,
     "aggregating": false,
-    "signature": "apoc.date.currentTimestamp() :: INTEGER",
-    "name": "apoc.date.currentTimestamp",
-    "description": "Returns the current Unix epoch timestamp in milliseconds.",
-    "returnDescription": "INTEGER",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": []
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.date.field(time :: INTEGER, unit = d :: STRING, timezone = UTC :: STRING) :: INTEGER",
-    "name": "apoc.date.field",
-    "description": "Returns the value of one field from the given date time.",
-    "returnDescription": "INTEGER",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "time",
-        "description": "The timestamp in ms since epoch to return a field from.",
-        "isDeprecated": false,
-        "type": "INTEGER"
-      },
-      {
-        "name": "unit",
-        "description": "The unit of the field to return the value of.",
-        "isDeprecated": false,
-        "default": "DefaultParameterValue{value=d, type=STRING}",
-        "type": "STRING"
-      },
-      {
-        "name": "timezone",
-        "description": "The timezone the given timestamp is in.",
-        "isDeprecated": false,
-        "default": "DefaultParameterValue{value=UTC, type=STRING}",
-        "type": "STRING"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
     "signature": "apoc.date.fields(date :: STRING, pattern = yyyy-MM-dd HH:mm:ss :: STRING) :: MAP",
     "name": "apoc.date.fields",
     "description": "Splits the given date into fields returning a `MAP` containing the values of each field.",
@@ -2262,25 +1776,6 @@
   {
     "isDeprecated": false,
     "aggregating": false,
-    "signature": "apoc.date.fromISO8601(time :: STRING) :: INTEGER",
-    "name": "apoc.date.fromISO8601",
-    "description": "Converts the given date `STRING` (ISO8601) to an `INTEGER` representing the time value in milliseconds.",
-    "returnDescription": "INTEGER",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "time",
-        "description": "The datetime to convert to ms.",
-        "isDeprecated": false,
-        "type": "STRING"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
     "signature": "apoc.date.parse(time :: STRING, unit = ms :: STRING, format = yyyy-MM-dd HH:mm:ss :: STRING, timezone =  :: STRING) :: INTEGER",
     "name": "apoc.date.parse",
     "description": "Parses the given date `STRING` from a specified format into the specified time unit.",
@@ -2329,32 +1824,6 @@
     "category": "",
     "isBuiltIn": false,
     "argumentDescription": []
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.date.toISO8601(time :: INTEGER, unit = ms :: STRING) :: STRING",
-    "name": "apoc.date.toISO8601",
-    "description": "Returns a `STRING` representation of a specified time value in the ISO8601 format.",
-    "returnDescription": "STRING",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "time",
-        "description": "The timestamp since epoch to format.",
-        "isDeprecated": false,
-        "type": "INTEGER"
-      },
-      {
-        "name": "unit",
-        "description": "The unit of the given timestamp.",
-        "isDeprecated": false,
-        "default": "DefaultParameterValue{value=ms, type=STRING}",
-        "type": "STRING"
-      }
-    ]
   },
   {
     "isDeprecated": false,
@@ -3360,50 +2829,6 @@
   {
     "isDeprecated": false,
     "aggregating": false,
-    "signature": "apoc.meta.cypher.isType(value :: ANY, type :: STRING) :: BOOLEAN",
-    "name": "apoc.meta.cypher.isType",
-    "description": "Returns true if the given value matches the given type.",
-    "returnDescription": "BOOLEAN",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "value",
-        "description": "An object to check the type of.",
-        "isDeprecated": false,
-        "type": "ANY"
-      },
-      {
-        "name": "type",
-        "description": "The verification type.",
-        "isDeprecated": false,
-        "type": "STRING"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.meta.cypher.type(value :: ANY) :: STRING",
-    "name": "apoc.meta.cypher.type",
-    "description": "Returns the type name of the given value.",
-    "returnDescription": "STRING",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "value",
-        "description": "An object to get the type of.",
-        "isDeprecated": false,
-        "type": "ANY"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
     "signature": "apoc.meta.cypher.types(props :: ANY) :: MAP",
     "name": "apoc.meta.cypher.types",
     "description": "Returns a `MAP` containing the type names of the given values.",
@@ -3450,84 +2875,6 @@
   {
     "isDeprecated": false,
     "aggregating": false,
-    "signature": "apoc.node.degree(node :: NODE, relTypes =  :: STRING) :: INTEGER",
-    "name": "apoc.node.degree",
-    "description": "Returns the total degrees of the given `NODE`.",
-    "returnDescription": "INTEGER",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "node",
-        "description": "The node to count the total number of relationships on.",
-        "isDeprecated": false,
-        "type": "NODE"
-      },
-      {
-        "name": "relTypes",
-        "description": "The relationship types to restrict the count to. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
-        "isDeprecated": false,
-        "default": "DefaultParameterValue{value=, type=STRING}",
-        "type": "STRING"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.node.degree.in(node :: NODE, relTypes =  :: STRING) :: INTEGER",
-    "name": "apoc.node.degree.in",
-    "description": "Returns the total number of incoming `RELATIONSHIP` values connected to the given `NODE`.",
-    "returnDescription": "INTEGER",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "node",
-        "description": "The node for which to count the total number of incoming relationships.",
-        "isDeprecated": false,
-        "type": "NODE"
-      },
-      {
-        "name": "relTypes",
-        "description": "The relationship type to restrict the count to.",
-        "isDeprecated": false,
-        "default": "DefaultParameterValue{value=, type=STRING}",
-        "type": "STRING"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.node.degree.out(node :: NODE, relTypes =  :: STRING) :: INTEGER",
-    "name": "apoc.node.degree.out",
-    "description": "Returns the total number of outgoing `RELATIONSHIP` values from the given `NODE`.",
-    "returnDescription": "INTEGER",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "node",
-        "description": "The node for which to count the total number of outgoing relationships.",
-        "isDeprecated": false,
-        "type": "NODE"
-      },
-      {
-        "name": "relTypes",
-        "description": "The relationship type to restrict the count to.",
-        "isDeprecated": false,
-        "default": "DefaultParameterValue{value=, type=STRING}",
-        "type": "STRING"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
     "signature": "apoc.node.id(node :: NODE) :: INTEGER",
     "name": "apoc.node.id",
     "description": "Returns the id for the given virtual `NODE`.",
@@ -3560,32 +2907,6 @@
         "description": "The node to return labels from.",
         "isDeprecated": false,
         "type": "NODE"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.node.relationship.exists(node :: NODE, relTypes =  :: STRING) :: BOOLEAN",
-    "name": "apoc.node.relationship.exists",
-    "description": "Returns a `BOOLEAN` based on whether the given `NODE` has a connecting `RELATIONSHIP` (or whether the given `NODE` has a connecting `RELATIONSHIP` of the given type and direction).",
-    "returnDescription": "BOOLEAN",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "node",
-        "description": "The node to check for the specified relationship types.",
-        "isDeprecated": false,
-        "type": "NODE"
-      },
-      {
-        "name": "relTypes",
-        "description": "The relationship types to check for on the given node. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
-        "isDeprecated": false,
-        "default": "DefaultParameterValue{value=, type=STRING}",
-        "type": "STRING"
       }
     ]
   },

--- a/core/src/test/resources/functions/cypher25/functions.json
+++ b/core/src/test/resources/functions/cypher25/functions.json
@@ -1,12 +1,543 @@
 [
   {
     "isDeprecated": true,
+    "aggregating": true,
+    "signature": "apoc.agg.graph(path :: ANY) :: MAP",
+    "name": "apoc.agg.graph",
+    "description": "Returns all distinct `NODE` and `RELATIONSHIP` values collected into a `MAP` with the keys `nodes` and `relationships`.",
+    "returnDescription": "MAP",
+    "deprecatedBy": "Cypher's `COLLECT {}` expression.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "path",
+        "description": "A path to return nodes and relationships from.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": true,
+    "signature": "apoc.agg.product(value :: INTEGER | FLOAT) :: INTEGER | FLOAT",
+    "name": "apoc.agg.product",
+    "description": "Returns the product of all non-null `INTEGER` and `FLOAT` values in the collection.",
+    "returnDescription": "INTEGER | FLOAT",
+    "deprecatedBy": "Cypher's `reduce()`: `RETURN reduce(x = 1, i IN values | x * i)`.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "value",
+        "description": "A value to be multiplied in the aggregate.",
+        "isDeprecated": false,
+        "type": "INTEGER | FLOAT"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
     "aggregating": false,
-    "signature": "apoc.math.coth(value :: FLOAT) :: FLOAT",
-    "name": "apoc.math.coth",
-    "description": "Returns the hyperbolic cotangent.",
+    "signature": "apoc.coll.contains(coll :: LIST<ANY>, value :: ANY) :: BOOLEAN",
+    "name": "apoc.coll.contains",
+    "description": "Returns whether or not the given value exists in the given collection.",
+    "returnDescription": "BOOLEAN",
+    "deprecatedBy": "Cypher's `IN`: `value IN coll`.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list to search for the given value.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "value",
+        "description": "The value in the list to check for the existence of.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.coll.containsAll(coll1 :: LIST<ANY>, coll2 :: LIST<ANY>) :: BOOLEAN",
+    "name": "apoc.coll.containsAll",
+    "description": "Returns whether or not all of the given values exist in the given collection.",
+    "returnDescription": "BOOLEAN",
+    "deprecatedBy": "Cypher's `all()`: `all(x IN coll2 WHERE x IN coll1)`",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "coll1",
+        "description": "The list to search for the given values in.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "coll2",
+        "description": "The list of values in the given list to check for the existence of.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.coll.fill(item :: STRING, count :: INTEGER) :: LIST<ANY>",
+    "name": "apoc.coll.fill",
+    "description": "Returns a `LIST<ANY>` with the given count of items.",
+    "returnDescription": "LIST<ANY>",
+    "deprecatedBy": "Cypher's list comprehension: `RETURN [i IN range(1, count) | item]`.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "item",
+        "description": "The item to be present in the returned list.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "count",
+        "description": "The number of times the given item should appear in the returned list.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.coll.max(values :: LIST<ANY>) :: ANY",
+    "name": "apoc.coll.max",
+    "description": "Returns the maximum of all values in the given `LIST<ANY>`.",
+    "returnDescription": "ANY",
+    "deprecatedBy": "Cypher's `max()` function: `UNWIND values AS value RETURN max(value)`.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "values",
+        "description": "The list to find the maximum in.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.coll.min(values :: LIST<ANY>) :: ANY",
+    "name": "apoc.coll.min",
+    "description": "Returns the minimum of all values in the given `LIST<ANY>`.",
+    "returnDescription": "ANY",
+    "deprecatedBy": "Cypher's `min()` function: `UNWIND values AS value RETURN min(value)`.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "values",
+        "description": "The list to find the minimum in.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.coll.occurrences(coll :: LIST<ANY>, item :: ANY) :: INTEGER",
+    "name": "apoc.coll.occurrences",
+    "description": "Returns the count of the given item in the collection.",
+    "returnDescription": "INTEGER",
+    "deprecatedBy": "Cypher's reduce() and `CASE` expression: `RETURN reduce(count = 0, x IN coll | count + CASE WHEN x = item THEN 1 ELSE 0 END)`",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list to collect the count of the given value from.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "item",
+        "description": "The value to count in the given list.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.coll.pairWithOffset(coll :: LIST<ANY>, offset :: INTEGER) :: LIST<ANY>",
+    "name": "apoc.coll.pairWithOffset",
+    "description": "Returns a `LIST<ANY>` of pairs defined by the offset.",
+    "returnDescription": "LIST<ANY>",
+    "deprecatedBy": "Cyphers list comprehension: `RETURN [i IN range(0, size(list) - 1) | [list[i], list[i + offset]]] AS value`.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list to create pairs from.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "offset",
+        "description": "The offset to make each pair with from the given list.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.coll.pairs(list :: LIST<ANY>) :: LIST<ANY>",
+    "name": "apoc.coll.pairs",
+    "description": "Returns a `LIST<ANY>` of adjacent elements in the `LIST<ANY>` ([1,2],[2,3],[3,null]).",
+    "returnDescription": "LIST<ANY>",
+    "deprecatedBy": "Cypher's list comprehension: `RETURN [i IN range(0, size(list) - 1) | [list[i], list[i + 1]]]`",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "list",
+        "description": "The list to create pairs from.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.coll.pairsMin(list :: LIST<ANY>) :: LIST<ANY>",
+    "name": "apoc.coll.pairsMin",
+    "description": "Returns `LIST<ANY>` values of adjacent elements in the `LIST<ANY>` ([1,2],[2,3]), skipping the final element.",
+    "returnDescription": "LIST<ANY>",
+    "deprecatedBy": "Cypher's list comprehension: `RETURN [i IN range(0, size(list) - 2) | [list[i], list[i + 1]]]`",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "list",
+        "description": "The list to create pairs from.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.coll.partition(coll :: LIST<ANY>, batchSize :: INTEGER) :: LIST<ANY>",
+    "name": "apoc.coll.partition",
+    "description": "Partitions the original `LIST<ANY>` into a new `LIST<ANY>` of the given batch size.\nThe final `LIST<ANY>` may be smaller than the given batch size.",
+    "returnDescription": "LIST<ANY>",
+    "deprecatedBy": "Cypher's list comprehension: `RETURN [i IN range(0, size(list), offset) | list[i..i + offset]] AS value`.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list to partition into smaller sublists.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "batchSize",
+        "description": "The max size of each partitioned sublist.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.coll.randomItem(coll :: LIST<ANY>) :: ANY",
+    "name": "apoc.coll.randomItem",
+    "description": "Returns a random item from the `LIST<ANY>`, or null on `LIST<NOTHING>` or `LIST<NULL>`.",
+    "returnDescription": "ANY",
+    "deprecatedBy": "Cypher's `rand()` function: `RETURN list[toInteger(rand() * size(list))]`",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list to return a random item from.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.coll.sortNodes(coll :: LIST<NODE>, prop :: STRING) :: LIST<ANY>",
+    "name": "apoc.coll.sortNodes",
+    "description": "Sorts the given `LIST<NODE>` by the property of the nodes into descending order.",
+    "returnDescription": "LIST<ANY>",
+    "deprecatedBy": "Cypher's COLLECT {} and ORDER BY: `RETURN COLLECT { MATCH (n) RETURN n ORDER BY n.prop DESC }`.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list of nodes to be sorted.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "prop",
+        "description": "The property key on the node to be used to sort the list by.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.coll.stdev(list :: LIST<INTEGER | FLOAT>, isBiasCorrected = true :: BOOLEAN) :: INTEGER | FLOAT",
+    "name": "apoc.coll.stdev",
+    "description": "Returns sample or population standard deviation with `isBiasCorrected` true or false respectively.",
+    "returnDescription": "INTEGER | FLOAT",
+    "deprecatedBy": "Cypher's `stDev()` and `stDevP()` functions.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "list",
+        "description": "A list to collect the standard deviation from.",
+        "isDeprecated": false,
+        "type": "LIST<INTEGER | FLOAT>"
+      },
+      {
+        "name": "isBiasCorrected",
+        "description": "Will perform a sample standard deviation if `isBiasCorrected`, otherwise a population standard deviation is performed.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=true, type=BOOLEAN}",
+        "type": "BOOLEAN"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.coll.sum(coll :: LIST<INTEGER | FLOAT>) :: FLOAT",
+    "name": "apoc.coll.sum",
+    "description": "Returns the sum of all the `INTEGER | FLOAT` in the `LIST<INTEGER | FLOAT>`.",
     "returnDescription": "FLOAT",
-    "deprecatedBy": "coth()",
+    "deprecatedBy": "Cypher's `reduce()` function: `RETURN reduce(sum = 0.0, x IN list | sum + x)`.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list of numbers to create a sum from.",
+        "isDeprecated": false,
+        "type": "LIST<INTEGER | FLOAT>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.coll.sumLongs(coll :: LIST<INTEGER | FLOAT>) :: INTEGER",
+    "name": "apoc.coll.sumLongs",
+    "description": "Returns the sum of all the `INTEGER | FLOAT` in the `LIST<INTEGER | FLOAT>`.",
+    "returnDescription": "INTEGER",
+    "deprecatedBy": "Cypher's `reduce()` function: `RETURN reduce(sum = 0.0, x IN toIntegerList(list) | sum + x)`.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list of numbers to create a sum from after each is cast to a java Long value.",
+        "isDeprecated": false,
+        "type": "LIST<INTEGER | FLOAT>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.coll.unionAll(list1 :: LIST<ANY>, list2 :: LIST<ANY>) :: LIST<ANY>",
+    "name": "apoc.coll.unionAll",
+    "description": "Returns the full union of the two given `LIST<ANY>` values (duplicates included).",
+    "returnDescription": "LIST<ANY>",
+    "deprecatedBy": "Cypher's list concatenation: `list1 + list2`.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "list1",
+        "description": "The list of values to compare against `list2` and form a union from.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "list2",
+        "description": "The list of values to compare against `list1` and form a union from.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.coll.zip(list1 :: LIST<ANY>, list2 :: LIST<ANY>) :: LIST<ANY>",
+    "name": "apoc.coll.zip",
+    "description": "Returns the two given `LIST<ANY>` values zipped together as a `LIST<LIST<ANY>>`.",
+    "returnDescription": "LIST<ANY>",
+    "deprecatedBy": "Cypher's `UNWIND` and `range()` function; `UNWIND range(0, size(list1) - 1) AS i RETURN [list1[i], list2[i]]`.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "list1",
+        "description": "The list to zip together with `list2`.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "list2",
+        "description": "The list to zip together with `list1`.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.convert.toList(value :: ANY) :: LIST<ANY>",
+    "name": "apoc.convert.toList",
+    "description": "Converts the given value into a `LIST<ANY>`.",
+    "returnDescription": "LIST<ANY>",
+    "deprecatedBy": "Cypher's conversion functions, see the docs for more information.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "value",
+        "description": "The value to convert into a list.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.date.currentTimestamp() :: INTEGER",
+    "name": "apoc.date.currentTimestamp",
+    "description": "Returns the current Unix epoch timestamp in milliseconds.",
+    "returnDescription": "INTEGER",
+    "deprecatedBy": "Cypher's `datetime.realtime().epochMillis`.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": []
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.date.field(time :: INTEGER, unit = d :: STRING, timezone = UTC :: STRING) :: INTEGER",
+    "name": "apoc.date.field",
+    "description": "Returns the value of one field from the given date time.",
+    "returnDescription": "INTEGER",
+    "deprecatedBy": "Cypher's `instance.field` component access.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "time",
+        "description": "The timestamp in ms since epoch to return a field from.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "unit",
+        "description": "The unit of the field to return the value of.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=d, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "timezone",
+        "description": "The timezone the given timestamp is in.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=UTC, type=STRING}",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.date.fromISO8601(time :: STRING) :: INTEGER",
+    "name": "apoc.date.fromISO8601",
+    "description": "Converts the given date `STRING` (ISO8601) to an `INTEGER` representing the time value in milliseconds.",
+    "returnDescription": "INTEGER",
+    "deprecatedBy": "Cypher's `datetime()`",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "time",
+        "description": "The datetime to convert to ms.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.date.toISO8601(time :: INTEGER, unit = ms :: STRING) :: STRING",
+    "name": "apoc.date.toISO8601",
+    "description": "Returns a `STRING` representation of a specified time value in the ISO8601 format.",
+    "returnDescription": "STRING",
+    "deprecatedBy": "Cypher's `toString()`.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "time",
+        "description": "The timestamp since epoch to format.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "unit",
+        "description": "The unit of the given timestamp.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=ms, type=STRING}",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.math.cosh(value :: FLOAT) :: FLOAT",
+    "name": "apoc.math.cosh",
+    "description": "Returns the hyperbolic cosine.",
+    "returnDescription": "FLOAT",
+    "deprecatedBy": "cosh()",
     "category": "",
     "isBuiltIn": false,
     "argumentDescription": [
@@ -21,11 +552,11 @@
   {
     "isDeprecated": true,
     "aggregating": false,
-    "signature": "apoc.math.cosh(value :: FLOAT) :: FLOAT",
-    "name": "apoc.math.cosh",
-    "description": "Returns the hyperbolic cosine.",
+    "signature": "apoc.math.coth(value :: FLOAT) :: FLOAT",
+    "name": "apoc.math.coth",
+    "description": "Returns the hyperbolic cotangent.",
     "returnDescription": "FLOAT",
-    "deprecatedBy": "cosh()",
+    "deprecatedBy": "coth()",
     "category": "",
     "isBuiltIn": false,
     "argumentDescription": [
@@ -72,6 +603,154 @@
         "description": "An angle in radians.",
         "isDeprecated": false,
         "type": "FLOAT"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.meta.cypher.isType(value :: ANY, type :: STRING) :: BOOLEAN",
+    "name": "apoc.meta.cypher.isType",
+    "description": "Returns true if the given value matches the given type.",
+    "returnDescription": "BOOLEAN",
+    "deprecatedBy": "Cypher's type predicate expressions: `value IS :: <TYPE>`.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "value",
+        "description": "An object to check the type of.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "type",
+        "description": "The verification type.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.meta.cypher.type(value :: ANY) :: STRING",
+    "name": "apoc.meta.cypher.type",
+    "description": "Returns the type name of the given value.",
+    "returnDescription": "STRING",
+    "deprecatedBy": "Cypher's `valueType()` function.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "value",
+        "description": "An object to get the type of.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.node.degree(node :: NODE, relTypes =  :: STRING) :: INTEGER",
+    "name": "apoc.node.degree",
+    "description": "Returns the total degrees of the given `NODE`.",
+    "returnDescription": "INTEGER",
+    "deprecatedBy": "Cypher's `COUNT {}` expression.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "node",
+        "description": "The node to count the total number of relationships on.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relTypes",
+        "description": "The relationship types to restrict the count to. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.node.degree.in(node :: NODE, relTypes =  :: STRING) :: INTEGER",
+    "name": "apoc.node.degree.in",
+    "description": "Returns the total number of incoming `RELATIONSHIP` values connected to the given `NODE`.",
+    "returnDescription": "INTEGER",
+    "deprecatedBy": "Cypher's `COUNT {}` expression.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "node",
+        "description": "The node for which to count the total number of incoming relationships.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relTypes",
+        "description": "The relationship type to restrict the count to.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.node.degree.out(node :: NODE, relTypes =  :: STRING) :: INTEGER",
+    "name": "apoc.node.degree.out",
+    "description": "Returns the total number of outgoing `RELATIONSHIP` values from the given `NODE`.",
+    "returnDescription": "INTEGER",
+    "deprecatedBy": "Cypher's `COUNT {}` expression.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "node",
+        "description": "The node for which to count the total number of outgoing relationships.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relTypes",
+        "description": "The relationship type to restrict the count to.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.node.relationship.exists(node :: NODE, relTypes =  :: STRING) :: BOOLEAN",
+    "name": "apoc.node.relationship.exists",
+    "description": "Returns a `BOOLEAN` based on whether the given `NODE` has a connecting `RELATIONSHIP` (or whether the given `NODE` has a connecting `RELATIONSHIP` of the given type and direction).",
+    "returnDescription": "BOOLEAN",
+    "deprecatedBy": "Cypher's `EXISTS {}` expression.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "node",
+        "description": "The node to check for the specified relationship types.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relTypes",
+        "description": "The relationship types to check for on the given node. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
       }
     ]
   }

--- a/core/src/test/resources/functions/cypher25/functions.json
+++ b/core/src/test/resources/functions/cypher25/functions.json
@@ -403,7 +403,7 @@
     "name": "apoc.coll.zip",
     "description": "Returns the two given `LIST<ANY>` values zipped together as a `LIST<LIST<ANY>>`.",
     "returnDescription": "LIST<ANY>",
-    "deprecatedBy": "Cypher's `UNWIND` and `range()` function; `UNWIND range(0, size(list1) - 1) AS i RETURN [list1[i], list2[i]]`.",
+    "deprecatedBy": "Cypher's `UNWIND` and `range()` function; `COLLECT { UNWIND range(0, size(list1) - 1) AS i RETURN [list1[i], list2[i]] }`.",
     "category": "",
     "isBuiltIn": false,
     "argumentDescription": [

--- a/core/src/test/resources/functions/cypher5/functions.json
+++ b/core/src/test/resources/functions/cypher5/functions.json
@@ -1,39 +1,442 @@
 [
   {
     "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.math.coth(value :: FLOAT) :: FLOAT",
-    "name": "apoc.math.coth",
-    "description": "Returns the hyperbolic cotangent.",
-    "returnDescription": "FLOAT",
+    "aggregating": true,
+    "signature": "apoc.agg.graph(path :: ANY) :: MAP",
+    "name": "apoc.agg.graph",
+    "description": "Returns all distinct `NODE` and `RELATIONSHIP` values collected into a `MAP` with the keys `nodes` and `relationships`.",
+    "returnDescription": "MAP",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "path",
+        "description": "A path to return nodes and relationships from.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": true,
+    "signature": "apoc.agg.product(value :: INTEGER | FLOAT) :: INTEGER | FLOAT",
+    "name": "apoc.agg.product",
+    "description": "Returns the product of all non-null `INTEGER` and `FLOAT` values in the collection.",
+    "returnDescription": "INTEGER | FLOAT",
     "deprecatedBy": null,
     "category": "",
     "isBuiltIn": false,
     "argumentDescription": [
       {
         "name": "value",
-        "description": "An angle in radians.",
+        "description": "A value to be multiplied in the aggregate.",
         "isDeprecated": false,
-        "type": "FLOAT"
+        "type": "INTEGER | FLOAT"
       }
     ]
   },
   {
     "isDeprecated": false,
     "aggregating": false,
-    "signature": "apoc.math.cosh(value :: FLOAT) :: FLOAT",
-    "name": "apoc.math.cosh",
-    "description": "Returns the hyperbolic cosine.",
+    "signature": "apoc.coll.contains(coll :: LIST<ANY>, value :: ANY) :: BOOLEAN",
+    "name": "apoc.coll.contains",
+    "description": "Returns whether or not the given value exists in the given collection.",
+    "returnDescription": "BOOLEAN",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list to search for the given value.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "value",
+        "description": "The value in the list to check for the existence of.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.coll.containsAll(coll1 :: LIST<ANY>, coll2 :: LIST<ANY>) :: BOOLEAN",
+    "name": "apoc.coll.containsAll",
+    "description": "Returns whether or not all of the given values exist in the given collection.",
+    "returnDescription": "BOOLEAN",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "coll1",
+        "description": "The list to search for the given values in.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "coll2",
+        "description": "The list of values in the given list to check for the existence of.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.coll.fill(item :: STRING, count :: INTEGER) :: LIST<ANY>",
+    "name": "apoc.coll.fill",
+    "description": "Returns a `LIST<ANY>` with the given count of items.",
+    "returnDescription": "LIST<ANY>",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "item",
+        "description": "The item to be present in the returned list.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "count",
+        "description": "The number of times the given item should appear in the returned list.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.coll.max(values :: LIST<ANY>) :: ANY",
+    "name": "apoc.coll.max",
+    "description": "Returns the maximum of all values in the given `LIST<ANY>`.",
+    "returnDescription": "ANY",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "values",
+        "description": "The list to find the maximum in.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.coll.min(values :: LIST<ANY>) :: ANY",
+    "name": "apoc.coll.min",
+    "description": "Returns the minimum of all values in the given `LIST<ANY>`.",
+    "returnDescription": "ANY",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "values",
+        "description": "The list to find the minimum in.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.coll.occurrences(coll :: LIST<ANY>, item :: ANY) :: INTEGER",
+    "name": "apoc.coll.occurrences",
+    "description": "Returns the count of the given item in the collection.",
+    "returnDescription": "INTEGER",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list to collect the count of the given value from.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "item",
+        "description": "The value to count in the given list.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.coll.pairWithOffset(coll :: LIST<ANY>, offset :: INTEGER) :: LIST<ANY>",
+    "name": "apoc.coll.pairWithOffset",
+    "description": "Returns a `LIST<ANY>` of pairs defined by the offset.",
+    "returnDescription": "LIST<ANY>",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list to create pairs from.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "offset",
+        "description": "The offset to make each pair with from the given list.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.coll.pairs(list :: LIST<ANY>) :: LIST<ANY>",
+    "name": "apoc.coll.pairs",
+    "description": "Returns a `LIST<ANY>` of adjacent elements in the `LIST<ANY>` ([1,2],[2,3],[3,null]).",
+    "returnDescription": "LIST<ANY>",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "list",
+        "description": "The list to create pairs from.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.coll.pairsMin(list :: LIST<ANY>) :: LIST<ANY>",
+    "name": "apoc.coll.pairsMin",
+    "description": "Returns `LIST<ANY>` values of adjacent elements in the `LIST<ANY>` ([1,2],[2,3]), skipping the final element.",
+    "returnDescription": "LIST<ANY>",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "list",
+        "description": "The list to create pairs from.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.coll.partition(coll :: LIST<ANY>, batchSize :: INTEGER) :: LIST<ANY>",
+    "name": "apoc.coll.partition",
+    "description": "Partitions the original `LIST<ANY>` into a new `LIST<ANY>` of the given batch size.\nThe final `LIST<ANY>` may be smaller than the given batch size.",
+    "returnDescription": "LIST<ANY>",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list to partition into smaller sublists.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "batchSize",
+        "description": "The max size of each partitioned sublist.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.coll.randomItem(coll :: LIST<ANY>) :: ANY",
+    "name": "apoc.coll.randomItem",
+    "description": "Returns a random item from the `LIST<ANY>`, or null on `LIST<NOTHING>` or `LIST<NULL>`.",
+    "returnDescription": "ANY",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list to return a random item from.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.coll.sortNodes(coll :: LIST<NODE>, prop :: STRING) :: LIST<ANY>",
+    "name": "apoc.coll.sortNodes",
+    "description": "Sorts the given `LIST<NODE>` by the property of the nodes into descending order.",
+    "returnDescription": "LIST<ANY>",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list of nodes to be sorted.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "prop",
+        "description": "The property key on the node to be used to sort the list by.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.coll.stdev(list :: LIST<INTEGER | FLOAT>, isBiasCorrected = true :: BOOLEAN) :: INTEGER | FLOAT",
+    "name": "apoc.coll.stdev",
+    "description": "Returns sample or population standard deviation with `isBiasCorrected` true or false respectively.",
+    "returnDescription": "INTEGER | FLOAT",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "list",
+        "description": "A list to collect the standard deviation from.",
+        "isDeprecated": false,
+        "type": "LIST<INTEGER | FLOAT>"
+      },
+      {
+        "name": "isBiasCorrected",
+        "description": "Will perform a sample standard deviation if `isBiasCorrected`, otherwise a population standard deviation is performed.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=true, type=BOOLEAN}",
+        "type": "BOOLEAN"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.coll.sum(coll :: LIST<INTEGER | FLOAT>) :: FLOAT",
+    "name": "apoc.coll.sum",
+    "description": "Returns the sum of all the `INTEGER | FLOAT` in the `LIST<INTEGER | FLOAT>`.",
     "returnDescription": "FLOAT",
     "deprecatedBy": null,
     "category": "",
     "isBuiltIn": false,
     "argumentDescription": [
       {
-        "name": "value",
-        "description": "An angle in radians.",
+        "name": "coll",
+        "description": "The list of numbers to create a sum from.",
         "isDeprecated": false,
-        "type": "FLOAT"
+        "type": "LIST<INTEGER | FLOAT>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.coll.sumLongs(coll :: LIST<INTEGER | FLOAT>) :: INTEGER",
+    "name": "apoc.coll.sumLongs",
+    "description": "Returns the sum of all the `INTEGER | FLOAT` in the `LIST<INTEGER | FLOAT>`.",
+    "returnDescription": "INTEGER",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list of numbers to create a sum from after each is cast to a java Long value.",
+        "isDeprecated": false,
+        "type": "LIST<INTEGER | FLOAT>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.coll.unionAll(list1 :: LIST<ANY>, list2 :: LIST<ANY>) :: LIST<ANY>",
+    "name": "apoc.coll.unionAll",
+    "description": "Returns the full union of the two given `LIST<ANY>` values (duplicates included).",
+    "returnDescription": "LIST<ANY>",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "list1",
+        "description": "The list of values to compare against `list2` and form a union from.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "list2",
+        "description": "The list of values to compare against `list1` and form a union from.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.coll.zip(list1 :: LIST<ANY>, list2 :: LIST<ANY>) :: LIST<ANY>",
+    "name": "apoc.coll.zip",
+    "description": "Returns the two given `LIST<ANY>` values zipped together as a `LIST<LIST<ANY>>`.",
+    "returnDescription": "LIST<ANY>",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "list1",
+        "description": "The list to zip together with `list2`.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "list2",
+        "description": "The list to zip together with `list1`.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.convert.toList(value :: ANY) :: LIST<ANY>",
+    "name": "apoc.convert.toList",
+    "description": "Converts the given value into a `LIST<ANY>`.",
+    "returnDescription": "LIST<ANY>",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "value",
+        "description": "The value to convert into a list.",
+        "isDeprecated": false,
+        "type": "ANY"
       }
     ]
   },
@@ -48,6 +451,96 @@
     "category": "",
     "isBuiltIn": false,
     "argumentDescription": []
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.date.currentTimestamp() :: INTEGER",
+    "name": "apoc.date.currentTimestamp",
+    "description": "Returns the current Unix epoch timestamp in milliseconds.",
+    "returnDescription": "INTEGER",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": []
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.date.field(time :: INTEGER, unit = d :: STRING, timezone = UTC :: STRING) :: INTEGER",
+    "name": "apoc.date.field",
+    "description": "Returns the value of one field from the given date time.",
+    "returnDescription": "INTEGER",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "time",
+        "description": "The timestamp in ms since epoch to return a field from.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "unit",
+        "description": "The unit of the field to return the value of.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=d, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "timezone",
+        "description": "The timezone the given timestamp is in.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=UTC, type=STRING}",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.date.fromISO8601(time :: STRING) :: INTEGER",
+    "name": "apoc.date.fromISO8601",
+    "description": "Converts the given date `STRING` (ISO8601) to an `INTEGER` representing the time value in milliseconds.",
+    "returnDescription": "INTEGER",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "time",
+        "description": "The datetime to convert to ms.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.date.toISO8601(time :: INTEGER, unit = ms :: STRING) :: STRING",
+    "name": "apoc.date.toISO8601",
+    "description": "Returns a `STRING` representation of a specified time value in the ISO8601 format.",
+    "returnDescription": "STRING",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "time",
+        "description": "The timestamp since epoch to format.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "unit",
+        "description": "The unit of the given timestamp.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=ms, type=STRING}",
+        "type": "STRING"
+      }
+    ]
   },
   {
     "isDeprecated": true,
@@ -77,6 +570,44 @@
         "description": "The value to set the given key to.",
         "isDeprecated": false,
         "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.math.cosh(value :: FLOAT) :: FLOAT",
+    "name": "apoc.math.cosh",
+    "description": "Returns the hyperbolic cosine.",
+    "returnDescription": "FLOAT",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "value",
+        "description": "An angle in radians.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.math.coth(value :: FLOAT) :: FLOAT",
+    "name": "apoc.math.coth",
+    "description": "Returns the hyperbolic cotangent.",
+    "returnDescription": "FLOAT",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "value",
+        "description": "An angle in radians.",
+        "isDeprecated": false,
+        "type": "FLOAT"
       }
     ]
   },
@@ -115,6 +646,154 @@
         "description": "An angle in radians.",
         "isDeprecated": false,
         "type": "FLOAT"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.meta.cypher.isType(value :: ANY, type :: STRING) :: BOOLEAN",
+    "name": "apoc.meta.cypher.isType",
+    "description": "Returns true if the given value matches the given type.",
+    "returnDescription": "BOOLEAN",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "value",
+        "description": "An object to check the type of.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "type",
+        "description": "The verification type.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.meta.cypher.type(value :: ANY) :: STRING",
+    "name": "apoc.meta.cypher.type",
+    "description": "Returns the type name of the given value.",
+    "returnDescription": "STRING",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "value",
+        "description": "An object to get the type of.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.node.degree(node :: NODE, relTypes =  :: STRING) :: INTEGER",
+    "name": "apoc.node.degree",
+    "description": "Returns the total degrees of the given `NODE`.",
+    "returnDescription": "INTEGER",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "node",
+        "description": "The node to count the total number of relationships on.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relTypes",
+        "description": "The relationship types to restrict the count to. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.node.degree.in(node :: NODE, relTypes =  :: STRING) :: INTEGER",
+    "name": "apoc.node.degree.in",
+    "description": "Returns the total number of incoming `RELATIONSHIP` values connected to the given `NODE`.",
+    "returnDescription": "INTEGER",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "node",
+        "description": "The node for which to count the total number of incoming relationships.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relTypes",
+        "description": "The relationship type to restrict the count to.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.node.degree.out(node :: NODE, relTypes =  :: STRING) :: INTEGER",
+    "name": "apoc.node.degree.out",
+    "description": "Returns the total number of outgoing `RELATIONSHIP` values from the given `NODE`.",
+    "returnDescription": "INTEGER",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "node",
+        "description": "The node for which to count the total number of outgoing relationships.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relTypes",
+        "description": "The relationship type to restrict the count to.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.node.relationship.exists(node :: NODE, relTypes =  :: STRING) :: BOOLEAN",
+    "name": "apoc.node.relationship.exists",
+    "description": "Returns a `BOOLEAN` based on whether the given `NODE` has a connecting `RELATIONSHIP` (or whether the given `NODE` has a connecting `RELATIONSHIP` of the given type and direction).",
+    "returnDescription": "BOOLEAN",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "node",
+        "description": "The node to check for the specified relationship types.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relTypes",
+        "description": "The relationship types to check for on the given node. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
       }
     ]
   },

--- a/core/src/test/resources/procedures/common/procedures.json
+++ b/core/src/test/resources/procedures/common/procedures.json
@@ -1,7630 +1,8527 @@
-[ {
-  "isDeprecated" : false,
-  "signature" : "apoc.algo.aStar(startNode :: NODE, endNode :: NODE, relTypesAndDirections :: STRING, weightPropertyName :: STRING, latPropertyName :: STRING, lonPropertyName :: STRING) :: (path :: PATH, weight :: FLOAT)",
-  "name" : "apoc.algo.aStar",
-  "description" : "Runs the A* search algorithm to find the optimal path between two `NODE` values, using the given `RELATIONSHIP` property name for the cost function.",
-  "returnDescription" : [ {
-    "name" : "path",
-    "description" : "The path result.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  }, {
-    "name" : "weight",
-    "description" : "The weight of the given path.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "startNode",
-    "description" : "The node to start the search from.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "endNode",
-    "description" : "The node to end the search on.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "relTypesAndDirections",
-    "description" : "The relationship types to restrict the algorithm to. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "weightPropertyName",
-    "description" : "The name of the property to use as the weight.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "latPropertyName",
-    "description" : "The name of the property to use as the latitude.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "lonPropertyName",
-    "description" : "The name of the property to use as the longitude.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.algo.aStarConfig(startNode :: NODE, endNode :: NODE, relTypesAndDirections :: STRING, config :: MAP) :: (path :: PATH, weight :: FLOAT)",
-  "name" : "apoc.algo.aStarConfig",
-  "description" : "Runs the A* search algorithm to find the optimal path between two `NODE` values, using the given `RELATIONSHIP` property name for the cost function.\nThis procedure looks for weight, latitude and longitude properties in the config.",
-  "returnDescription" : [ {
-    "name" : "path",
-    "description" : "The path result.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  }, {
-    "name" : "weight",
-    "description" : "The weight of the given path.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "startNode",
-    "description" : "The node to start the search from.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "endNode",
-    "description" : "The node to end the search on.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "relTypesAndDirections",
-    "description" : "The relationship types to restrict the algorithm to. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{ weight = 'distance' :: STRING, default = Double.MAX_VALUE :: FLOAT, y = 'latitude' :: STRING, x = 'longitude' :: STRING, pointPropName :: STRING }",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.algo.allSimplePaths(startNode :: NODE, endNode :: NODE, relTypesAndDirections :: STRING, maxNodes :: INTEGER) :: (path :: PATH)",
-  "name" : "apoc.algo.allSimplePaths",
-  "description" : "Runs a search algorithm to find all of the simple paths between the given `RELATIONSHIP` values, up to a max depth described by `maxNodes`.\nThe returned paths will not contain loops.",
-  "returnDescription" : [ {
-    "name" : "path",
-    "description" : "The path result.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "startNode",
-    "description" : "The node to start the search from.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "endNode",
-    "description" : "The node to end the search on.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "relTypesAndDirections",
-    "description" : "The relationship types to restrict the algorithm to. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "maxNodes",
-    "description" : "The max depth (in terms of nodes) the algorithm will explore.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.algo.cover(nodes :: ANY) :: (rel :: RELATIONSHIP)",
-  "name" : "apoc.algo.cover",
-  "description" : "Returns all `RELATIONSHIP` values connecting the given set of `NODE` values.",
-  "returnDescription" : [ {
-    "name" : "rel",
-    "description" : "The relationships connected to the given nodes.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The nodes to look for connected relationships on.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.algo.dijkstra(startNode :: NODE, endNode :: NODE, relTypesAndDirections :: STRING, weightPropertyName :: STRING, defaultWeight = NaN :: FLOAT, numberOfWantedPaths = 1 :: INTEGER) :: (path :: PATH, weight :: FLOAT)",
-  "name" : "apoc.algo.dijkstra",
-  "description" : "Runs Dijkstra's algorithm using the given `RELATIONSHIP` property as the cost function.",
-  "returnDescription" : [ {
-    "name" : "path",
-    "description" : "The path result.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  }, {
-    "name" : "weight",
-    "description" : "The weight of the given path.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "startNode",
-    "description" : "The node to start the search from.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "endNode",
-    "description" : "The node to end the search on.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "relTypesAndDirections",
-    "description" : "The relationship types to restrict the algorithm to. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "weightPropertyName",
-    "description" : "The name of the property to use as the weight.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "defaultWeight",
-    "description" : "The `defaultWeight` is used when no specific weight is provided for the given relationship or node. The default value for defaultWeight is NaN.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=NaN, type=FLOAT}",
-    "type" : "FLOAT"
-  }, {
-    "name" : "numberOfWantedPaths",
-    "description" : "The number of wanted paths to return.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=1, type=INTEGER}",
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.atomic.add(container :: ANY, propertyName :: STRING, number :: INTEGER | FLOAT, retryAttempts = 5 :: INTEGER) :: (container :: ANY, property :: STRING, oldValue :: ANY, newValue :: ANY)",
-  "name" : "apoc.atomic.add",
-  "description" : "Sets the given property to the sum of itself and the given `INTEGER` or `FLOAT` value.\nThe procedure then sets the property to the returned sum.",
-  "returnDescription" : [ {
-    "name" : "container",
-    "description" : "The updated node or relationship.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "property",
-    "description" : "The name of the updated property.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "oldValue",
-    "description" : "The original value on the property.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "newValue",
-    "description" : "The new value on the property.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "container",
-    "description" : "The node or relationship that contains the property to which the value will be added.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "propertyName",
-    "description" : "The name of the property whose value will be added to.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "number",
-    "description" : "The number to add.",
-    "isDeprecated" : false,
-    "type" : "INTEGER | FLOAT"
-  }, {
-    "name" : "retryAttempts",
-    "description" : "The max retry attempts.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=5, type=INTEGER}",
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.atomic.concat(container :: ANY, propertyName :: STRING, string :: STRING, retryAttempts = 5 :: INTEGER) :: (container :: ANY, property :: STRING, oldValue :: ANY, newValue :: ANY)",
-  "name" : "apoc.atomic.concat",
-  "description" : "Sets the given property to the concatenation of itself and the `STRING` value.\nThe procedure then sets the property to the returned `STRING`.",
-  "returnDescription" : [ {
-    "name" : "container",
-    "description" : "The updated node or relationship.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "property",
-    "description" : "The name of the updated property.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "oldValue",
-    "description" : "The original value on the property.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "newValue",
-    "description" : "The new value on the property.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "container",
-    "description" : "The node or relationship that contains the property to which the value will be concatenated.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "propertyName",
-    "description" : "The name of the property to be concatenated.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "string",
-    "description" : "The string value to concatenate with the property.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "retryAttempts",
-    "description" : "The max retry attempts.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=5, type=INTEGER}",
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.atomic.insert(container :: ANY, propertyName :: STRING, position :: INTEGER, value :: ANY, retryAttempts = 5 :: INTEGER) :: (container :: ANY, property :: STRING, oldValue :: ANY, newValue :: ANY)",
-  "name" : "apoc.atomic.insert",
-  "description" : "Inserts a value at position into the `LIST<ANY>` value of a property.\nThe procedure then sets the result back on the property.",
-  "returnDescription" : [ {
-    "name" : "container",
-    "description" : "The updated node or relationship.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "property",
-    "description" : "The name of the updated property.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "oldValue",
-    "description" : "The original value on the property.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "newValue",
-    "description" : "The new value on the property.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "container",
-    "description" : "The node or relationship that has a property containing a list.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "propertyName",
-    "description" : "The name of the property into which the value will be inserted.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "position",
-    "description" : "The position in the list to insert the item into.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "value",
-    "description" : "The value to insert.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "retryAttempts",
-    "description" : "The max retry attempts.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=5, type=INTEGER}",
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.atomic.remove(container :: ANY, propertyName :: STRING, position :: INTEGER, retryAttempts = 5 :: INTEGER) :: (container :: ANY, property :: STRING, oldValue :: ANY, newValue :: ANY)",
-  "name" : "apoc.atomic.remove",
-  "description" : "Removes the element at position from the `LIST<ANY>` value of a property.\nThe procedure then sets the property to the resulting `LIST<ANY>` value.",
-  "returnDescription" : [ {
-    "name" : "container",
-    "description" : "The updated node or relationship.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "property",
-    "description" : "The name of the updated property.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "oldValue",
-    "description" : "The original value on the property.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "newValue",
-    "description" : "The new value on the property.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "container",
-    "description" : "The node or relationship that has a property containing a list.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "propertyName",
-    "description" : "The name of the property from which the value will be removed.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "position",
-    "description" : "The position in the list to remove the item from.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "retryAttempts",
-    "description" : "The max retry attempts.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=5, type=INTEGER}",
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.atomic.subtract(container :: ANY, propertyName :: STRING, number :: INTEGER | FLOAT, retryAttempts = 5 :: INTEGER) :: (container :: ANY, property :: STRING, oldValue :: ANY, newValue :: ANY)",
-  "name" : "apoc.atomic.subtract",
-  "description" : "Sets the property of a value to itself minus the given `INTEGER` or `FLOAT` value.\nThe procedure then sets the property to the returned sum.",
-  "returnDescription" : [ {
-    "name" : "container",
-    "description" : "The updated node or relationship.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "property",
-    "description" : "The name of the updated property.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "oldValue",
-    "description" : "The original value on the property.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "newValue",
-    "description" : "The new value on the property.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "container",
-    "description" : "The node or relationship that contains the property from which the value will be subtracted.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "propertyName",
-    "description" : "The name of the property from which the value will be subtracted.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "number",
-    "description" : "The number to subtract.",
-    "isDeprecated" : false,
-    "type" : "INTEGER | FLOAT"
-  }, {
-    "name" : "retryAttempts",
-    "description" : "The max retry attempts.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=5, type=INTEGER}",
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.atomic.update(container :: ANY, propertyName :: STRING, operation :: STRING, retryAttempts = 5 :: INTEGER) :: (container :: ANY, property :: STRING, oldValue :: ANY, newValue :: ANY)",
-  "name" : "apoc.atomic.update",
-  "description" : "Updates the value of a property with a Cypher operation.",
-  "returnDescription" : [ {
-    "name" : "container",
-    "description" : "The updated node or relationship.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "property",
-    "description" : "The name of the updated property.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "oldValue",
-    "description" : "The original value on the property.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "newValue",
-    "description" : "The new value on the property.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "container",
-    "description" : "The node or relationship with the property to be updated.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "propertyName",
-    "description" : "The name of the property to be updated.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "operation",
-    "description" : "The operation to perform to update the property.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "retryAttempts",
-    "description" : "The max retry attempts.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=5, type=INTEGER}",
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.coll.elements(coll :: LIST<ANY>, limit = -1 :: INTEGER, offset = 0 :: INTEGER) :: (_1 :: ANY, _2 :: ANY, _3 :: ANY, _4 :: ANY, _5 :: ANY, _6 :: ANY, _7 :: ANY, _8 :: ANY, _9 :: ANY, _10 :: ANY, _1s :: STRING, _2s :: STRING, _3s :: STRING, _4s :: STRING, _5s :: STRING, _6s :: STRING, _7s :: STRING, _8s :: STRING, _9s :: STRING, _10s :: STRING, _1i :: INTEGER, _2i :: INTEGER, _3i :: INTEGER, _4i :: INTEGER, _5i :: INTEGER, _6i :: INTEGER, _7i :: INTEGER, _8i :: INTEGER, _9i :: INTEGER, _10i :: INTEGER, _1f :: FLOAT, _2f :: FLOAT, _3f :: FLOAT, _4f :: FLOAT, _5f :: FLOAT, _6f :: FLOAT, _7f :: FLOAT, _8f :: FLOAT, _9f :: FLOAT, _10f :: FLOAT, _1b :: BOOLEAN, _2b :: BOOLEAN, _3b :: BOOLEAN, _4b :: BOOLEAN, _5b :: BOOLEAN, _6b :: BOOLEAN, _7b :: BOOLEAN, _8b :: BOOLEAN, _9b :: BOOLEAN, _10b :: BOOLEAN, _1l :: LIST<ANY>, _2l :: LIST<ANY>, _3l :: LIST<ANY>, _4l :: LIST<ANY>, _5l :: LIST<ANY>, _6l :: LIST<ANY>, _7l :: LIST<ANY>, _8l :: LIST<ANY>, _9l :: LIST<ANY>, _10l :: LIST<ANY>, _1m :: MAP, _2m :: MAP, _3m :: MAP, _4m :: MAP, _5m :: MAP, _6m :: MAP, _7m :: MAP, _8m :: MAP, _9m :: MAP, _10m :: MAP, _1n :: NODE, _2n :: NODE, _3n :: NODE, _4n :: NODE, _5n :: NODE, _6n :: NODE, _7n :: NODE, _8n :: NODE, _9n :: NODE, _10n :: NODE, _1r :: RELATIONSHIP, _2r :: RELATIONSHIP, _3r :: RELATIONSHIP, _4r :: RELATIONSHIP, _5r :: RELATIONSHIP, _6r :: RELATIONSHIP, _7r :: RELATIONSHIP, _8r :: RELATIONSHIP, _9r :: RELATIONSHIP, _10r :: RELATIONSHIP, _1p :: PATH, _2p :: PATH, _3p :: PATH, _4p :: PATH, _5p :: PATH, _6p :: PATH, _7p :: PATH, _8p :: PATH, _9p :: PATH, _10p :: PATH, elements :: INTEGER)",
-  "name" : "apoc.coll.elements",
-  "description" : "Deconstructs a `LIST<ANY>` into identifiers indicating their specific type.",
-  "returnDescription" : [ {
-    "name" : "_1",
-    "description" : "The value of the first item.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "_2",
-    "description" : "The value of the second item.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "_3",
-    "description" : "The value of the third item.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "_4",
-    "description" : "The value of the fourth item.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "_5",
-    "description" : "The value of the fifth item.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "_6",
-    "description" : "The value of the sixth item.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "_7",
-    "description" : "The value of the seventh item.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "_8",
-    "description" : "The value of the eighth item.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "_9",
-    "description" : "The value of the ninth item.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "_10",
-    "description" : "The value of the tenth item.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "_1s",
-    "description" : "The value of the first item, if it is a string value.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "_2s",
-    "description" : "The value of the second item, if it is a string value.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "_3s",
-    "description" : "The value of the third item, if it is a string value.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "_4s",
-    "description" : "The value of the fourth item, if it is a string value.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "_5s",
-    "description" : "The value of the fifth item, if it is a string value.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "_6s",
-    "description" : "The value of the sixth item, if it is a string value.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "_7s",
-    "description" : "The value of the seventh item, if it is a string value.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "_8s",
-    "description" : "The value of the eighth item, if it is a string value.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "_9s",
-    "description" : "The value of the ninth item, if it is a string value.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "_10s",
-    "description" : "The value of the tenth item, if it is a string value.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "_1i",
-    "description" : "The value of the first item, if it is an integer value.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "_2i",
-    "description" : "The value of the second item, if it is an integer value.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "_3i",
-    "description" : "The value of the third item, if it is an integer value.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "_4i",
-    "description" : "The value of the fourth item, if it is an integer value.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "_5i",
-    "description" : "The value of the fifth item, if it is an integer value.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "_6i",
-    "description" : "The value of the sixth item, if it is an integer value.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "_7i",
-    "description" : "The value of the seventh item, if it is an integer value.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "_8i",
-    "description" : "The value of the eighth item, if it is an integer value.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "_9i",
-    "description" : "The value of the ninth item, if it is an integer value.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "_10i",
-    "description" : "The value of the tenth item, if it is an integer value.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "_1f",
-    "description" : "The value of the first item, if it is a float value.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "_2f",
-    "description" : "The value of the second item, if it is a float value.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "_3f",
-    "description" : "The value of the third item, if it is a float value.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "_4f",
-    "description" : "The value of the fourth item, if it is a float value.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "_5f",
-    "description" : "The value of the fifth item, if it is a float value.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "_6f",
-    "description" : "The value of the sixth item, if it is a float value.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "_7f",
-    "description" : "The value of the seventh item, if it is a float value.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "_8f",
-    "description" : "The value of the eighth item, if it is a float value.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "_9f",
-    "description" : "The value of the ninth item, if it is a float value.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "_10f",
-    "description" : "The value of the tenth item, if it is a float value.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "_1b",
-    "description" : "The value of the first item, if it is a boolean value.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "_2b",
-    "description" : "The value of the second item, if it is a boolean value.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "_3b",
-    "description" : "The value of the third item, if it is a boolean value.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "_4b",
-    "description" : "The value of the fourth item, if it is a boolean value.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "_5b",
-    "description" : "The value of the fifth item, if it is a boolean value.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "_6b",
-    "description" : "The value of the sixth item, if it is a boolean value.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "_7b",
-    "description" : "The value of the seventh item, if it is a boolean value.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "_8b",
-    "description" : "The value of the eighth item, if it is a boolean value.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "_9b",
-    "description" : "The value of the ninth item, if it is a boolean value.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "_10b",
-    "description" : "The value of the tenth item, if it is a boolean value.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "_1l",
-    "description" : "The value of the first item, if it is a list value.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "_2l",
-    "description" : "The value of the second item, if it is a list value.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "_3l",
-    "description" : "The value of the third item, if it is a list value.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "_4l",
-    "description" : "The value of the fourth item, if it is a list value.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "_5l",
-    "description" : "The value of the fifth item, if it is a list value.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "_6l",
-    "description" : "The value of the sixth item, if it is a list value.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "_7l",
-    "description" : "The value of the seventh item, if it is a list value.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "_8l",
-    "description" : "The value of the eighth item, if it is a list value.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "_9l",
-    "description" : "The value of the ninth item, if it is a list value.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "_10l",
-    "description" : "The value of the tenth item, if it is a list value.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "_1m",
-    "description" : "The value of the first item, if it is a map value.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "_2m",
-    "description" : "The value of the second item, if it is a map value.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "_3m",
-    "description" : "The value of the third item, if it is a map value.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "_4m",
-    "description" : "The value of the fourth item, if it is a map value.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "_5m",
-    "description" : "The value of the fifth item, if it is a map value.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "_6m",
-    "description" : "The value of the sixth item, if it is a map value.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "_7m",
-    "description" : "The value of the seventh item, if it is a map value.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "_8m",
-    "description" : "The value of the eighth item, if it is a map value.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "_9m",
-    "description" : "The value of the ninth item, if it is a map value.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "_10m",
-    "description" : "The value of the tenth item, if it is a map value.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "_1n",
-    "description" : "The value of the first item, if it is a node value.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "_2n",
-    "description" : "The value of the second item, if it is a node value.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "_3n",
-    "description" : "The value of the third item, if it is a node value.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "_4n",
-    "description" : "The value of the fourth item, if it is a node value.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "_5n",
-    "description" : "The value of the fifth item, if it is a node value.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "_6n",
-    "description" : "The value of the sixth item, if it is a node value.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "_7n",
-    "description" : "The value of the seventh item, if it is a node value.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "_8n",
-    "description" : "The value of the eighth item, if it is a node value.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "_9n",
-    "description" : "The value of the ninth item, if it is a node value.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "_10n",
-    "description" : "The value of the tenth item, if it is a node value.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "_1r",
-    "description" : "The value of the first item, if it is a relationship value.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "_2r",
-    "description" : "The value of the second item, if it is a relationship value.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "_3r",
-    "description" : "The value of the third item, if it is a relationship value.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "_4r",
-    "description" : "The value of the fourth item, if it is a relationship value.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "_5r",
-    "description" : "The value of the fifth item, if it is a relationship value.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "_6r",
-    "description" : "The value of the sixth item, if it is a relationship value.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "_7r",
-    "description" : "The value of the seventh item, if it is a relationship value.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "_8r",
-    "description" : "The value of the eighth item, if it is a relationship value.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "_9r",
-    "description" : "The value of the ninth item, if it is a relationship value.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "_10r",
-    "description" : "The value of the tenth item, if it is a relationship value.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "_1p",
-    "description" : "The value of the first item, if it is a path value.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  }, {
-    "name" : "_2p",
-    "description" : "The value of the second item, if it is a path value.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  }, {
-    "name" : "_3p",
-    "description" : "The value of the third item, if it is a path value.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  }, {
-    "name" : "_4p",
-    "description" : "The value of the fourth item, if it is a path value.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  }, {
-    "name" : "_5p",
-    "description" : "The value of the fifth item, if it is a path value.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  }, {
-    "name" : "_6p",
-    "description" : "The value of the sixth item, if it is a path value.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  }, {
-    "name" : "_7p",
-    "description" : "The value of the seventh item, if it is a path value.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  }, {
-    "name" : "_8p",
-    "description" : "The value of the eighth item, if it is a path value.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  }, {
-    "name" : "_9p",
-    "description" : "The value of the ninth item, if it is a path value.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  }, {
-    "name" : "_10p",
-    "description" : "The value of the tenth item, if it is a path value.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  }, {
-    "name" : "elements",
-    "description" : "The number of deconstructed elements.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "coll",
-    "description" : "A list of values to deconstruct.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "limit",
-    "description" : "The maximum size of elements to deconstruct from the given list.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=-1, type=INTEGER}",
-    "type" : "INTEGER"
-  }, {
-    "name" : "offset",
-    "description" : "The offset to start deconstructing from.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=0, type=INTEGER}",
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.coll.pairWithOffset(coll :: LIST<ANY>, offset :: INTEGER) :: (value :: LIST<ANY>)",
-  "name" : "apoc.coll.pairWithOffset",
-  "description" : "Returns a `LIST<ANY>` of pairs defined by the offset.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "The created pair.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "coll",
-    "description" : "The list to create pairs from.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "offset",
-    "description" : "The offset to make each pair with from the given list.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.coll.partition(coll :: LIST<ANY>, batchSize :: INTEGER) :: (value :: LIST<ANY>)",
-  "name" : "apoc.coll.partition",
-  "description" : "Partitions the original `LIST<ANY>` into a new `LIST<ANY>` of the given batch size.\nThe final `LIST<ANY>` may be smaller than the given batch size.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "The partitioned list.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "coll",
-    "description" : "The list to partition into smaller sublists.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "batchSize",
-    "description" : "The max size of each partitioned sublist.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.coll.split(coll :: LIST<ANY>, value :: ANY) :: (value :: LIST<ANY>)",
-  "name" : "apoc.coll.split",
-  "description" : "Splits a collection by the given value.\nThe value itself will not be part of the resulting `LIST<ANY>` values.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "The split list.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "coll",
-    "description" : "The list to split into parts.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "value",
-    "description" : "The value to split the given list by.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.coll.zipToRows(list1 :: LIST<ANY>, list2 :: LIST<ANY>) :: (value :: LIST<ANY>)",
-  "name" : "apoc.coll.zipToRows",
-  "description" : "Returns the two `LIST<ANY>` values zipped together, with one row per zipped pair.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "A zipped pair.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "list1",
-    "description" : "The list to zip together with `list2`.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "list2",
-    "description" : "The list to zip together with `list1`.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.convert.setJsonProperty(node :: NODE, key :: STRING, value :: ANY)",
-  "name" : "apoc.convert.setJsonProperty",
-  "description" : "Serializes the given JSON object and sets it as a property on the given `NODE`.",
-  "returnDescription" : [ ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "node",
-    "description" : "The node to set the JSON property on.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "key",
-    "description" : "The name of the property to set.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "value",
-    "description" : "The property to serialize as a JSON object.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.create.addLabels(nodes :: ANY, labels :: LIST<STRING>) :: (node :: NODE)",
-  "name" : "apoc.create.addLabels",
-  "description" : "Adds the given labels to the given `NODE` values.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "The updated node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The nodes to add labels to.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "labels",
-    "description" : "The labels to add to the nodes.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.create.clonePathToVirtual(path :: PATH) :: (path :: PATH)",
-  "name" : "apoc.create.clonePathToVirtual",
-  "description" : "Takes the given `PATH` and returns a virtual representation of it.",
-  "returnDescription" : [ {
-    "name" : "path",
-    "description" : "The path result.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "path",
-    "description" : "The path to create a virtual path from.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.create.clonePathsToVirtual(paths :: LIST<PATH>) :: (path :: PATH)",
-  "name" : "apoc.create.clonePathsToVirtual",
-  "description" : "Takes the given `LIST<PATH>` and returns a virtual representation of them.",
-  "returnDescription" : [ {
-    "name" : "path",
-    "description" : "The path result.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "paths",
-    "description" : "The paths to create virtual paths from.",
-    "isDeprecated" : false,
-    "type" : "LIST<PATH>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.create.node(labels :: LIST<STRING>, props :: MAP) :: (node :: NODE)",
-  "name" : "apoc.create.node",
-  "description" : "Creates a `NODE` with the given dynamic labels.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "The created node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "labels",
-    "description" : "The labels to assign to the new node.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "props",
-    "description" : "The properties to assign to the new node.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.create.nodes(labels :: LIST<STRING>, props :: LIST<MAP>) :: (node :: NODE)",
-  "name" : "apoc.create.nodes",
-  "description" : "Creates `NODE` values with the given dynamic labels.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "The created node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "labels",
-    "description" : "The labels to assign to the new nodes.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "props",
-    "description" : "The properties to assign to the new nodes.",
-    "isDeprecated" : false,
-    "type" : "LIST<MAP>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.create.relationship(from :: NODE, relType :: STRING, props :: MAP, to :: NODE) :: (rel :: RELATIONSHIP)",
-  "name" : "apoc.create.relationship",
-  "description" : "Creates a `RELATIONSHIP` with the given dynamic relationship type.",
-  "returnDescription" : [ {
-    "name" : "rel",
-    "description" : "The created relationship.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "from",
-    "description" : "The node from which the outgoing relationship will start.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "relType",
-    "description" : "The type to assign to the new relationship.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "props",
-    "description" : "The properties to assign to the new relationship.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "to",
-    "description" : "The node to which the incoming relationship will be connected.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.create.removeLabels(nodes :: ANY, labels :: LIST<STRING>) :: (node :: NODE)",
-  "name" : "apoc.create.removeLabels",
-  "description" : "Removes the given labels from the given `NODE` values.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "The updated node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The node to remove labels from.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "labels",
-    "description" : "The labels to remove from the given node.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.create.removeProperties(nodes :: ANY, keys :: LIST<STRING>) :: (node :: NODE)",
-  "name" : "apoc.create.removeProperties",
-  "description" : "Removes the given properties from the given `NODE` values.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "The updated node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The nodes to remove properties from.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "keys",
-    "description" : "The property keys to remove from the given nodes.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.create.removeRelProperties(rels :: ANY, keys :: LIST<STRING>) :: (rel :: RELATIONSHIP)",
-  "name" : "apoc.create.removeRelProperties",
-  "description" : "Removes the given properties from the given `RELATIONSHIP` values.",
-  "returnDescription" : [ {
-    "name" : "rel",
-    "description" : "The updated relationship.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "rels",
-    "description" : "The relationships to remove properties from.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "keys",
-    "description" : "The property keys to remove from the given nodes.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.create.setLabels(nodes :: ANY, labels :: LIST<STRING>) :: (node :: NODE)",
-  "name" : "apoc.create.setLabels",
-  "description" : "Sets the given labels to the given `NODE` values. Non-matching labels are removed from the nodes.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "The updated node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The nodes to set labels on.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "labels",
-    "description" : "The labels to set on the given nodes.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.create.setProperties(nodes :: ANY, keys :: LIST<STRING>, values :: LIST<ANY>) :: (node :: NODE)",
-  "name" : "apoc.create.setProperties",
-  "description" : "Sets the given properties to the given `NODE` values.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "The updated node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The nodes to set properties on.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "keys",
-    "description" : "The property keys to set on the given nodes.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "values",
-    "description" : "The values to assign to the properties on the given nodes.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.create.setProperty(nodes :: ANY, key :: STRING, value :: ANY) :: (node :: NODE)",
-  "name" : "apoc.create.setProperty",
-  "description" : "Sets the given property to the given `NODE` values.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "The updated node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The nodes to set a property on.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "key",
-    "description" : "The name of the property key to set.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "value",
-    "description" : "The value of the property to set.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.create.setRelProperties(rels :: ANY, keys :: LIST<STRING>, values :: LIST<ANY>) :: (rel :: RELATIONSHIP)",
-  "name" : "apoc.create.setRelProperties",
-  "description" : "Sets the given properties on the `RELATIONSHIP` values.",
-  "returnDescription" : [ {
-    "name" : "rel",
-    "description" : "The updated relationship.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "rels",
-    "description" : "The relationships to set properties on.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "keys",
-    "description" : "The keys of the properties to set on the given relationships.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "values",
-    "description" : "The values of the properties to set on the given relationships.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.create.setRelProperty(rels :: ANY, key :: STRING, value :: ANY) :: (rel :: RELATIONSHIP)",
-  "name" : "apoc.create.setRelProperty",
-  "description" : "Sets the given property on the `RELATIONSHIP` values.",
-  "returnDescription" : [ {
-    "name" : "rel",
-    "description" : "The updated relationship.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "rels",
-    "description" : "The relationships to set a property on.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "key",
-    "description" : "The name of the property key to set.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "value",
-    "description" : "The value of the property to set.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.create.vNode(labels :: LIST<STRING>, props :: MAP) :: (node :: NODE)",
-  "name" : "apoc.create.vNode",
-  "description" : "Returns a virtual `NODE`.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "The created virtual node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "labels",
-    "description" : "The labels to assign to the new virtual node.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "props",
-    "description" : "The properties to assign to the new virtual node.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.create.vNodes(labels :: LIST<STRING>, props :: LIST<MAP>) :: (node :: NODE)",
-  "name" : "apoc.create.vNodes",
-  "description" : "Returns virtual `NODE` values.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "The created virtual node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "labels",
-    "description" : "The labels to assign to the new virtual node.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "props",
-    "description" : "The properties to assign to the new virtual nodes.",
-    "isDeprecated" : false,
-    "type" : "LIST<MAP>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.create.vRelationship(from :: NODE, relType :: STRING, props :: MAP, to :: NODE) :: (rel :: RELATIONSHIP)",
-  "name" : "apoc.create.vRelationship",
-  "description" : "Returns a virtual `RELATIONSHIP`.",
-  "returnDescription" : [ {
-    "name" : "rel",
-    "description" : "The created virtual relationship.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "from",
-    "description" : "The node to connect the outgoing virtual relationship from.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "relType",
-    "description" : "The type to assign to the new virtual relationship.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "props",
-    "description" : "The properties to assign to the new virtual relationship.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "to",
-    "description" : "The node to which the incoming virtual relationship will be connected.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.create.virtualPath(labelsN :: LIST<STRING>, n :: MAP, arelType :: STRING, props :: MAP, labelsM :: LIST<STRING>, m :: MAP) :: (from :: NODE, rel :: RELATIONSHIP, to :: NODE)",
-  "name" : "apoc.create.virtualPath",
-  "description" : "Returns a virtual `PATH`.",
-  "returnDescription" : [ {
-    "name" : "from",
-    "description" : "The created virtual start node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "rel",
-    "description" : "The created virtual relationship.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "to",
-    "description" : "The created virtual end node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "labelsN",
-    "description" : "The labels to assign to the new virtual start node.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "n",
-    "description" : "The properties to assign to the new virtual start node.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "arelType",
-    "description" : "The type to assign to the new virtual relationship.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "props",
-    "description" : "The properties to assign to the new virtual relationship.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "labelsM",
-    "description" : "The labels to assign to the new virtual node.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "m",
-    "description" : "The properties to assign to the new virtual node.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.cypher.doIt(statement :: STRING, params :: MAP) :: (value :: MAP)",
-  "name" : "apoc.cypher.doIt",
-  "description" : "Runs a dynamically constructed statement with the given parameters. This procedure allows for both read and write statements.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "The result returned from the Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "statement",
-    "description" : "The Cypher statement to run.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "params",
-    "description" : "The parameters for the given Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.cypher.run(statement :: STRING, params :: MAP) :: (value :: MAP)",
-  "name" : "apoc.cypher.run",
-  "description" : "Runs a dynamically constructed read-only statement with the given parameters.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "The result returned from the Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "statement",
-    "description" : "The Cypher statement to run.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "params",
-    "description" : "The parameters for the given Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.cypher.runMany(statement :: STRING, params :: MAP, config = {} :: MAP) :: (row :: INTEGER, result :: MAP)",
-  "name" : "apoc.cypher.runMany",
-  "description" : "Runs each semicolon separated statement and returns a summary of the statement outcomes.",
-  "returnDescription" : [ {
-    "name" : "row",
-    "description" : "The row number of the run Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "result",
-    "description" : "The result returned from the Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "statement",
-    "description" : "The Cypher statements to run, semicolon separated (;).",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "params",
-    "description" : "The parameters for the given Cypher statements.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "config",
-    "description" : "{ statistics = true :: BOOLEAN }",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.cypher.runManyReadOnly(statement :: STRING, params :: MAP, config = {} :: MAP) :: (row :: INTEGER, result :: MAP)",
-  "name" : "apoc.cypher.runManyReadOnly",
-  "description" : "Runs each semicolon separated read-only statement and returns a summary of the statement outcomes.",
-  "returnDescription" : [ {
-    "name" : "row",
-    "description" : "The row number of the run Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "result",
-    "description" : "The result returned from the Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "statement",
-    "description" : "The Cypher statements to run, semicolon separated (;).",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "params",
-    "description" : "The parameters for the given Cypher statements.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "config",
-    "description" : "{ statistics = true :: BOOLEAN }",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.cypher.runSchema(statement :: STRING, params :: MAP) :: (value :: MAP)",
-  "name" : "apoc.cypher.runSchema",
-  "description" : "Runs the given query schema statement with the given parameters.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "The result returned from the Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "statement",
-    "description" : "The Cypher schema statement to run.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "params",
-    "description" : "The parameters for the given Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.cypher.runWrite(statement :: STRING, params :: MAP) :: (value :: MAP)",
-  "name" : "apoc.cypher.runWrite",
-  "description" : "Alias for `apoc.cypher.doIt`.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "The result returned from the Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "statement",
-    "description" : "The Cypher statement to run.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "params",
-    "description" : "The parameters for the given Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.example.movies() :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
-  "name" : "apoc.example.movies",
-  "description" : "Seeds the database with the Neo4j movie dataset.",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file containing the movies example.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "source",
-    "description" : "Where the examples were sourced from.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format the movies file was in.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of nodes imported.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of relationships imported.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of properties imported.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the import.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the import was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the import was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "Whether the import ran successfully.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "data",
-    "description" : "The data returned by the import.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.export.csv.all(file :: STRING, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
-  "name" : "apoc.export.csv.all",
-  "description" : "Exports the full database to the provided CSV file.",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data was exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "source",
-    "description" : "A summary of the exported data.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format the file is exported in.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of exported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of exported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of exported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the export.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "Whether the export ran successfully.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "data",
-    "description" : "The data returned by the export.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data will be exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        quotes = 'always' :: ['always', 'none', 'ifNeeded'],\n        differentiateNulls = false :: BOOLEAN,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.export.csv.data(nodes :: LIST<NODE>, rels :: LIST<RELATIONSHIP>, file :: STRING, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
-  "name" : "apoc.export.csv.data",
-  "description" : "Exports the given `NODE` and `RELATIONSHIP` values to the provided CSV file.",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data was exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "source",
-    "description" : "A summary of the exported data.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format the file is exported in.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of exported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of exported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of exported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the export.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "Whether the export ran successfully.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "data",
-    "description" : "The data returned by the export.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "A list of nodes to export.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "rels",
-    "description" : "A list of relationships to export.",
-    "isDeprecated" : false,
-    "type" : "LIST<RELATIONSHIP>"
-  }, {
-    "name" : "file",
-    "description" : "The name of the file to which the data will be exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        quotes = 'always' :: ['always', 'none', 'ifNeeded'],\n        differentiateNulls = false :: BOOLEAN,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.export.csv.graph(graph :: MAP, file :: STRING, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
-  "name" : "apoc.export.csv.graph",
-  "description" : "Exports the given graph to the provided CSV file.",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data was exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "source",
-    "description" : "A summary of the exported data.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format the file is exported in.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of exported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of exported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of exported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the export.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "Whether the export ran successfully.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "data",
-    "description" : "The data returned by the export.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "graph",
-    "description" : "The graph to export.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "file",
-    "description" : "The name of the file to which the data will be exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        quotes = 'always' :: ['always', 'none', 'ifNeeded'],\n        differentiateNulls = false :: BOOLEAN,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.export.csv.query(query :: STRING, file :: STRING, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
-  "name" : "apoc.export.csv.query",
-  "description" : "Exports the results from running the given Cypher query to the provided CSV file.",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data was exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "source",
-    "description" : "A summary of the exported data.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format the file is exported in.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of exported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of exported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of exported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the export.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "Whether the export ran successfully.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "data",
-    "description" : "The data returned by the export.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "query",
-    "description" : "The query used to collect the data for export.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "file",
-    "description" : "The name of the file to which the data will be exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None':: STRING,\n        charset = 'UTF_8' :: STRING,\n        quotes = 'always' :: ['always', 'none', 'ifNeeded'],\n        differentiateNulls = false :: BOOLEAN,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.export.cypher.all(file =  :: STRING, config = {} :: MAP) :: (file :: STRING, batches :: INTEGER, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, cypherStatements :: ANY, nodeStatements :: ANY, relationshipStatements :: ANY, schemaStatements :: ANY, cleanupStatements :: ANY)",
-  "name" : "apoc.export.cypher.all",
-  "description" : "Exports the full database (incl. indexes) as Cypher statements to the provided file (default: Cypher Shell).",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data was exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "source",
-    "description" : "A summary of the exported data.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format the file is exported in.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of exported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of exported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of exported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the export.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "cypherStatements",
-    "description" : "The executed Cypher Statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "nodeStatements",
-    "description" : "The executed node statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "relationshipStatements",
-    "description" : "The executed relationship statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "schemaStatements",
-    "description" : "The executed schema statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "cleanupStatements",
-    "description" : "The executed cleanup statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data will be exported.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=, type=STRING}",
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.export.cypher.data(nodes :: LIST<NODE>, rels :: LIST<RELATIONSHIP>, file =  :: STRING, config = {} :: MAP) :: (file :: STRING, batches :: INTEGER, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, cypherStatements :: ANY, nodeStatements :: ANY, relationshipStatements :: ANY, schemaStatements :: ANY, cleanupStatements :: ANY)",
-  "name" : "apoc.export.cypher.data",
-  "description" : "Exports the given `NODE` and `RELATIONSHIP` values (incl. indexes) as Cypher statements to the provided file (default: Cypher Shell).",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data was exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "source",
-    "description" : "A summary of the exported data.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format the file is exported in.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of exported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of exported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of exported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the export.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "cypherStatements",
-    "description" : "The executed Cypher Statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "nodeStatements",
-    "description" : "The executed node statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "relationshipStatements",
-    "description" : "The executed relationship statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "schemaStatements",
-    "description" : "The executed schema statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "cleanupStatements",
-    "description" : "The executed cleanup statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "A list of nodes to export.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "rels",
-    "description" : "A list of relationships to export.",
-    "isDeprecated" : false,
-    "type" : "LIST<RELATIONSHIP>"
-  }, {
-    "name" : "file",
-    "description" : "The name of the file to which the data will be exported.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=, type=STRING}",
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.export.cypher.graph(graph :: MAP, file :: STRING, config = {} :: MAP) :: (file :: STRING, batches :: INTEGER, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, cypherStatements :: ANY, nodeStatements :: ANY, relationshipStatements :: ANY, schemaStatements :: ANY, cleanupStatements :: ANY)",
-  "name" : "apoc.export.cypher.graph",
-  "description" : "Exports the given graph (incl. indexes) as Cypher statements to the provided file (default: Cypher Shell).",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data was exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "source",
-    "description" : "A summary of the exported data.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format the file is exported in.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of exported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of exported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of exported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the export.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "cypherStatements",
-    "description" : "The executed Cypher Statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "nodeStatements",
-    "description" : "The executed node statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "relationshipStatements",
-    "description" : "The executed relationship statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "schemaStatements",
-    "description" : "The executed schema statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "cleanupStatements",
-    "description" : "The executed cleanup statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "graph",
-    "description" : "The graph to export.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "file",
-    "description" : "The name of the file to which the data will be exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.export.cypher.query(statement :: STRING, file =  :: STRING, config = {} :: MAP) :: (file :: STRING, batches :: INTEGER, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, cypherStatements :: ANY, nodeStatements :: ANY, relationshipStatements :: ANY, schemaStatements :: ANY, cleanupStatements :: ANY)",
-  "name" : "apoc.export.cypher.query",
-  "description" : "Exports the `NODE` and `RELATIONSHIP` values from the given Cypher query (incl. indexes) as Cypher statements to the provided file (default: Cypher Shell).",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data was exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "source",
-    "description" : "A summary of the exported data.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format the file is exported in.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of exported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of exported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of exported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the export.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "cypherStatements",
-    "description" : "The executed Cypher Statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "nodeStatements",
-    "description" : "The executed node statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "relationshipStatements",
-    "description" : "The executed relationship statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "schemaStatements",
-    "description" : "The executed schema statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "cleanupStatements",
-    "description" : "The executed cleanup statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "statement",
-    "description" : "The query used to collect the data for export.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "file",
-    "description" : "The name of the file to which the data will be exported.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=, type=STRING}",
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.export.cypher.schema(file =  :: STRING, config = {} :: MAP) :: (file :: STRING, batches :: INTEGER, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, cypherStatements :: ANY, nodeStatements :: ANY, relationshipStatements :: ANY, schemaStatements :: ANY, cleanupStatements :: ANY)",
-  "name" : "apoc.export.cypher.schema",
-  "description" : "Exports all schema indexes and constraints to Cypher statements.",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data was exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "source",
-    "description" : "A summary of the exported data.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format the file is exported in.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of exported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of exported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of exported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the export.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "cypherStatements",
-    "description" : "The executed Cypher Statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "nodeStatements",
-    "description" : "The executed node statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "relationshipStatements",
-    "description" : "The executed relationship statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "schemaStatements",
-    "description" : "The executed schema statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "cleanupStatements",
-    "description" : "The executed cleanup statements.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data will be exported.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=, type=STRING}",
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.export.graphml.all(file :: STRING, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
-  "name" : "apoc.export.graphml.all",
-  "description" : "Exports the full database to the provided GraphML file.",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data was exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "source",
-    "description" : "A summary of the exported data.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format the file is exported in.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of exported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of exported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of exported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the export.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "Whether the export ran successfully.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "data",
-    "description" : "The data returned by the export.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data will be exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        format = 'cypher-shell' :: STRING,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'NONE' :: ['NONE', 'BYTES', 'GZIP', 'BZIP2', 'DEFLATE', 'BLOCK_LZ4', 'FRAMED_SNAPPY'],\n        charset = 'UTF_8' :: STRING,\n        source :: MAP,\n        target :: MAP,\n        useTypes :: BOOLEAN,\n        caption :: LIST<STRING>\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.export.graphml.data(nodes :: LIST<NODE>, rels :: LIST<RELATIONSHIP>, file :: STRING, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
-  "name" : "apoc.export.graphml.data",
-  "description" : "Exports the given `NODE` and `RELATIONSHIP` values to the provided GraphML file.",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data was exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "source",
-    "description" : "A summary of the exported data.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format the file is exported in.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of exported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of exported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of exported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the export.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "Whether the export ran successfully.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "data",
-    "description" : "The data returned by the export.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "A list of nodes to export.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "rels",
-    "description" : "A list of relationships to export.",
-    "isDeprecated" : false,
-    "type" : "LIST<RELATIONSHIP>"
-  }, {
-    "name" : "file",
-    "description" : "The name of the file to which the data will be exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        format = 'cypher-shell' :: STRING,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'NONE' :: ['NONE', 'BYTES', 'GZIP', 'BZIP2', 'DEFLATE', 'BLOCK_LZ4', 'FRAMED_SNAPPY'],\n        charset = 'UTF_8' :: STRING,\n        source :: MAP,\n        target :: MAP,\n        useTypes :: BOOLEAN,\n        caption :: LIST<STRING>\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.export.graphml.graph(graph :: MAP, file :: STRING, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
-  "name" : "apoc.export.graphml.graph",
-  "description" : "Exports the given graph to the provided GraphML file.",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data was exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "source",
-    "description" : "A summary of the exported data.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format the file is exported in.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of exported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of exported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of exported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the export.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "Whether the export ran successfully.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "data",
-    "description" : "The data returned by the export.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "graph",
-    "description" : "The graph to export.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "file",
-    "description" : "The name of the file to which the data will be exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        format = 'cypher-shell' :: STRING,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'NONE' :: ['NONE', 'BYTES', 'GZIP', 'BZIP2', 'DEFLATE', 'BLOCK_LZ4', 'FRAMED_SNAPPY'],\n        charset = 'UTF_8' :: STRING,\n        source :: MAP,\n        target :: MAP,\n        useTypes :: BOOLEAN,\n        caption :: LIST<STRING>\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.export.graphml.query(statement :: STRING, file :: STRING, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
-  "name" : "apoc.export.graphml.query",
-  "description" : "Exports the given `NODE` and `RELATIONSHIP` values from the Cypher statement to the provided GraphML file.",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data was exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "source",
-    "description" : "A summary of the exported data.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format the file is exported in.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of exported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of exported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of exported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the export.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "Whether the export ran successfully.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "data",
-    "description" : "The data returned by the export.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "statement",
-    "description" : "The query used to collect the data for export.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "file",
-    "description" : "The name of the file to which the data will be exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{\n        stream = false :: BOOLEAN,\n        format = 'cypher-shell' :: STRING,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'NONE' :: ['NONE', 'BYTES', 'GZIP', 'BZIP2', 'DEFLATE', 'BLOCK_LZ4', 'FRAMED_SNAPPY'],\n        charset = 'UTF_8' :: STRING,\n        source :: MAP,\n        target :: MAP,\n        useTypes :: BOOLEAN,\n        caption :: LIST<STRING>,\n        nodesOfRelationships = false :: BOOLEAN\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.export.json.all(file :: STRING, config = {} :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
-  "name" : "apoc.export.json.all",
-  "description" : "Exports the full database to the provided JSON file.",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data was exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "source",
-    "description" : "A summary of the exported data.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format the file is exported in.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of exported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of exported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of exported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the export.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "Whether the export ran successfully.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "data",
-    "description" : "The data returned by the export.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data will be exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description":"{\n        stream = false :: BOOLEAN,\n        writeNodeProperties = true :: BOOLEAN,\n        writeRelationshipProperties = writeNodeProperties :: BOOLEAN,\n        jsonFormat = 'JSON_LINES' :: STRING,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.export.json.data(nodes :: LIST<NODE>, rels :: LIST<RELATIONSHIP>, file :: STRING, config = {} :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
-  "name" : "apoc.export.json.data",
-  "description" : "Exports the given `NODE` and `RELATIONSHIP` values to the provided JSON file.",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data was exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "source",
-    "description" : "A summary of the exported data.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format the file is exported in.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of exported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of exported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of exported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the export.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "Whether the export ran successfully.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "data",
-    "description" : "The data returned by the export.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "A list of nodes to export.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "rels",
-    "description" : "A list of relationships to export.",
-    "isDeprecated" : false,
-    "type" : "LIST<RELATIONSHIP>"
-  }, {
-    "name" : "file",
-    "description" : "The name of the file to which the data will be exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description":"{\n        stream = false :: BOOLEAN,\n        writeNodeProperties = true :: BOOLEAN,\n        writeRelationshipProperties = writeNodeProperties :: BOOLEAN,\n        jsonFormat = 'JSON_LINES' :: STRING,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.export.json.graph(graph :: MAP, file :: STRING, config = {} :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
-  "name" : "apoc.export.json.graph",
-  "description" : "Exports the given graph to the provided JSON file.",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data was exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "source",
-    "description" : "A summary of the exported data.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format the file is exported in.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of exported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of exported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of exported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the export.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "Whether the export ran successfully.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "data",
-    "description" : "The data returned by the export.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "graph",
-    "description" : "The graph to export.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "file",
-    "description" : "The name of the file to which the data will be exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description":"{\n        stream = false :: BOOLEAN,\n        writeNodeProperties = true :: BOOLEAN,\n        writeRelationshipProperties = writeNodeProperties :: BOOLEAN,\n        jsonFormat = 'JSON_LINES' :: STRING,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.export.json.query(statement :: STRING, file :: STRING, config = {} :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
-  "name" : "apoc.export.json.query",
-  "description" : "Exports the results from the Cypher statement to the provided JSON file.",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file to which the data was exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "source",
-    "description" : "A summary of the exported data.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format the file is exported in.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of exported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of exported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of exported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the export.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the export was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "Whether the export ran successfully.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "data",
-    "description" : "The data returned by the export.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "statement",
-    "description" : "The query used to collect the data for export.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "file",
-    "description" : "The name of the file to which the data will be exported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description":"{\n        stream = false :: BOOLEAN,\n        writeNodeProperties = true :: BOOLEAN,\n        writeRelationshipProperties = writeNodeProperties :: BOOLEAN,\n        jsonFormat = 'JSON_LINES' :: STRING,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.graph.from(data :: ANY, name :: STRING, props :: MAP) :: (graph :: MAP)",
-  "name" : "apoc.graph.from",
-  "description" : "Generates a virtual sub-graph by extracting all of the `NODE` and `RELATIONSHIP` values from the given data.",
-  "returnDescription" : [ {
-    "name" : "graph",
-    "description" : "The resulting graph.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "data",
-    "description" : "An object to extract nodes and relationships from. It can be of type; NODE | RELATIONSHIP | PATH | LIST<ANY>.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "name",
-    "description" : "The name of the resulting graph.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "props",
-    "description" : "The properties to be present in the resulting graph.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.graph.fromCypher(statement :: STRING, params :: MAP, name :: STRING, props :: MAP) :: (graph :: MAP)",
-  "name" : "apoc.graph.fromCypher",
-  "description" : "Generates a virtual sub-graph by extracting all of the `NODE` and `RELATIONSHIP` values from the data returned by the given Cypher statement.",
-  "returnDescription" : [ {
-    "name" : "graph",
-    "description" : "The resulting graph.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "statement",
-    "description" : "The Cypher statement to create the graph from.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "params",
-    "description" : "The parameters for the given Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "name",
-    "description" : "The name of the resulting graph.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "props",
-    "description" : "The properties to include in the resulting graph.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.graph.fromDB(name :: STRING, props :: MAP) :: (graph :: MAP)",
-  "name" : "apoc.graph.fromDB",
-  "description" : "Generates a virtual sub-graph by extracting all of the `NODE` and `RELATIONSHIP` values from the data returned by the given database.",
-  "returnDescription" : [ {
-    "name" : "graph",
-    "description" : "The resulting graph.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "name",
-    "description" : "The name of the resulting graph.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "props",
-    "description" : "The properties to be present in the resulting graph.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.graph.fromData(nodes :: LIST<NODE>, rels :: LIST<RELATIONSHIP>, name :: STRING, props :: MAP) :: (graph :: MAP)",
-  "name" : "apoc.graph.fromData",
-  "description" : "Generates a virtual sub-graph by extracting all of the `NODE` and `RELATIONSHIP` values from the given data.",
-  "returnDescription" : [ {
-    "name" : "graph",
-    "description" : "The resulting graph.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The nodes to include in the resulting graph.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "rels",
-    "description" : "The relationship to include in the resulting graph.",
-    "isDeprecated" : false,
-    "type" : "LIST<RELATIONSHIP>"
-  }, {
-    "name" : "name",
-    "description" : "The name of the resulting graph.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "props",
-    "description" : "The properties to include in the resulting graph.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.graph.fromDocument(json :: ANY, config = {} :: MAP) :: (graph :: MAP)",
-  "name" : "apoc.graph.fromDocument",
-  "description" : "Generates a virtual sub-graph by extracting all of the `NODE` and `RELATIONSHIP` values from the data returned by the given JSON file.",
-  "returnDescription" : [ {
-    "name" : "graph",
-    "description" : "The resulting graph.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "json",
-    "description" : "A JSON object to generate a graph from.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "config",
-    "description" : "{\n        write = false :: BOOLEAN,\n        labelField = 'type' :: STRING.\n        idField = 'id' :: STRING,\n        generateID = true :: BOOLEAN,\n        defaultLabel = '' :: STRING,\n        skipValidation = false :: BOOLEAN,\n        mappings = {} :: MAP\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.graph.fromPath(path :: PATH, name :: STRING, props :: MAP) :: (graph :: MAP)",
-  "name" : "apoc.graph.fromPath",
-  "description" : "Generates a virtual sub-graph by extracting all of the `NODE` and `RELATIONSHIP` values from the data returned by the given `PATH`.",
-  "returnDescription" : [ {
-    "name" : "graph",
-    "description" : "The resulting graph.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "path",
-    "description" : "A path to extract the nodes and relationships from.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  }, {
-    "name" : "name",
-    "description" : "The name to give the resulting graph.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "props",
-    "description" : "The properties to include in the resulting graph.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.graph.fromPaths(paths :: LIST<PATH>, name :: STRING, props :: MAP) :: (graph :: MAP)",
-  "name" : "apoc.graph.fromPaths",
-  "description" : "Generates a virtual sub-graph by extracting all of the `NODE` and `RELATIONSHIP` values from the data returned by the given `PATH` values.",
-  "returnDescription" : [ {
-    "name" : "graph",
-    "description" : "The resulting graph.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "paths",
-    "description" : "A list of paths to extract nodes and relationships from.",
-    "isDeprecated" : false,
-    "type" : "LIST<PATH>"
-  }, {
-    "name" : "name",
-    "description" : "The name of the resulting graph.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "props",
-    "description" : "The properties to include in the resulting graph.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.graph.validateDocument(json :: ANY, config = {} :: MAP) :: (row :: MAP)",
-  "name" : "apoc.graph.validateDocument",
-  "description" : "Validates the JSON file and returns the result of the validation.",
-  "returnDescription" : [ {
-    "name" : "row",
-    "description" : "The result of the validation.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "json",
-    "description" : "The JSON object to validate.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "config",
-    "description" : "{\n        write = false :: BOOLEAN,\n        labelField = 'type' :: STRING.\n        idField = 'id' :: STRING,\n        generateID = true :: BOOLEAN,\n        defaultLabel = '' :: STRING,\n        skipValidation = false :: BOOLEAN,\n        mappings = {} :: MAP\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.help(proc :: STRING) :: (type :: STRING, name :: STRING, text :: STRING, signature :: STRING, roles :: LIST<STRING>, writes :: BOOLEAN, core :: BOOLEAN, isDeprecated :: BOOLEAN)",
-  "name" : "apoc.help",
-  "description" : "Returns descriptions of the available APOC procedures and functions. If a keyword is provided, it will return only those procedures and functions that have the keyword in their name.",
-  "returnDescription" : [ {
-    "name" : "type",
-    "description" : "Whether it is a function or a procedure.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "name",
-    "description" : "The name of the function or procedure.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "text",
-    "description" : "The description of the function or procedure.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "signature",
-    "description" : "The signature of the function or procedure.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "roles",
-    "description" : "This value is always null.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "writes",
-    "description" : "This value is always null.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "core",
-    "description" : "If the function or procedure belongs to APOC Core.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "isDeprecated",
-    "description" : "If the function or procedure is deprecated.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "proc",
-    "description" : "A keyword to filter the results by.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.import.csv(nodes :: LIST<MAP>, rels :: LIST<MAP>, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
-  "name" : "apoc.import.csv",
-  "description" : "Imports `NODE` and `RELATIONSHIP` values with the given labels and types from the provided CSV file.",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file from which the data was imported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "source",
-    "description" : "The source of the imported data: \"file\", \"binary\" or \"file/binary\".",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format of the file: [\"csv\", \"graphml\", \"json\"].",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of imported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of imported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of imported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the import.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the import was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the import was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "Whether the import ran successfully.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "data",
-    "description" : "The data returned by the import.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "List of map values of where to import the node values from; { fileName :: STRING, data :: BYTEARRAY, labels :: LIST<STRING> }.",
-    "isDeprecated" : false,
-    "type" : "LIST<MAP>"
-  }, {
-    "name" : "rels",
-    "description" : "List of map values specifying where to import relationship values from: { fileName :: STRING, data :: BYTEARRAY, type :: STRING }.",
-    "isDeprecated" : false,
-    "type" : "LIST<MAP>"
-  }, {
-    "name" : "config",
-    "description" : "{\n    delimiter = \",\" :: STRING,\n    arrayDelimiter = \";\" :: STRING,\n    ignoreDuplicateNodes = false :: BOOLEAN,\n    quotationCharacter = \"\"\" :: STRING,\n    stringIds = true :: BOOLEAN,\n    skipLines = 1 :: INTEGER,\n    ignoreBlankString = false :: BOOLEAN,\n    ignoreEmptyCellArray = false :: BOOLEAN,\n    compression = \"NONE\" :: [\"NONE\", \"BYTES\", \"GZIP\", \"BZIP2\", \"DEFLATE\", \"BLOCK_LZ4\", \"FRAMED_SNAPPY\"],\n    charset = \"UTF-8\" :: STRING,\n    batchSize = 2000 :: INTEGER\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.import.graphml(urlOrBinaryFile :: ANY, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
-  "name" : "apoc.import.graphml",
-  "description" : "Imports a graph from the provided GraphML file.",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file from which the data was imported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "source",
-    "description" : "The source of the imported data: \"file\", \"binary\" or \"file/binary\".",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format of the file: [\"csv\", \"graphml\", \"json\"].",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of imported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of imported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of imported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the import.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the import was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the import was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "Whether the import ran successfully.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "data",
-    "description" : "The data returned by the import.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "urlOrBinaryFile",
-    "description" : "The name of the file or binary data to import the data from.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "config",
-    "description" : "{\n    readLabels = false :: BOOLEAN,\n    defaultRelationshipType = \"RELATED\" :: STRING,\n    storeNodeIds = false :: BOOLEAN,\n    batchSize = 20000 :: INTEGER,\n    compression = \"NONE\" :: [\"NONE\", \"BYTES\", \"GZIP\", \"BZIP2\", \"DEFLATE\", \"BLOCK_LZ4\", \"FRAMED_SNAPPY\"],\n    source = {} :: MAP,\n    target = {} :: MAP\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.import.json(urlOrBinaryFile :: ANY, config = {} :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
-  "name" : "apoc.import.json",
-  "description" : "Imports a graph from the provided JSON file.",
-  "returnDescription" : [ {
-    "name" : "file",
-    "description" : "The name of the file from which the data was imported.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "source",
-    "description" : "The source of the imported data: \"file\", \"binary\" or \"file/binary\".",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "format",
-    "description" : "The format of the file: [\"csv\", \"graphml\", \"json\"].",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The number of imported nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relationships",
-    "description" : "The number of imported relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "properties",
-    "description" : "The number of imported properties.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "time",
-    "description" : "The duration of the import.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rows",
-    "description" : "The number of rows returned.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchSize",
-    "description" : "The size of the batches the import was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batches",
-    "description" : "The number of batches the import was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "Whether the import ran successfully.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "data",
-    "description" : "The data returned by the import.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "urlOrBinaryFile",
-    "description" : "The name of the file or binary data to import the data from.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "config",
-    "description" : "{\n    unwindBatchSize = 5000 :: INTEGER,\n    txBatchSize = 5000 :: INTEGER,\n    importIdName = \"neo4jImportId\" :: STRING,\n    nodePropertyMappings = {} :: MAP,\n    relPropertyMappings = {} :: MAP,\n    compression = \"NONE\" :: [\"NONE\", \"BYTES\", \"GZIP\", \"BZIP2\", \"DEFLATE\", \"BLOCK_LZ4\", \"FRAMED_SNAPPY\"],\n    cleanup = false :: BOOLEAN,\n    nodePropFilter = {} :: MAP,\n    relPropFilter = {} :: MAP\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.import.xml(urlOrBinary :: ANY, config = {} :: MAP) :: (node :: NODE)",
-  "name" : "apoc.import.xml",
-  "description" : "Imports a graph from the provided XML file.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "An imported node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "urlOrBinary",
-    "description" : "The name of the file or binary data to import the data from.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "config",
-    "description" : "{\n    connectCharacters = false :: BOOLEAN,\n    filterLeadingWhitespace = false :: BOOLEAN,\n    delimiter = \" \" :: STRING,\n    label :: STRING,\n    relType :: STRING,\n    charactersForTag :: MAP\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.load.json(urlOrKeyOrBinary :: ANY, path =  :: STRING, config = {} :: MAP) :: (value :: MAP)",
-  "name" : "apoc.load.json",
-  "description" : "Imports JSON file as a stream of values if the given JSON file is a `LIST<ANY>`.\nIf the given JSON file is a `MAP`, this procedure imports a single value instead.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "A map of data loaded from the given file.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "urlOrKeyOrBinary",
-    "description" : "The name of the file or binary data to import the data from.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "path",
-    "description" : "A JSON path expression used to extract a certain part from the list.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=, type=STRING}",
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{\n    failOnError = true :: BOOLEAN,\n    pathOptions :: LIST<STRING>,\n    compression = \"NONE\" :: [\"NONE\", \"BYTES\", \"GZIP\", \"BZIP2\", \"DEFLATE\", \"BLOCK_LZ4\", \"FRAMED_SNAPPY\"]\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.load.jsonArray(url :: STRING, path =  :: STRING, config = {} :: MAP) :: (value :: ANY)",
-  "name" : "apoc.load.jsonArray",
-  "description" : "Loads array from a JSON URL (e.g. web-API) to then import the given JSON file as a stream of values.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "Data loaded from the given file.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "url",
-    "description" : "The path to the JSON file.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "path",
-    "description" : "A JSON path expression used to extract a certain part from the list.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=, type=STRING}",
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{\n    failOnError = true :: BOOLEAN,\n    pathOptions :: LIST<STRING>,\n    compression = \"NONE\" :: [\"NONE\", \"BYTES\", \"GZIP\", \"BZIP2\"\", \"DEFLATE\", \"BLOCK_LZ4\", \"FRAMED_SNAPPY\"]\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.load.xml(urlOrBinary :: ANY, path = / :: STRING, config = {} :: MAP, simple = false :: BOOLEAN) :: (value :: MAP)",
-  "name" : "apoc.load.xml",
-  "description" : "Loads a single nested `MAP` from an XML URL (e.g. web-API).",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "A map of data loaded from the given file.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "urlOrBinary",
-    "description" : "The name of the file or binary data to import the data from.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "path",
-    "description" : "An xPath expression to select nodes from the given XML document.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=/, type=STRING}",
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{\n    failOnError = true :: BOOLEAN,\n    headers = {} :: MAP,\n    compression = \"NONE\" :: [\"NONE\", \"BYTES\", \"GZIP\", \"BZIP2\", \"DEFLATE\", \"BLOCK_LZ4\", \"FRAMED_SNAPPY\"]\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  }, {
-    "name" : "simple",
-    "description" : "Whether or not to parse the given XML in simple mode.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=false, type=BOOLEAN}",
-    "type" : "BOOLEAN"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.lock.all(nodes :: LIST<NODE>, rels :: LIST<RELATIONSHIP>)",
-  "name" : "apoc.lock.all",
-  "description" : "Acquires a write lock on the given `NODE` and `RELATIONSHIP` values.",
-  "returnDescription" : [ ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The list of nodes to acquire a write lock on.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "rels",
-    "description" : "The list of relationships to acquire a write lock on.",
-    "isDeprecated" : false,
-    "type" : "LIST<RELATIONSHIP>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.lock.nodes(nodes :: LIST<NODE>)",
-  "name" : "apoc.lock.nodes",
-  "description" : "Acquires a write lock on the given `NODE` values.",
-  "returnDescription" : [ ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The list of nodes to acquire a write lock on.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.lock.read.nodes(nodes :: LIST<NODE>)",
-  "name" : "apoc.lock.read.nodes",
-  "description" : "Acquires a read lock on the given `NODE` values.",
-  "returnDescription" : [ ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The list of nodes to acquire a read lock on.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.lock.read.rels(rels :: LIST<RELATIONSHIP>)",
-  "name" : "apoc.lock.read.rels",
-  "description" : "Acquires a read lock on the given `RELATIONSHIP` values.",
-  "returnDescription" : [ ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "rels",
-    "description" : "The list of relationships to acquire a read lock on.",
-    "isDeprecated" : false,
-    "type" : "LIST<RELATIONSHIP>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.lock.rels(rels :: LIST<RELATIONSHIP>)",
-  "name" : "apoc.lock.rels",
-  "description" : "Acquires a write lock on the given `RELATIONSHIP` values.",
-  "returnDescription" : [ ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "rels",
-    "description" : "The list of relationships to acquire a write lock on.",
-    "isDeprecated" : false,
-    "type" : "LIST<RELATIONSHIP>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.math.regr(label :: STRING, propertyY :: STRING, propertyX :: STRING) :: (r2 :: FLOAT, avgX :: FLOAT, avgY :: FLOAT, slope :: FLOAT)",
-  "name" : "apoc.math.regr",
-  "description" : "Returns the coefficient of determination (R-squared) for the values of propertyY and propertyX in the given label.",
-  "returnDescription" : [ {
-    "name" : "r2",
-    "description" : "The coefficient of determination.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "avgX",
-    "description" : "The average of the x values.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "avgY",
-    "description" : "The average of the y values.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "slope",
-    "description" : "The calculated slope.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "label",
-    "description" : "The label of the nodes to perform the regression on.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "propertyY",
-    "description" : "The name of the y property.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "propertyX",
-    "description" : "The name of the x property.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.merge.node(labels :: LIST<STRING>, identProps :: MAP, onCreateProps = {} :: MAP, onMatchProps = {} :: MAP) :: (node :: NODE)",
-  "name" : "apoc.merge.node",
-  "description" : "Merges the given `NODE` values with the given dynamic labels.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "The updated node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "labels",
-    "description" : "The list of labels used for the generated MERGE statement.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "identProps",
-    "description" : "Properties on the node that are always merged.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "onCreateProps",
-    "description" : "Properties that are merged when a node is created.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  }, {
-    "name" : "onMatchProps",
-    "description" : "Properties that are merged when a node is matched.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.merge.node.eager(labels :: LIST<STRING>, identProps :: MAP, onCreateProps = {} :: MAP, onMatchProps = {} :: MAP) :: (node :: NODE)",
-  "name" : "apoc.merge.node.eager",
-  "description" : "Merges the given `NODE` values with the given dynamic labels eagerly.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "The updated node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "labels",
-    "description" : "The list of labels used for the generated MERGE statement.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "identProps",
-    "description" : "Properties on the node that are always merged.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "onCreateProps",
-    "description" : "Properties that are merged when a node is created.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  }, {
-    "name" : "onMatchProps",
-    "description" : "Properties that are merged when a node is matched.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.merge.nodeWithStats(labels :: LIST<STRING>, identProps :: MAP, onCreateProps = {} :: MAP, onMatchProps = {} :: MAP) :: (stats :: MAP, node :: NODE)",
-  "name" : "apoc.merge.nodeWithStats",
-  "description" : "Merges the given `NODE` values with the given dynamic labels. Provides queryStatistics in the result.",
-  "returnDescription" : [ {
-    "name" : "stats",
-    "description" : "The returned query statistics.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "node",
-    "description" : "The updated node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "labels",
-    "description" : "The list of labels used for the generated MERGE statement.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "identProps",
-    "description" : "Properties on the node that are always merged.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "onCreateProps",
-    "description" : "Properties that are merged when a node is created.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  }, {
-    "name" : "onMatchProps",
-    "description" : "Properties that are merged when a node is matched.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.merge.nodeWithStats.eager(labels :: LIST<STRING>, identProps :: MAP, onCreateProps = {} :: MAP, onMatchProps = {} :: MAP) :: (stats :: MAP, node :: NODE)",
-  "name" : "apoc.merge.nodeWithStats.eager",
-  "description" : "Merges the given `NODE` values with the given dynamic labels eagerly. Provides queryStatistics in the result.",
-  "returnDescription" : [ {
-    "name" : "stats",
-    "description" : "The returned query statistics.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "node",
-    "description" : "The updated node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "labels",
-    "description" : "The list of labels used for the generated MERGE statement.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "identProps",
-    "description" : "Properties on the node that are always merged.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "onCreateProps",
-    "description" : "Properties that are merged when a node is created.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  }, {
-    "name" : "onMatchProps",
-    "description" : "Properties that are merged when a node is matched.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.merge.relationship(startNode :: NODE, relType :: STRING, identProps :: MAP, onCreateProps :: MAP, endNode :: NODE, onMatchProps = {} :: MAP) :: (rel :: RELATIONSHIP)",
-  "name" : "apoc.merge.relationship",
-  "description" : "Merges the given `RELATIONSHIP` values with the given dynamic types/properties.",
-  "returnDescription" : [ {
-    "name" : "rel",
-    "description" : "The updated relationship.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "startNode",
-    "description" : "The start node of the relationship.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "relType",
-    "description" : "The type of the relationship.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "identProps",
-    "description" : "Properties on the relationship that are always merged.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "onCreateProps",
-    "description" : "Properties that are merged when a relationship is created.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "endNode",
-    "description" : "The end node of the relationship.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "onMatchProps",
-    "description" : "Properties that are merged when a relationship is matched.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.merge.relationship.eager(startNode :: NODE, relType :: STRING, identProps :: MAP, onCreateProps :: MAP, endNode :: NODE, onMatchProps = {} :: MAP) :: (rel :: RELATIONSHIP)",
-  "name" : "apoc.merge.relationship.eager",
-  "description" : "Merges the given `RELATIONSHIP` values with the given dynamic types/properties eagerly.",
-  "returnDescription" : [ {
-    "name" : "rel",
-    "description" : "The updated relationship.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "startNode",
-    "description" : "The start node of the relationship.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "relType",
-    "description" : "The type of the relationship.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "identProps",
-    "description" : "Properties on the relationship that are always merged.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "onCreateProps",
-    "description" : "Properties that are merged when a relationship is created.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "endNode",
-    "description" : "The end node of the relationship.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "onMatchProps",
-    "description" : "Properties that are merged when a relationship is matched.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.merge.relationshipWithStats(startNode :: NODE, relType :: STRING, identProps :: MAP, onCreateProps :: MAP, endNode :: NODE, onMatchProps = {} :: MAP) :: (stats :: MAP, rel :: RELATIONSHIP)",
-  "name" : "apoc.merge.relationshipWithStats",
-  "description" : "Merges the given `RELATIONSHIP` values with the given dynamic types/properties. Provides queryStatistics in the result.",
-  "returnDescription" : [ {
-    "name" : "stats",
-    "description" : "The returned query statistics.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "rel",
-    "description" : "The updated relationship.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "startNode",
-    "description" : "The start node of the relationship.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "relType",
-    "description" : "The type of the relationship.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "identProps",
-    "description" : "Properties on the relationship that are always merged.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "onCreateProps",
-    "description" : "Properties that are merged when a relationship is created.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "endNode",
-    "description" : "The end node of the relationship.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "onMatchProps",
-    "description" : "Properties that are merged when a relationship is matched.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.merge.relationshipWithStats.eager(startNode :: NODE, relType :: STRING, identProps :: MAP, onCreateProps :: MAP, endNode :: NODE, onMatchProps = {} :: MAP) :: (stats :: MAP, rel :: RELATIONSHIP)",
-  "name" : "apoc.merge.relationshipWithStats.eager",
-  "description" : "Merges the given `RELATIONSHIP` values with the given dynamic types/properties eagerly. Provides queryStatistics in the result.",
-  "returnDescription" : [ {
-    "name" : "stats",
-    "description" : "The returned query statistics.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "rel",
-    "description" : "The updated relationship.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "startNode",
-    "description" : "The start node of the relationship.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "relType",
-    "description" : "The type of the relationship.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "identProps",
-    "description" : "Properties on the relationship that are always merged.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "onCreateProps",
-    "description" : "Properties that are merged when a relationship is created.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "endNode",
-    "description" : "The end node of the relationship.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "onMatchProps",
-    "description" : "Properties that are merged when a relationship is matched.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.meta.data(config = {} :: MAP) :: (label :: STRING, property :: STRING, count :: INTEGER, unique :: BOOLEAN, index :: BOOLEAN, existence :: BOOLEAN, type :: STRING, array :: BOOLEAN, sample :: LIST<ANY>, left :: INTEGER, right :: INTEGER, other :: LIST<STRING>, otherLabels :: LIST<STRING>, elementType :: STRING)",
-  "name" : "apoc.meta.data",
-  "description" : "Examines the full graph and returns a table of metadata.",
-  "returnDescription" : [ {
-    "name" : "label",
-    "description" : "The label or type name.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "property",
-    "description" : "The property name.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "count",
-    "description" : "The count of seen values.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "unique",
-    "description" : "If all seen values are unique.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "index",
-    "description" : "If an index exists for this property.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "existence",
-    "description" : "If an existence constraint exists for this property.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "type",
-    "description" : "The type represented by this row.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "array",
-    "description" : "Indicates whether the property is an array. If the type column is \"RELATIONSHIP,\" this will be true if there is at least one node with two outgoing relationships of the type specified by the label or property column.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "sample",
-    "description" : "This is always null.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "left",
-    "description" : "The ratio (rounded down) of the count of outgoing relationships for a specific label and relationship type relative to the total count of those patterns.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "right",
-    "description" : "The ratio (rounded down) of the count of incoming relationships for a specific label and relationship type relative to the total count of those patterns.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "other",
-    "description" : "The labels of connect nodes.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "otherLabels",
-    "description" : "For uniqueness constraints, this field shows other labels present on nodes that also contain the uniqueness constraint.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "elementType",
-    "description" : "Whether this refers to a node or a relationship.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "config",
-    "description" : "Number of nodes to sample, setting sample to `-1` will remove sampling; { sample = 1000 :: INTEGER }",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.meta.data.of(graph :: ANY, config = {} :: MAP) :: (label :: STRING, property :: STRING, count :: INTEGER, unique :: BOOLEAN, index :: BOOLEAN, existence :: BOOLEAN, type :: STRING, array :: BOOLEAN, sample :: LIST<ANY>, left :: INTEGER, right :: INTEGER, other :: LIST<STRING>, otherLabels :: LIST<STRING>, elementType :: STRING)",
-  "name" : "apoc.meta.data.of",
-  "description" : "Examines the given sub-graph and returns a table of metadata.",
-  "returnDescription" : [ {
-    "name" : "label",
-    "description" : "The label or type name.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "property",
-    "description" : "The property name.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "count",
-    "description" : "The count of seen values.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "unique",
-    "description" : "If all seen values are unique.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "index",
-    "description" : "If an index exists for this property.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "existence",
-    "description" : "If an existence constraint exists for this property.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "type",
-    "description" : "The type represented by this row.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "array",
-    "description" : "Indicates whether the property is an array. If the type column is \"RELATIONSHIP,\" this will be true if there is at least one node with two outgoing relationships of the type specified by the label or property column.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "sample",
-    "description" : "This is always null.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "left",
-    "description" : "The ratio (rounded down) of the count of outgoing relationships for a specific label and relationship type relative to the total count of those patterns.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "right",
-    "description" : "The ratio (rounded down) of the count of incoming relationships for a specific label and relationship type relative to the total count of those patterns.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "other",
-    "description" : "The labels of connect nodes.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "otherLabels",
-    "description" : "For uniqueness constraints, this field shows other labels present on nodes that also contain the uniqueness constraint.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "elementType",
-    "description" : "Whether this refers to a node or a relationship.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "graph",
-    "description" : "The graph to extract metadata from.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "config",
-    "description" : "Number of nodes to sample, setting sample to `-1` will remove sampling; { sample = 1000 :: INTEGER }",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.meta.graph(config = {} :: MAP) :: (nodes :: LIST<NODE>, relationships :: LIST<RELATIONSHIP>)",
-  "name" : "apoc.meta.graph",
-  "description" : "Examines the full graph and returns a meta-graph.",
-  "returnDescription" : [ {
-    "name" : "nodes",
-    "description" : "Nodes representing the meta data.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "relationships",
-    "description" : "Relationships representing the meta data.",
-    "isDeprecated" : false,
-    "type" : "LIST<RELATIONSHIP>"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "config",
-    "description" : "The number of nodes whose relationships are checked to remove false positives and the number of relationships to read per sampled node. A value of -1 will read all; { sample = 1 :: INTEGER, maxRels = -1 :: INTEGER }",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.meta.graph.of(graph = {} :: ANY, config = {} :: MAP) :: (nodes :: LIST<NODE>, relationships :: LIST<RELATIONSHIP>)",
-  "name" : "apoc.meta.graph.of",
-  "description" : "Examines the given sub-graph and returns a meta-graph.",
-  "returnDescription" : [ {
-    "name" : "nodes",
-    "description" : "Nodes representing the meta data.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "relationships",
-    "description" : "Relationships representing the meta data.",
-    "isDeprecated" : false,
-    "type" : "LIST<RELATIONSHIP>"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "graph",
-    "description" : "The graph to extract metadata from.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=ANY}",
-    "type" : "ANY"
-  }, {
-    "name" : "config",
-    "description" : "The number of nodes whose relationships are checked to remove false positives and the number of relationships to read per sampled node. A value of -1 will read all; { sample = 1 :: INTEGER, maxRels = -1 :: INTEGER, addRelationshipsBetweenNodes = true :: BOOLEAN }",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.meta.graphSample(config = {} :: MAP) :: (nodes :: LIST<NODE>, relationships :: LIST<RELATIONSHIP>)",
-  "name" : "apoc.meta.graphSample",
-  "description" : "Examines the full graph and returns a meta-graph.\nUnlike `apoc.meta.graph`, this procedure does not filter away non-existing paths.",
-  "returnDescription" : [ {
-    "name" : "nodes",
-    "description" : "Nodes representing the meta data.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "relationships",
-    "description" : "Relationships representing the meta data.",
-    "isDeprecated" : false,
-    "type" : "LIST<RELATIONSHIP>"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "config",
-    "description" : "Empty map (deprecated).",
-    "isDeprecated" : true,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.meta.nodeTypeProperties(config = {} :: MAP) :: (nodeType :: STRING, nodeLabels :: LIST<STRING>, propertyName :: STRING, propertyTypes :: LIST<STRING>, mandatory :: BOOLEAN, propertyObservations :: INTEGER, totalObservations :: INTEGER)",
-  "name" : "apoc.meta.nodeTypeProperties",
-  "description" : "Examines the full graph and returns a table of metadata with information about the `NODE` values therein.",
-  "returnDescription" : [ {
-    "name" : "nodeType",
-    "description" : "The type of the node.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodeLabels",
-    "description" : "The labels on the node.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "propertyName",
-    "description" : "The name of the property.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "propertyTypes",
-    "description" : "The types this property has.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "mandatory",
-    "description" : "Whether or not this property exists on all nodes of the given type.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "propertyObservations",
-    "description" : "The number of times this property was observed.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "totalObservations",
-    "description" : "The number of times the label was seen.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "config",
-    "description" : "{\n        includeLabels = [] :: LIST<STRING>,\n        includeRels = [] :: LIST<STRING>,\n        excludeLabels = [] :: LIST<STRING>,\n        excludeRels = [] :: LIST<STRING>,\n        sample = 1000 :: INTEGER,\n        maxRels = 100 :: INTEGER\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.meta.relTypeProperties(config = {} :: MAP) :: (relType :: STRING, sourceNodeLabels :: LIST<STRING>, targetNodeLabels :: LIST<STRING>, propertyName :: STRING, propertyTypes :: LIST<STRING>, mandatory :: BOOLEAN, propertyObservations :: INTEGER, totalObservations :: INTEGER)",
-  "name" : "apoc.meta.relTypeProperties",
-  "description" : "Examines the full graph and returns a table of metadata with information about the `RELATIONSHIP` values therein.",
-  "returnDescription" : [ {
-    "name" : "relType",
-    "description" : "The type of the relationship.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "sourceNodeLabels",
-    "description" : "The labels belonging to the start node.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "targetNodeLabels",
-    "description" : "The labels belonging to the end node.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "propertyName",
-    "description" : "The name of the property.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "propertyTypes",
-    "description" : "The types this property has.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "mandatory",
-    "description" : "Whether or not this property exists on all nodes of the given type.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "propertyObservations",
-    "description" : "The number of times this property was observed.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "totalObservations",
-    "description" : "The number of times the label was seen.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "config",
-    "description" : "{\n        includeLabels = [] :: LIST<STRING>,\n        includeRels = [] :: LIST<STRING>,\n        excludeLabels = [] :: LIST<STRING>,\n        excludeRels = [] :: LIST<STRING>,\n        sample = 1000 :: INTEGER,\n        maxRels = 100 :: INTEGER\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.meta.schema(config = {} :: MAP) :: (value :: MAP)",
-  "name" : "apoc.meta.schema",
-  "description" : "Examines the given sub-graph and returns metadata as a `MAP`.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "Meta information represented as a map.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "config",
-    "description" : "Number of nodes to sample, setting sample to `-1` will remove sampling; { sample = 1000 :: INTEGER }",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.meta.stats() :: (labelCount :: INTEGER, relTypeCount :: INTEGER, propertyKeyCount :: INTEGER, nodeCount :: INTEGER, relCount :: INTEGER, labels :: MAP, relTypes :: MAP, relTypesCount :: MAP, stats :: MAP)",
-  "name" : "apoc.meta.stats",
-  "description" : "Returns the metadata stored in the transactional database statistics.",
-  "returnDescription" : [ {
-    "name" : "labelCount",
-    "description" : "The total number of distinct node labels.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relTypeCount",
-    "description" : "The total number of distinct relationship types.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "propertyKeyCount",
-    "description" : "The count of property keys.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "nodeCount",
-    "description" : "The total number of nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "relCount",
-    "description" : "The total number of relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "labels",
-    "description" : "A map of labels to their count.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "relTypes",
-    "description" : "A map of relationship types per start or end node label.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "relTypesCount",
-    "description" : "A map of relationship types to their count.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "stats",
-    "description" : "A map containing all the given return fields from this procedure.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.meta.subGraph(config :: MAP) :: (nodes :: LIST<NODE>, relationships :: LIST<RELATIONSHIP>)",
-  "name" : "apoc.meta.subGraph",
-  "description" : "Examines the given sub-graph and returns a meta-graph.",
-  "returnDescription" : [ {
-    "name" : "nodes",
-    "description" : "Nodes representing the meta data.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "relationships",
-    "description" : "Relationships representing the meta data.",
-    "isDeprecated" : false,
-    "type" : "LIST<RELATIONSHIP>"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "config",
-    "description" : "{\n    excludeLabels :: LIST<STRING>,\n    includeLabels :: LIST<STRING>,\n    includeRels :: LIST<STRING>,\n    maxRels = -1 :: INTEGER,\n    sample = 1 :: INTEGER\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.neighbors.athop(node :: NODE, relTypes =  :: STRING, distance = 1 :: INTEGER) :: (node :: NODE)",
-  "name" : "apoc.neighbors.athop",
-  "description" : "Returns all `NODE` values connected by the given `RELATIONSHIP` types at the specified distance.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "A neighboring node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "node",
-    "description" : "The starting node for the algorithm.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "relTypes",
-    "description" : "A list of relationship types to follow. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=, type=STRING}",
-    "type" : "STRING"
-  }, {
-    "name" : "distance",
-    "description" : "The number of hops to take.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=1, type=INTEGER}",
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.neighbors.athop.count(node :: NODE, relTypes =  :: STRING, distance = 1 :: INTEGER) :: (value :: INTEGER)",
-  "name" : "apoc.neighbors.athop.count",
-  "description" : "Returns the count of all `NODE` values connected by the given `RELATIONSHIP` types at the specified distance.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "The total count of neighboring nodes at the given hop distance.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "node",
-    "description" : "The starting node for the algorithm.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "relTypes",
-    "description" : "A list of relationship types to follow. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=, type=STRING}",
-    "type" : "STRING"
-  }, {
-    "name" : "distance",
-    "description" : "The number of hops to take.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=1, type=INTEGER}",
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.neighbors.byhop(node :: NODE, relTypes =  :: STRING, distance = 1 :: INTEGER) :: (nodes :: LIST<NODE>)",
-  "name" : "apoc.neighbors.byhop",
-  "description" : "Returns all `NODE` values connected by the given `RELATIONSHIP` types within the specified distance. Returns `LIST<NODE>` values, where each `PATH` of `NODE` values represents one row of the `LIST<NODE>` values.",
-  "returnDescription" : [ {
-    "name" : "nodes",
-    "description" : "A list of neighboring nodes at a distinct hop distance.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "node",
-    "description" : "The starting node for the algorithm.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "relTypes",
-    "description" : "A list of relationship types to follow. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=, type=STRING}",
-    "type" : "STRING"
-  }, {
-    "name" : "distance",
-    "description" : "The max number of hops to take.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=1, type=INTEGER}",
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.neighbors.byhop.count(node :: NODE, relTypes =  :: STRING, distance = 1 :: INTEGER) :: (value :: LIST<ANY>)",
-  "name" : "apoc.neighbors.byhop.count",
-  "description" : "Returns the count of all `NODE` values connected by the given `RELATIONSHIP` types within the specified distance.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "A list of neighbor counts for each distinct hop distance.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "node",
-    "description" : "The starting node for the algorithm.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "relTypes",
-    "description" : "A list of relationship types to follow. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=, type=STRING}",
-    "type" : "STRING"
-  }, {
-    "name" : "distance",
-    "description" : "The max number of hops to take.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=1, type=INTEGER}",
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.neighbors.tohop(node :: NODE, relTypes =  :: STRING, distance = 1 :: INTEGER) :: (node :: NODE)",
-  "name" : "apoc.neighbors.tohop",
-  "description" : "Returns all `NODE` values connected by the given `RELATIONSHIP` types within the specified distance.\n`NODE` values are returned individually for each row.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "A neighboring node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "node",
-    "description" : "The starting node for the algorithm.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "relTypes",
-    "description" : "A list of relationship types to follow. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=, type=STRING}",
-    "type" : "STRING"
-  }, {
-    "name" : "distance",
-    "description" : "The max number of hops to take.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=1, type=INTEGER}",
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.neighbors.tohop.count(node :: NODE, relTypes =  :: STRING, distance = 1 :: INTEGER) :: (value :: INTEGER)",
-  "name" : "apoc.neighbors.tohop.count",
-  "description" : "Returns the count of all `NODE` values connected by the given `RELATIONSHIP` values in the pattern within the specified distance.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "The total count of neighboring nodes within the given hop distance.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "node",
-    "description" : "The starting node for the algorithm.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "relTypes",
-    "description" : "A list of relationship types to follow. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=, type=STRING}",
-    "type" : "STRING"
-  }, {
-    "name" : "distance",
-    "description" : "The max number of hops to take.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=1, type=INTEGER}",
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.nodes.collapse(nodes :: LIST<NODE>, config = {} :: MAP) :: (from :: NODE, rel :: RELATIONSHIP, to :: NODE)",
-  "name" : "apoc.nodes.collapse",
-  "description" : "Merges `NODE` values together in the given `LIST<NODE>`.\nThe `NODE` values are then combined to become one `NODE`, with all labels of the previous `NODE` values attached to it, and all `RELATIONSHIP` values pointing to it.",
-  "returnDescription" : [ {
-    "name" : "from",
-    "description" : "The recently collapsed virtual node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "rel",
-    "description" : "A relationship connected to the collapsed node.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "to",
-    "description" : "A node connected to the other end of the relationship.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The list of node values to merge.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "config",
-    "description" : "{\n    mergeRels :: BOOLEAN,\n    selfRef :: BOOLEAN,\n    produceSelfRef = true :: BOOLEAN,\n    preserveExistingSelfRels = true :: BOOLEAN,\n    countMerge = true :: BOOLEAN,\n    collapsedLabel :: BOOLEAN,\n    singleElementAsArray = false :: BOOLEAN,\n    avoidDuplicates = false :: BOOLEAN,\n    relationshipSelectionStrategy = \"incoming\" :: [\"incoming\", \"outgoing\", \"merge\"]\n    properties :: [\"overwrite\", \"discard\", \"combine\"]\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.nodes.cycles(nodes :: LIST<NODE>, config = {} :: MAP) :: (path :: PATH)",
-  "name" : "apoc.nodes.cycles",
-  "description" : "Detects all `PATH` cycles in the given `LIST<NODE>`.\nThis procedure can be limited on `RELATIONSHIP` values as well.",
-  "returnDescription" : [ {
-    "name" : "path",
-    "description" : "A path containing a found cycle.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The list of nodes to check for path cycles.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "config",
-    "description" : "{\n    maxDepth :: INTEGER,\n    relTypes = [] :: LIST<STRING>\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.nodes.delete(nodes :: ANY, batchSize :: INTEGER) :: (value :: INTEGER)",
-  "name" : "apoc.nodes.delete",
-  "description" : "Deletes all `NODE` values with the given ids.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "The number of deleted nodes.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The nodes to be deleted. Nodes can be of type `STRING` (elementId()), `INTEGER` (id()), `NODE`, or `LIST<STRING | INTEGER | NODE>`.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "batchSize",
-    "description" : "The number of node values to delete in a single batch.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.nodes.get(nodes :: ANY) :: (node :: NODE)",
-  "name" : "apoc.nodes.get",
-  "description" : "Returns all `NODE` values with the given ids.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "A node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The nodes to be returned. Nodes can be of type `STRING` (elementId()), `INTEGER` (id()), `NODE`, or `LIST<STRING | INTEGER | NODE>`.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.nodes.group(labels :: LIST<STRING>, groupByProperties :: LIST<STRING>, aggregations = [{*=count}, {*=count}] :: LIST<MAP>, config = {} :: MAP) :: (nodes :: LIST<NODE>, relationships :: LIST<RELATIONSHIP>, node :: NODE, relationship :: RELATIONSHIP)",
-  "name" : "apoc.nodes.group",
-  "description" : "Allows for the aggregation of `NODE` values based on the given properties.\nThis procedure returns virtual `NODE` values.",
-  "returnDescription" : [ {
-    "name" : "nodes",
-    "description" : "A list of grouped nodes represented as virtual nodes.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "relationships",
-    "description" : "A list of grouped relationships represented as virtual relationships.",
-    "isDeprecated" : false,
-    "type" : "LIST<RELATIONSHIP>"
-  }, {
-    "name" : "node",
-    "description" : "The grouping node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "relationship",
-    "description" : "The grouping relationship.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "labels",
-    "description" : "The list of node labels to aggregate over. Use `['*']` to indicate all node labels should be looked at.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "groupByProperties",
-    "description" : "The property keys to group the nodes by.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "aggregations",
-    "description" : "The first map specifies the node properties to aggregate with their corresponding aggregation functions, while the second map specifies the relationship properties for aggregation.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=[{*=count}, {*=count}], type=LIST<MAP>}",
-    "type" : "LIST<MAP>"
-  }, {
-    "name" : "config",
-    "description" : "{\n    includeRels :: STRING | LIST<STRING>\n    excludeRels :: STRING | LIST<STRING>,\n    orphans = true :: BOOLEAN,\n    selfRels = true :: BOOLEAN,\n    limitNodes = -1 :: INTEGER,\n    limitRels = -1 :: INTEGER,\n    relsPerNode = -1 :: INTEGER,\n    filter :: MAP\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.nodes.link(nodes :: LIST<NODE>, type :: STRING, config = {} :: MAP)",
-  "name" : "apoc.nodes.link",
-  "description" : "Creates a linked list of the given `NODE` values connected by the given `RELATIONSHIP` type.",
-  "returnDescription" : [ ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The list of nodes to be linked.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "type",
-    "description" : "The relationship type name to link the nodes with.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{ avoidDuplicates = false :: BOOLEAN }",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.nodes.rels(rels :: ANY) :: (rel :: RELATIONSHIP)",
-  "name" : "apoc.nodes.rels",
-  "description" : "Returns all `RELATIONSHIP` values with the given ids.",
-  "returnDescription" : [ {
-    "name" : "rel",
-    "description" : "A relationship.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "rels",
-    "description" : "The relationships to be returned. Relationships can be of type `STRING` (elementId()), `INTEGER` (id()), `RELATIONSHIP`, or `LIST<STRING | INTEGER | RELATIONSHIP>",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.path.expand(startNode :: ANY, relFilter :: STRING, labelFilter :: STRING, minDepth :: INTEGER, maxDepth :: INTEGER) :: (path :: PATH)",
-  "name" : "apoc.path.expand",
-  "description" : "Returns `PATH` values expanded from the start `NODE` following the given `RELATIONSHIP` types from min-depth to max-depth.",
-  "returnDescription" : [ {
-    "name" : "path",
-    "description" : "The expanded path.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "startNode",
-    "description" : "The node to start the algorithm from. `startNode` can be of type `STRING` (elementId()), `INTEGER` (id()), `NODE`, or `LIST<STRING | INTEGER | NODE>`.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "relFilter",
-    "description" : "An allow list of types allowed on the returned relationships.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "labelFilter",
-    "description" : "An allow list of labels allowed on the returned nodes.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "minDepth",
-    "description" : "The minimum number of hops allowed in the returned paths.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "maxDepth",
-    "description" : "The maximum number of hops allowed in the returned paths.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.path.expandConfig(startNode :: ANY, config :: MAP) :: (path :: PATH)",
-  "name" : "apoc.path.expandConfig",
-  "description" : "Returns `PATH` values expanded from the start `NODE` with the given `RELATIONSHIP` types from min-depth to max-depth.",
-  "returnDescription" : [ {
-    "name" : "path",
-    "description" : "The expanded path.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "startNode",
-    "description" : "The node to start the algorithm from. `startNode` can be of type `STRING` (elementId()), `INTEGER` (id()), `NODE`, or `LIST<STRING | INTEGER | NODE>.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "config",
-    "description" : "{\n    minLevel = -1 :: INTEGER,\n    maxLevel = -1 :: INTEGER,\n    relationshipFilter :: STRING,\n    labelFilter :: STRING,\n    beginSequenceAtStart = true :: BOOLEAN,\n    uniqueness = \"RELATIONSHIP_PATH\" :: STRING,\n    bfs = true :: BOOLEAN,\n    filterStartNode = false :: BOOLEAN,\n    limit = -1 :: INTEGER,\n    optional = false :: BOOLEAN,\n    endNodes :: LIST<NODES>,\n    terminatorNodes:: LIST<NODES>,\n    allowlistNodes:: LIST<NODES>,\n    denylistNodes:: LIST<NODES>\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.path.spanningTree(startNode :: ANY, config :: MAP) :: (path :: PATH)",
-  "name" : "apoc.path.spanningTree",
-  "description" : "Returns spanning tree `PATH` values expanded from the start `NODE` following the given `RELATIONSHIP` types to max-depth.",
-  "returnDescription" : [ {
-    "name" : "path",
-    "description" : "A spanning tree path.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "startNode",
-    "description" : "The node to start the algorithm from. `startNode` can be of type `STRING` (elementId()), `INTEGER` (id()), `NODE`, or `LIST<STRING | INTEGER | NODE>.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "config",
-    "description" : "{\n    minLevel = -1 :: INTEGER,\n    maxLevel = -1 :: INTEGER,\n    relationshipFilter :: STRING,\n    labelFilter :: STRING,\n    beginSequenceAtStart = true :: BOOLEAN,\n    uniqueness = \"RELATIONSHIP_PATH\" :: STRING,\n    bfs = true :: BOOLEAN,\n    filterStartNode = false :: BOOLEAN,\n    limit = -1 :: INTEGER,\n    optional = false :: BOOLEAN,\n    endNodes :: LIST<NODES>,\n    terminatorNodes:: LIST<NODES>,\n    allowlistNodes:: LIST<NODES>,\n    denylistNodes:: LIST<NODES>\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.path.subgraphAll(startNode :: ANY, config :: MAP) :: (nodes :: LIST<NODE>, relationships :: LIST<RELATIONSHIP>)",
-  "name" : "apoc.path.subgraphAll",
-  "description" : "Returns the sub-graph reachable from the start `NODE` following the given `RELATIONSHIP` types to max-depth.",
-  "returnDescription" : [ {
-    "name" : "nodes",
-    "description" : "Nodes part of the returned subgraph.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "relationships",
-    "description" : "Relationships part of the returned subgraph.",
-    "isDeprecated" : false,
-    "type" : "LIST<RELATIONSHIP>"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "startNode",
-    "description" : "The node to start the algorithm from. `startNode` can be of type `STRING` (elementId()), `INTEGER` (id()), `NODE`, or `LIST<STRING | INTEGER | NODE>.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "config",
-    "description" : "{\n    minLevel = -1 :: INTEGER,\n    maxLevel = -1 :: INTEGER,\n    relationshipFilter :: STRING,\n    labelFilter :: STRING,\n    beginSequenceAtStart = true :: BOOLEAN,\n    uniqueness = \"RELATIONSHIP_PATH\" :: STRING,\n    bfs = true :: BOOLEAN,\n    filterStartNode = false :: BOOLEAN,\n    limit = -1 :: INTEGER,\n    optional = false :: BOOLEAN,\n    endNodes :: LIST<NODES>,\n    terminatorNodes:: LIST<NODES>,\n    allowlistNodes:: LIST<NODES>,\n    denylistNodes:: LIST<NODES>\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.path.subgraphNodes(startNode :: ANY, config :: MAP) :: (node :: NODE)",
-  "name" : "apoc.path.subgraphNodes",
-  "description" : "Returns the `NODE` values in the sub-graph reachable from the start `NODE` following the given `RELATIONSHIP` types to max-depth.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "Nodes part of the returned subgraph.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "startNode",
-    "description" : "The node to start the algorithm from. `startNode` can be of type `STRING` (elementId()), `INTEGER` (id()), `NODE`, or `LIST<STRING | INTEGER | NODE>`.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "config",
-    "description" : "{\n    minLevel = -1 :: INTEGER,\n    maxLevel = -1 :: INTEGER,\n    relationshipFilter :: STRING,\n    labelFilter :: STRING,\n    beginSequenceAtStart = true :: BOOLEAN,\n    uniqueness = \"RELATIONSHIP_PATH\" :: STRING,\n    bfs = true :: BOOLEAN,\n    filterStartNode = false :: BOOLEAN,\n    limit = -1 :: INTEGER,\n    optional = false :: BOOLEAN,\n    endNodes :: LIST<NODES>,\n    terminatorNodes:: LIST<NODES>,\n    allowlistNodes:: LIST<NODES>,\n    denylistNodes:: LIST<NODES>\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.paths.toJsonTree(paths :: LIST<PATH>, lowerCaseRels = true :: BOOLEAN, config = {} :: MAP) :: (value :: MAP)",
-  "name" : "apoc.paths.toJsonTree",
-  "description" : "Creates a stream of nested documents representing the graph as a tree by traversing outgoing relationships.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "The resulting tree.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "paths",
-    "description" : "A list of paths to convert into a tree.",
-    "isDeprecated" : false,
-    "type" : "LIST<PATH>"
-  }, {
-    "name" : "lowerCaseRels",
-    "description" : "Whether or not to convert relationship types to lower case.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=true, type=BOOLEAN}",
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "config",
-    "description" : "{ nodes = {} :: MAP, rels = {} :: MAP, sortPaths = true :: BOOLEAN }",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.periodic.cancel(name :: STRING) :: (name :: STRING, delay :: INTEGER, rate :: INTEGER, done :: BOOLEAN, cancelled :: BOOLEAN)",
-  "name" : "apoc.periodic.cancel",
-  "description" : "Cancels the given background job.",
-  "returnDescription" : [ {
-    "name" : "name",
-    "description" : "The name of the job.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "delay",
-    "description" : "The delay on the job.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rate",
-    "description" : "The rate of the job.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "If the job has completed.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "cancelled",
-    "description" : "If the job has been cancelled.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "name",
-    "description" : "The name of the job to cancel.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.periodic.commit(statement :: STRING, params = {} :: MAP) :: (updates :: INTEGER, executions :: INTEGER, runtime :: INTEGER, batches :: INTEGER, failedBatches :: INTEGER, batchErrors :: MAP, failedCommits :: INTEGER, commitErrors :: MAP, wasTerminated :: BOOLEAN)",
-  "name" : "apoc.periodic.commit",
-  "description" : "Runs the given statement in separate batched transactions.",
-  "returnDescription" : [ {
-    "name" : "updates",
-    "description" : "The total number of updates.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "executions",
-    "description" : "The total number of executions.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "runtime",
-    "description" : "The total time taken in nanoseconds.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batches",
-    "description" : "The number of run batches.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "failedBatches",
-    "description" : "The number of failed batches.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "batchErrors",
-    "description" : "Errors returned from the failed batches.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "failedCommits",
-    "description" : "The number of failed commits.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "commitErrors",
-    "description" : "Errors returned from the failed commits.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "wasTerminated",
-    "description" : "If the job was terminated.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "statement",
-    "description" : "The Cypher statement to run.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "params",
-    "description" : "The parameters for the given Cypher statement.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.periodic.countdown(name :: STRING, statement :: STRING, delay :: INTEGER) :: (name :: STRING, delay :: INTEGER, rate :: INTEGER, done :: BOOLEAN, cancelled :: BOOLEAN)",
-  "name" : "apoc.periodic.countdown",
-  "description" : "Runs a repeatedly called background statement until it returns 0.",
-  "returnDescription" : [ {
-    "name" : "name",
-    "description" : "The name of the job.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "delay",
-    "description" : "The delay on the job.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rate",
-    "description" : "The rate of the job.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "If the job has completed.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "cancelled",
-    "description" : "If the job has been cancelled.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "name",
-    "description" : "The name of the job.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "statement",
-    "description" : "The Cypher statement to run, returning a count on each run indicating the remaining iterations.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "delay",
-    "description" : "The delay in seconds to wait between each job execution.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.periodic.iterate(cypherIterate :: STRING, cypherAction :: STRING, config :: MAP) :: (batches :: INTEGER, total :: INTEGER, timeTaken :: INTEGER, committedOperations :: INTEGER, failedOperations :: INTEGER, failedBatches :: INTEGER, retries :: INTEGER, errorMessages :: MAP, batch :: MAP, operations :: MAP, wasTerminated :: BOOLEAN, failedParams :: MAP, updateStatistics :: MAP)",
-  "name" : "apoc.periodic.iterate",
-  "description" : "Runs the second statement for each item returned by the first statement.\nThis procedure returns the number of batches and the total number of processed rows.",
-  "returnDescription" : [ {
-    "name" : "batches",
-    "description" : "The total number of batches.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "total",
-    "description" : "The number of processed input rows.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "timeTaken",
-    "description" : "The duration taken in seconds.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "committedOperations",
-    "description" : "The number of successful inner queries (actions).",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "failedOperations",
-    "description" : "The number of failed inner queries (actions).",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "failedBatches",
-    "description" : "The number of failed batches.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "retries",
-    "description" : "The number of retries.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "errorMessages",
-    "description" : "A map of batch error messages paired with their corresponding error counts.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "batch",
-    "description" : "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "operations",
-    "description" : "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "wasTerminated",
-    "description" : "If the transaction was terminated before completion.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "failedParams",
-    "description" : "Parameters of failed batches. The key is the batch number as a STRING and the value is a list of batch parameters.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "updateStatistics",
-    "description" : "{\n    nodesCreated :: INTEGER,\n    nodesDeleted :: INTEGER,\n    relationshipsCreated :: INTEGER,\n    relationshipsDeleted :: INTEGER,\n    propertiesSet :: INTEGER,\n    labelsAdded :: INTEGER,\n    labelsRemoved :: INTEGER\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "cypherIterate",
-    "description" : "The first Cypher statement to be run.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "cypherAction",
-    "description" : "The Cypher statement to run for each item returned by the initial Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{\n    batchSize = 10000 :: INTEGER,\n    parallel = false :: BOOLEAN,\n    retries = 0 :: INTEGER,\n    batchMode = \"BATCH\" :: STRING,\n    params = {} :: MAP,\n    concurrency :: INTEGER,\n    failedParams = -1 :: INTEGER,\n    planner = \"DEFAULT\" :: [\"DEFAULT\", \"COST\", \"IDP\", \"DP\"]\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.periodic.list() :: (name :: STRING, delay :: INTEGER, rate :: INTEGER, done :: BOOLEAN, cancelled :: BOOLEAN)",
-  "name" : "apoc.periodic.list",
-  "description" : "Returns a `LIST<ANY>` of all background jobs.",
-  "returnDescription" : [ {
-    "name" : "name",
-    "description" : "The name of the job.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "delay",
-    "description" : "The delay on the job.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rate",
-    "description" : "The rate of the job.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "If the job has completed.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "cancelled",
-    "description" : "If the job has been cancelled.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.periodic.repeat(name :: STRING, statement :: STRING, rate :: INTEGER, config = {} :: MAP) :: (name :: STRING, delay :: INTEGER, rate :: INTEGER, done :: BOOLEAN, cancelled :: BOOLEAN)",
-  "name" : "apoc.periodic.repeat",
-  "description" : "Runs a repeatedly called background job.\nTo stop this procedure, use `apoc.periodic.cancel`.",
-  "returnDescription" : [ {
-    "name" : "name",
-    "description" : "The name of the job.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "delay",
-    "description" : "The delay on the job.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rate",
-    "description" : "The rate of the job.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "If the job has completed.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "cancelled",
-    "description" : "If the job has been cancelled.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "name",
-    "description" : "The name of the job.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "statement",
-    "description" : "The Cypher statement to run.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "rate",
-    "description" : "The delay in seconds to wait between each job execution.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "config",
-    "description" : "{ params = {} :: MAP }",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.periodic.submit(name :: STRING, statement :: STRING, params = {} :: MAP) :: (name :: STRING, delay :: INTEGER, rate :: INTEGER, done :: BOOLEAN, cancelled :: BOOLEAN)",
-  "name" : "apoc.periodic.submit",
-  "description" : "Creates a background job which runs the given Cypher statement once.",
-  "returnDescription" : [ {
-    "name" : "name",
-    "description" : "The name of the job.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "delay",
-    "description" : "The delay on the job.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "rate",
-    "description" : "The rate of the job.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "done",
-    "description" : "If the job has completed.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "cancelled",
-    "description" : "If the job has been cancelled.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "name",
-    "description" : "The name of the job.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "statement",
-    "description" : "The Cypher statement to run.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "params",
-    "description" : "{ params = {} :: MAP }",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.periodic.truncate(config = {} :: MAP)",
-  "name" : "apoc.periodic.truncate",
-  "description" : "Removes all entities (and optionally indexes and constraints) from the database using the `apoc.periodic.iterate` procedure.",
-  "returnDescription" : [ ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "config",
-    "description" : "{\n    dropSchema = true :: BOOLEAN,\n    batchSize = 10000 :: INTEGER,\n    parallel = false :: BOOLEAN,\n    retries = 0 :: INTEGER,\n    batchMode = \"BATCH\" :: STRING,\n    params = {} :: MAP,\n    concurrency :: INTEGER,\n    failedParams = -1 :: INTEGER,\n    planner = \"DEFAULT\" :: [\"DEFAULT\", \"COST\", \"IDP\", \"DP\"]\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.refactor.categorize(sourceKey :: STRING, type :: STRING, outgoing :: BOOLEAN, label :: STRING, targetKey :: STRING, copiedKeys :: LIST<STRING>, batchSize :: INTEGER)",
-  "name" : "apoc.refactor.categorize",
-  "description" : "Creates new category `NODE` values from `NODE` values in the graph with the specified `sourceKey` as one of its property keys.\nThe new category `NODE` values are then connected to the original `NODE` values with a `RELATIONSHIP` of the given type.",
-  "returnDescription" : [ ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "sourceKey",
-    "description" : "The property key to add to the on the new node.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "type",
-    "description" : "The relationship type to connect to the new node.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "outgoing",
-    "description" : "Whether the relationship should be outgoing or not.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "label",
-    "description" : "The label of the new node.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "targetKey",
-    "description" : "The name by which the source key value will be referenced on the new node.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "copiedKeys",
-    "description" : "A list of additional property keys to be copied to the new node.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "batchSize",
-    "description" : "The max size of each batch.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.refactor.cloneNodes(nodes :: LIST<NODE>, withRelationships = false :: BOOLEAN, skipProperties = [] :: LIST<STRING>) :: (input :: INTEGER, output :: NODE, error :: STRING)",
-  "name" : "apoc.refactor.cloneNodes",
-  "description" : "Clones the given `NODE` values with their labels and properties.\nIt is possible to skip any `NODE` properties using skipProperties (note: this only skips properties on `NODE` values and not their `RELATIONSHIP` values).",
-  "returnDescription" : [ {
-    "name" : "input",
-    "description" : "The internal id of the original entity.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "output",
-    "description" : "The copied entity.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "error",
-    "description" : "Any error that occurred during the copy process.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The nodes to be cloned.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "withRelationships",
-    "description" : "Whether or not the connected relationships should also be cloned.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=false, type=BOOLEAN}",
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "skipProperties",
-    "description" : "Whether or not to skip the node properties when cloning.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=[], type=LIST<STRING>}",
-    "type" : "LIST<STRING>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.refactor.cloneSubgraph(nodes :: LIST<NODE>, rels = [] :: LIST<RELATIONSHIP>, config = {} :: MAP) :: (input :: INTEGER, output :: NODE, error :: STRING)",
-  "name" : "apoc.refactor.cloneSubgraph",
-  "description" : "Clones the given `NODE` values with their labels and properties (optionally skipping any properties in the `skipProperties` `LIST<STRING>` via the config `MAP`), and clones the given `RELATIONSHIP` values.\nIf no `RELATIONSHIP` values are provided, all existing `RELATIONSHIP` values between the given `NODE` values will be cloned.",
-  "returnDescription" : [ {
-    "name" : "input",
-    "description" : "The internal id of the original entity.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "output",
-    "description" : "The copied entity.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "error",
-    "description" : "Any error that occurred during the copy process.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The nodes to be cloned.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "rels",
-    "description" : "The relationships to be cloned. If left empty all relationships between the given nodes will be cloned.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=[], type=LIST<RELATIONSHIP>}",
-    "type" : "LIST<RELATIONSHIP>"
-  }, {
-    "name" : "config",
-    "description" : "{\n    standinNodes :: LIST<LIST<NODE>>,\n    skipProperties :: LIST<STRING>,\n    createNodesInNewTransactions = false :: BOOLEAN\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.refactor.cloneSubgraphFromPaths(paths :: LIST<PATH>, config = {} :: MAP) :: (input :: INTEGER, output :: NODE, error :: STRING)",
-  "name" : "apoc.refactor.cloneSubgraphFromPaths",
-  "description" : "Clones a sub-graph defined by the given `LIST<PATH>` values.\nIt is possible to skip any `NODE` properties using the `skipProperties` `LIST<STRING>` via the config `MAP`.",
-  "returnDescription" : [ {
-    "name" : "input",
-    "description" : "The internal id of the original entity.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "output",
-    "description" : "The copied entity.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "error",
-    "description" : "Any error that occurred during the copy process.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "paths",
-    "description" : "The paths to be cloned.",
-    "isDeprecated" : false,
-    "type" : "LIST<PATH>"
-  }, {
-    "name" : "config",
-    "description" : "{\n    standinNodes :: LIST<LIST<NODE>>,\n    skipProperties :: LIST<STRING>\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.refactor.collapseNode(nodes :: ANY, relType :: STRING) :: (input :: INTEGER, output :: RELATIONSHIP, error :: STRING)",
-  "name" : "apoc.refactor.collapseNode",
-  "description" : "Collapses the given `NODE` and replaces it with a `RELATIONSHIP` of the given type.",
-  "returnDescription" : [ {
-    "name" : "input",
-    "description" : "The id of the given relationship.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "output",
-    "description" : "The id of the new relationship with the updated type.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "error",
-    "description" : "The message if an error occurred.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The nodes to collapse. Nodes can be of type `STRING` (elementId()), `INTEGER` (id()), `NODE`, or `LIST<STRING | INTEGER | NODE>`.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "relType",
-    "description" : "The name of the resulting relationship type.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.refactor.extractNode(rels :: ANY, labels :: LIST<STRING>, outType :: STRING, inType :: STRING) :: (input :: INTEGER, output :: NODE, error :: STRING)",
-  "name" : "apoc.refactor.extractNode",
-  "description" : "Expands the given `RELATIONSHIP` VALUES into intermediate `NODE` VALUES.\nThe intermediate `NODE` values are connected by the given `outType` and `inType`.",
-  "returnDescription" : [ {
-    "name" : "input",
-    "description" : "The internal id of the original entity.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "output",
-    "description" : "The copied entity.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "error",
-    "description" : "Any error that occurred during the copy process.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "rels",
-    "description" : "The relationships to turn into new nodes. Relationships can be of type `STRING` (elementId()), `INTEGER` (id()), `RELATIONSHIP`, or `LIST<STRING | INTEGER | RELATIONSHIP>`.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "labels",
-    "description" : "The labels to be added to the new nodes.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "outType",
-    "description" : "The type of the outgoing relationship.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "inType",
-    "description" : "The type of the ingoing relationship.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.refactor.from(rel :: RELATIONSHIP, newNode :: NODE, config = {} :: MAP) :: (input :: INTEGER, output :: RELATIONSHIP, error :: STRING)",
-  "name" : "apoc.refactor.from",
-  "description" : "Redirects the given `RELATIONSHIP` to the given start `NODE`.",
-  "returnDescription" : [ {
-    "name" : "input",
-    "description" : "The internal id of the original entity.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "output",
-    "description" : "The copied entity.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "error",
-    "description" : "Any error that occurred during the copy process.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "rel",
-    "description" : "The relationship to redirect.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "newNode",
-    "description" : "The node to redirect the given relationship to.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "config",
-    "description" : "{\n    failOnErrors = false :: BOOLEAN\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.refactor.invert(rel :: RELATIONSHIP, config = {} :: MAP) :: (input :: INTEGER, output :: RELATIONSHIP, error :: STRING)",
-  "name" : "apoc.refactor.invert",
-  "description" : "Inverts the direction of the given `RELATIONSHIP`.",
-  "returnDescription" : [ {
-    "name" : "input",
-    "description" : "The internal id of the original entity.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "output",
-    "description" : "The copied entity.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "error",
-    "description" : "Any error that occurred during the copy process.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "rel",
-    "description" : "The relationship to reverse.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "config",
-    "description" : "{\n    failOnErrors = false :: BOOLEAN\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.refactor.mergeNodes(nodes :: LIST<NODE>, config = {} :: MAP) :: (node :: NODE)",
-  "name" : "apoc.refactor.mergeNodes",
-  "description" : "Merges the given `LIST<NODE>` onto the first `NODE` in the `LIST<NODE>`.\nAll `RELATIONSHIP` values are merged onto that `NODE` as well.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "The merged node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "nodes",
-    "description" : "The nodes to be merged onto the first node.",
-    "isDeprecated" : false,
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "config",
-    "description" : "{\n    mergeRels :: BOOLEAN,\n    selfRef :: BOOLEAN,\n    produceSelfRef = true :: BOOLEAN,\n    preserveExistingSelfRels = true :: BOOLEAN,\n    countMerge = true :: BOOLEAN,\n    collapsedLabel :: BOOLEAN,\n    singleElementAsArray = false :: BOOLEAN,\n    avoidDuplicates = false :: BOOLEAN,\n    relationshipSelectionStrategy = \"incoming\" :: [\"incoming\", \"outgoing\", \"merge\"]\n    properties :: [\"overwrite\", \"\"discard\", \"combine\"]\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.refactor.mergeRelationships(rels :: LIST<RELATIONSHIP>, config = {} :: MAP) :: (rel :: RELATIONSHIP)",
-  "name" : "apoc.refactor.mergeRelationships",
-  "description" : "Merges the given `LIST<RELATIONSHIP>` onto the first `RELATIONSHIP` in the `LIST<RELATIONSHIP>`.",
-  "returnDescription" : [ {
-    "name" : "rel",
-    "description" : "The merged relationship.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "rels",
-    "description" : "The relationships to be merged onto the first relationship.",
-    "isDeprecated" : false,
-    "type" : "LIST<RELATIONSHIP>"
-  }, {
-    "name" : "config",
-    "description" : "{\n    mergeRels :: BOOLEAN,\n    selfRef :: BOOLEAN,\n    produceSelfRef = true :: BOOLEAN,\n    preserveExistingSelfRels = true :: BOOLEAN,\n    countMerge = true :: BOOLEAN,\n    collapsedLabel :: BOOLEAN,\n    singleElementAsArray = false :: BOOLEAN,\n    avoidDuplicates = false :: BOOLEAN,\n    relationshipSelectionStrategy = \"incoming\" :: [\"incoming\", \"outgoing\", \"merge\"]\n    properties :: [\"overwrite\", \"discard\", \"combine\"]\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.refactor.normalizeAsBoolean(entity :: ANY, propertyKey :: STRING, trueValues :: LIST<ANY>, falseValues :: LIST<ANY>)",
-  "name" : "apoc.refactor.normalizeAsBoolean",
-  "description" : "Refactors the given property to a `BOOLEAN`.",
-  "returnDescription" : [ ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "entity",
-    "description" : "The node or relationship whose properties will be normalized to booleans.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "propertyKey",
-    "description" : "The name of the property key to normalize.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "trueValues",
-    "description" : "The possible representations of true values.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  }, {
-    "name" : "falseValues",
-    "description" : "The possible representations of false values.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.refactor.rename.label(oldLabel :: STRING, newLabel :: STRING, nodes = [] :: LIST<NODE>) :: (batches :: INTEGER, total :: INTEGER, timeTaken :: INTEGER, committedOperations :: INTEGER, failedOperations :: INTEGER, failedBatches :: INTEGER, retries :: INTEGER, errorMessages :: MAP, batch :: MAP, operations :: MAP, constraints :: LIST<STRING>, indexes :: LIST<STRING>)",
-  "name" : "apoc.refactor.rename.label",
-  "description" : "Renames the given label from `oldLabel` to `newLabel` for all `NODE` values.\nIf a `LIST<NODE>` is provided, the renaming is applied to the `NODE` values within this `LIST<NODE>` only.",
-  "returnDescription" : [ {
-    "name" : "batches",
-    "description" : "The number of batches the operation was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "total",
-    "description" : "The total number of renamings performed.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "timeTaken",
-    "description" : "The time taken to complete the operation.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "committedOperations",
-    "description" : "The total number of committed operations.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "failedOperations",
-    "description" : "The total number of failed operations.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "failedBatches",
-    "description" : "The total number of failed batches.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "retries",
-    "description" : "The total number of retries.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "errorMessages",
-    "description" : "The collected error messages.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "batch",
-    "description" : "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "operations",
-    "description" : "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "constraints",
-    "description" : "Constraints associated with the given label or type.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "indexes",
-    "description" : "Indexes associated with the given label or type.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "oldLabel",
-    "description" : "The label to rename.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "newLabel",
-    "description" : "The new name to give the label.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The nodes to apply the new name to. If this list is empty, all nodes with the old label will be renamed.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=[], type=LIST<NODE>}",
-    "type" : "LIST<NODE>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.refactor.rename.nodeProperty(oldName :: STRING, newName :: STRING, nodes = [] :: LIST<NODE>, config = {} :: MAP) :: (batches :: INTEGER, total :: INTEGER, timeTaken :: INTEGER, committedOperations :: INTEGER, failedOperations :: INTEGER, failedBatches :: INTEGER, retries :: INTEGER, errorMessages :: MAP, batch :: MAP, operations :: MAP, constraints :: LIST<STRING>, indexes :: LIST<STRING>)",
-  "name" : "apoc.refactor.rename.nodeProperty",
-  "description" : "Renames the given property from `oldName` to `newName` for all `NODE` values.\nIf a `LIST<NODE>` is provided, the renaming is applied to the `NODE` values within this `LIST<NODE>` only.",
-  "returnDescription" : [ {
-    "name" : "batches",
-    "description" : "The number of batches the operation was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "total",
-    "description" : "The total number of renamings performed.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "timeTaken",
-    "description" : "The time taken to complete the operation.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "committedOperations",
-    "description" : "The total number of committed operations.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "failedOperations",
-    "description" : "The total number of failed operations.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "failedBatches",
-    "description" : "The total number of failed batches.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "retries",
-    "description" : "The total number of retries.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "errorMessages",
-    "description" : "The collected error messages.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "batch",
-    "description" : "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "operations",
-    "description" : "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "constraints",
-    "description" : "Constraints associated with the given label or type.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "indexes",
-    "description" : "Indexes associated with the given label or type.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "oldName",
-    "description" : "The property to rename.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "newName",
-    "description" : "The new name to give the property.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "nodes",
-    "description" : "The nodes to apply the new name to. If this list is empty, all nodes with the old property name will be renamed.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=[], type=LIST<NODE>}",
-    "type" : "LIST<NODE>"
-  }, {
-    "name" : "config",
-    "description" : "{\n    batchSize = 100000 :: INTEGER,\n    concurrency :: INTEGER,\n    retries = 0 :: INTEGER,\n    parallel = true :: BOOLEAN,\n    batchMode = \"BATCH\" :: STRING\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.refactor.rename.type(oldType :: STRING, newType :: STRING, rels = [] :: LIST<RELATIONSHIP>, config = {} :: MAP) :: (batches :: INTEGER, total :: INTEGER, timeTaken :: INTEGER, committedOperations :: INTEGER, failedOperations :: INTEGER, failedBatches :: INTEGER, retries :: INTEGER, errorMessages :: MAP, batch :: MAP, operations :: MAP, constraints :: LIST<STRING>, indexes :: LIST<STRING>)",
-  "name" : "apoc.refactor.rename.type",
-  "description" : "Renames all `RELATIONSHIP` values with type `oldType` to `newType`.\nIf a `LIST<RELATIONSHIP>` is provided, the renaming is applied to the `RELATIONSHIP` values within this `LIST<RELATIONSHIP>` only.",
-  "returnDescription" : [ {
-    "name" : "batches",
-    "description" : "The number of batches the operation was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "total",
-    "description" : "The total number of renamings performed.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "timeTaken",
-    "description" : "The time taken to complete the operation.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "committedOperations",
-    "description" : "The total number of committed operations.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "failedOperations",
-    "description" : "The total number of failed operations.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "failedBatches",
-    "description" : "The total number of failed batches.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "retries",
-    "description" : "The total number of retries.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "errorMessages",
-    "description" : "The collected error messages.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "batch",
-    "description" : "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "operations",
-    "description" : "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "constraints",
-    "description" : "Constraints associated with the given label or type.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "indexes",
-    "description" : "Indexes associated with the given label or type.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "oldType",
-    "description" : "The type to rename.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "newType",
-    "description" : "The new type for the relationship.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "rels",
-    "description" : "The relationships to apply the new name to. If this list is empty, all relationships with the old type will be renamed.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=[], type=LIST<RELATIONSHIP>}",
-    "type" : "LIST<RELATIONSHIP>"
-  }, {
-    "name" : "config",
-    "description" : "{\n    batchSize = 100000 :: INTEGER,\n    concurrency :: INTEGER,\n    retries = 0 :: INTEGER,\n    parallel = true :: BOOLEAN,\n    batchMode = \"BATCH\" :: STRING\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.refactor.rename.typeProperty(oldName :: STRING, newName :: STRING, rels = [] :: LIST<RELATIONSHIP>, config = {} :: MAP) :: (batches :: INTEGER, total :: INTEGER, timeTaken :: INTEGER, committedOperations :: INTEGER, failedOperations :: INTEGER, failedBatches :: INTEGER, retries :: INTEGER, errorMessages :: MAP, batch :: MAP, operations :: MAP, constraints :: LIST<STRING>, indexes :: LIST<STRING>)",
-  "name" : "apoc.refactor.rename.typeProperty",
-  "description" : "Renames the given property from `oldName` to `newName` for all `RELATIONSHIP` values.\nIf a `LIST<RELATIONSHIP>` is provided, the renaming is applied to the `RELATIONSHIP` values within this `LIST<RELATIONSHIP>` only.",
-  "returnDescription" : [ {
-    "name" : "batches",
-    "description" : "The number of batches the operation was run in.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "total",
-    "description" : "The total number of renamings performed.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "timeTaken",
-    "description" : "The time taken to complete the operation.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "committedOperations",
-    "description" : "The total number of committed operations.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "failedOperations",
-    "description" : "The total number of failed operations.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "failedBatches",
-    "description" : "The total number of failed batches.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "retries",
-    "description" : "The total number of retries.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "errorMessages",
-    "description" : "The collected error messages.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "batch",
-    "description" : "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "operations",
-    "description" : "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "constraints",
-    "description" : "Constraints associated with the given label or type.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "indexes",
-    "description" : "Indexes associated with the given label or type.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "oldName",
-    "description" : "The property to rename.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "newName",
-    "description" : "The new name to give the property.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "rels",
-    "description" : "The relationships to apply the new name to. If this list is empty, all relationships with the old properties name will be renamed.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=[], type=LIST<RELATIONSHIP>}",
-    "type" : "LIST<RELATIONSHIP>"
-  }, {
-    "name" : "config",
-    "description" : "{\n    batchSize = 100000 :: INTEGER,\n    concurrency :: INTEGER,\n    retries = 0 :: INTEGER,\n    parallel = true :: BOOLEAN,\n    batchMode = \"BATCH\" :: STRING\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.refactor.setType(rel :: RELATIONSHIP, newType :: STRING) :: (input :: INTEGER, output :: RELATIONSHIP, error :: STRING)",
-  "name" : "apoc.refactor.setType",
-  "description" : "Changes the type of the given `RELATIONSHIP`.",
-  "returnDescription" : [ {
-    "name" : "input",
-    "description" : "The id of the given relationship.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "output",
-    "description" : "The id of the new relationship with the updated type.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "error",
-    "description" : "The message if an error occurred.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "rel",
-    "description" : "The relationship to change the type of.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "newType",
-    "description" : "The new type for the relationship.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.refactor.to(rel :: RELATIONSHIP, endNode :: NODE, config = {} :: MAP) :: (input :: INTEGER, output :: RELATIONSHIP, error :: STRING)",
-  "name" : "apoc.refactor.to",
-  "description" : "Redirects the given `RELATIONSHIP` to the given end `NODE`.",
-  "returnDescription" : [ {
-    "name" : "input",
-    "description" : "The id of the given relationship.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "output",
-    "description" : "The id of the new relationship with the updated type.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "error",
-    "description" : "The message if an error occurred.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "rel",
-    "description" : "The relationship to redirect.",
-    "isDeprecated" : false,
-    "type" : "RELATIONSHIP"
-  }, {
-    "name" : "endNode",
-    "description" : "The new end node the relationship should point to.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  }, {
-    "name" : "config",
-    "description" : "{\n    failOnErrors = false :: BOOLEAN\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.schema.assert(indexes :: MAP, constraints :: MAP, dropExisting = true :: BOOLEAN) :: (label :: ANY, key :: STRING, keys :: LIST<STRING>, unique :: BOOLEAN, action :: STRING)",
-  "name" : "apoc.schema.assert",
-  "description" : "Drops all other existing indexes and constraints when `dropExisting` is `true` (default is `true`).\nAsserts at the end of the operation that the given indexes and unique constraints are there.",
-  "returnDescription" : [ {
-    "name" : "label",
-    "description" : "The label associated with the constraint or index.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "key",
-    "description" : "The property key associated with the constraint or index.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "keys",
-    "description" : "The property keys associated with the constraint or index.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "unique",
-    "description" : "Whether or not this is a uniqueness constraint.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "action",
-    "description" : "The action applied to this constraint or index; can be [\"KEPT\", \"CREATED\", \"DROPPED\"]",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "indexes",
-    "description" : "A map that pairs labels with lists of properties to create indexes from.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "constraints",
-    "description" : "A map that pairs labels with lists of properties to create constraints from.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "dropExisting",
-    "description" : "Whether or not to drop all other existing indexes and constraints.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=true, type=BOOLEAN}",
-    "type" : "BOOLEAN"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.schema.nodes(config = {} :: MAP) :: (name :: STRING, label :: ANY, properties :: LIST<STRING>, status :: STRING, type :: STRING, failure :: STRING, populationProgress :: FLOAT, size :: INTEGER, valuesSelectivity :: FLOAT, userDescription :: STRING)",
-  "name" : "apoc.schema.nodes",
-  "description" : "Returns all indexes and constraints information for all `NODE` labels in the database.\nIt is possible to define a set of labels to include or exclude in the config parameters.",
-  "returnDescription" : [ {
-    "name" : "name",
-    "description" : "A generated name for the index or constraint.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "label",
-    "description" : "The label associated with the constraint or index.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "properties",
-    "description" : "The property keys associated with the constraint or index.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "status",
-    "description" : "The status of the constraint or index.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "type",
-    "description" : "The type of the index or constraint.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "failure",
-    "description" : "If a failure has occurred.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "populationProgress",
-    "description" : "The percentage of the constraint or index population. ",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "size",
-    "description" : "The number of entries in the given constraint or index.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "valuesSelectivity",
-    "description" : "A ratio between 0.0 and 1.0, representing how many unique values were seen from the sampling.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "userDescription",
-    "description" : "A descriptor of the constraint or index.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "config",
-    "description" : "{\n    labels :: LIST<STRING>,\n    excludeLabels :: LIST<STRING>,\n    relationships :: LIST<STRING>,\n    excludeRelationships :: LIST<STRING>\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.schema.properties.distinct(label :: STRING, key :: STRING) :: (value :: LIST<ANY>)",
-  "name" : "apoc.schema.properties.distinct",
-  "description" : "Returns all distinct `NODE` property values for the given key.",
-  "returnDescription" : [ {
-    "name" : "value",
-    "description" : "The list of distinct values for the given property.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "label",
-    "description" : "The node label to find distinct properties on.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "key",
-    "description" : "The name of the property to find distinct values of.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.schema.properties.distinctCount(label =  :: STRING, key =  :: STRING) :: (label :: STRING, key :: STRING, value :: ANY, count :: INTEGER)",
-  "name" : "apoc.schema.properties.distinctCount",
-  "description" : "Returns all distinct property values and counts for the given key.",
-  "returnDescription" : [ {
-    "name" : "label",
-    "description" : "The label of the node.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "key",
-    "description" : "The name of the property key.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "value",
-    "description" : "The distinct value.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "count",
-    "description" : "The number of occurrences of the value.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "label",
-    "description" : "The node label to count distinct properties on.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=, type=STRING}",
-    "type" : "STRING"
-  }, {
-    "name" : "key",
-    "description" : "The name of the property to count distinct values of.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=, type=STRING}",
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.schema.relationships(config = {} :: MAP) :: (name :: STRING, type :: STRING, properties :: LIST<STRING>, status :: STRING, relationshipType :: ANY)",
-  "name" : "apoc.schema.relationships",
-  "description" : "Returns the indexes and constraints information for all the relationship types in the database.\nIt is possible to define a set of relationship types to include or exclude in the config parameters.",
-  "returnDescription" : [ {
-    "name" : "name",
-    "description" : "A generated name for the index or constraint.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "type",
-    "description" : "The type of the index or constraint.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "properties",
-    "description" : "The property keys associated with the constraint or index.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "status",
-    "description" : "The status of the constraint or index.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "relationshipType",
-    "description" : "The relationship type associated with the constraint or index.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "config",
-    "description" : "{\n    labels :: LIST<STRING>,\n    excludeLabels :: LIST<STRING>,\n    relationships :: LIST<STRING>,\n    excludeRelationships :: LIST<STRING>\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.search.multiSearchReduced(labelPropertyMap :: ANY, operator :: STRING, value :: STRING) :: (id :: INTEGER, labels :: LIST<STRING>, values :: MAP)",
-  "name" : "apoc.search.multiSearchReduced",
-  "description" : "Returns a reduced representation of the `NODE` values found after a parallel search over multiple indexes.\nThe reduced `NODE` values representation includes: node id, node labels, and the searched properties.",
-  "returnDescription" : [ {
-    "name" : "id",
-    "description" : "The id of the found node.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "labels",
-    "description" : "The labels of the found node.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "values",
-    "description" : "The matched values of the found node.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "labelPropertyMap",
-    "description" : "A map that pairs labels with lists of properties. This can also be represented as a JSON string.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "operator",
-    "description" : "The search operator, can be one of: [\"exact\", \"starts with\", \"ends with\", \"contains\", \"<\", \">\", \"=\", \"<>\", \"<=\", \">=\", \"=~\"].",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "value",
-    "description" : "The search value.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.search.node(labelPropertyMap :: ANY, operator :: STRING, value :: STRING) :: (node :: NODE)",
-  "name" : "apoc.search.node",
-  "description" : "Returns all the distinct `NODE` values found after a parallel search over multiple indexes.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "The found node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "labelPropertyMap",
-    "description" : "A map that pairs labels with lists of properties. This can also be represented as a JSON string.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "operator",
-    "description" : "The search operator, can be one of: [\"exact\", \"starts with\", \"ends with\", \"contains\", \"<\", \">\", \"=\", \"<>\", \"<=\", \">=\", \"=~\"].",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "value",
-    "description" : "The search value.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.search.nodeAll(labelPropertyMap :: ANY, operator :: STRING, value :: STRING) :: (node :: NODE)",
-  "name" : "apoc.search.nodeAll",
-  "description" : "Returns all the `NODE` values found after a parallel search over multiple indexes.",
-  "returnDescription" : [ {
-    "name" : "node",
-    "description" : "The found node.",
-    "isDeprecated" : false,
-    "type" : "NODE"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "labelPropertyMap",
-    "description" : "A map that pairs labels with lists of properties. This can also be represented as a JSON string.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "operator",
-    "description" : "The search operator, can be one of: [\"exact\", \"starts with\", \"ends with\", \"contains\", \"<\", \">\", \"=\", \"<>\", \"<=\", \">=\", \"=~\"].",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "value",
-    "description" : "The search value.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.search.nodeAllReduced(labelPropertyMap :: ANY, operator :: STRING, value :: ANY) :: (id :: INTEGER, labels :: LIST<STRING>, values :: MAP)",
-  "name" : "apoc.search.nodeAllReduced",
-  "description" : "Returns a reduced representation of the `NODE` values found after a parallel search over multiple indexes.\nThe reduced `NODE` values representation includes: node id, node labels, and the searched properties.",
-  "returnDescription" : [ {
-    "name" : "id",
-    "description" : "The id of the found node.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "labels",
-    "description" : "The labels of the found node.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "values",
-    "description" : "The matched values of the found node.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "labelPropertyMap",
-    "description" : "A map that pairs labels with lists of properties. This can also be represented as a JSON string.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "operator",
-    "description" : "The search operator, can be one of: [\"exact\", \"starts with\", \"ends with\", \"contains\", \"<\", \">\", \"=\", \"<>\", \"<=\", \">=\", \"=~\"].",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "value",
-    "description" : "The search value.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.search.nodeReduced(labelPropertyMap :: ANY, operator :: STRING, value :: STRING) :: (id :: INTEGER, labels :: LIST<STRING>, values :: MAP)",
-  "name" : "apoc.search.nodeReduced",
-  "description" : "Returns a reduced representation of the distinct `NODE` values found after a parallel search over multiple indexes.\nThe reduced `NODE` values representation includes: node id, node labels, and the searched properties.",
-  "returnDescription" : [ {
-    "name" : "id",
-    "description" : "The id of the found node.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "labels",
-    "description" : "The labels of the found node.",
-    "isDeprecated" : false,
-    "type" : "LIST<STRING>"
-  }, {
-    "name" : "values",
-    "description" : "The matched values of the found node.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "labelPropertyMap",
-    "description" : "A map that pairs labels with lists of properties. This can also be represented as a JSON string.",
-    "isDeprecated" : false,
-    "type" : "ANY"
-  }, {
-    "name" : "operator",
-    "description" : "The search operator, can be one of: [\"exact\", \"starts with\", \"ends with\", \"contains\", \"<\", \">\", \"=\", \"<>\", \"<=\", \">=\", \"=~\"].",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "value",
-    "description" : "The search value.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.spatial.geocode(location :: STRING, maxResults = 100 :: INTEGER, quotaException = false :: BOOLEAN, config = {} :: MAP) :: (location :: MAP, data :: MAP, latitude :: FLOAT, longitude :: FLOAT, description :: STRING)",
-  "name" : "apoc.spatial.geocode",
-  "description" : "Returns the geographic location (latitude, longitude, and description) of the given address using a geocoding service (default: OpenStreetMap).",
-  "returnDescription" : [ {
-    "name" : "location",
-    "description" : "A detailed map of information on the found location.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "data",
-    "description" : "A map of returned data from the given provider.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "latitude",
-    "description" : "The latitude of the found location.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "longitude",
-    "description" : "The longitude of the found location.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "description",
-    "description" : "A description of the found location.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "location",
-    "description" : "The location to search for.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "maxResults",
-    "description" : "The maximum number of returned results.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=100, type=INTEGER}",
-    "type" : "INTEGER"
-  }, {
-    "name" : "quotaException",
-    "description" : "Whether or not to throw an exception when the maximum request quota is reached.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=false, type=BOOLEAN}",
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "config",
-    "description" : "{\n        provider = 'osm' :: STRING,\n        url :: STRING,\n        reverseUrl: :: STRING,\n        key :: STRING\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.spatial.geocodeOnce(location :: STRING, config = {} :: MAP) :: (location :: MAP, data :: MAP, latitude :: FLOAT, longitude :: FLOAT, description :: STRING)",
-  "name" : "apoc.spatial.geocodeOnce",
-  "description" : "Returns the geographic location (latitude, longitude, and description) of the given address using a geocoding service (default: OpenStreetMap).\nThis procedure returns at most one result.",
-  "returnDescription" : [ {
-    "name" : "location",
-    "description" : "A detailed map of information on the found location.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "data",
-    "description" : "A map of returned data from the given provider.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "latitude",
-    "description" : "The latitude of the found location.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "longitude",
-    "description" : "The longitude of the found location.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "description",
-    "description" : "A description of the found location.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "location",
-    "description" : "The location to search for.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "config",
-    "description" : "{\n        provider = 'osm' :: STRING,\n        url :: STRING,\n        reverseUrl: :: STRING,\n        key :: STRING\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.spatial.reverseGeocode(latitude :: FLOAT, longitude :: FLOAT, quotaException = false :: BOOLEAN, config = {} :: MAP) :: (location :: MAP, data :: MAP, latitude :: FLOAT, longitude :: FLOAT, description :: STRING)",
-  "name" : "apoc.spatial.reverseGeocode",
-  "description" : "Returns a textual address from the given geographic location (latitude, longitude) using a geocoding service (default: OpenStreetMap).\nThis procedure returns at most one result.",
-  "returnDescription" : [ {
-    "name" : "location",
-    "description" : "A detailed map of information on the found location.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "data",
-    "description" : "A map of returned data from the given provider.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "latitude",
-    "description" : "The latitude of the found location.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "longitude",
-    "description" : "The longitude of the found location.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "description",
-    "description" : "A description of the found location.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "latitude",
-    "description" : "The latitude of the location.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "longitude",
-    "description" : "The longitude of the location.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  }, {
-    "name" : "quotaException",
-    "description" : "Whether or not to throw an exception when the maximum request quota is reached.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=false, type=BOOLEAN}",
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "config",
-    "description" : "{\n        provider = 'osm' :: STRING,\n        url :: STRING,\n        reverseUrl: :: STRING,\n        key :: STRING\n}\n",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.spatial.sortByDistance(paths :: LIST<PATH>) :: (path :: PATH, distance :: FLOAT)",
-  "name" : "apoc.spatial.sortByDistance",
-  "description" : "Sorts the given collection of `PATH` values by the sum of their distance based on the latitude/longitude values in the `NODE` values.",
-  "returnDescription" : [ {
-    "name" : "path",
-    "description" : "The sorted path result.",
-    "isDeprecated" : false,
-    "type" : "PATH"
-  }, {
-    "name" : "distance",
-    "description" : "The distance between the nodes.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "paths",
-    "description" : "A list of paths to be sorted by the sum of distances, calculated based on the latitude/longitude values in the nodes.",
-    "isDeprecated" : false,
-    "type" : "LIST<PATH>"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.stats.degrees(relTypes =  :: STRING) :: (type :: STRING, direction :: STRING, total :: INTEGER, p50 :: INTEGER, p75 :: INTEGER, p90 :: INTEGER, p95 :: INTEGER, p99 :: INTEGER, p999 :: INTEGER, max :: INTEGER, min :: INTEGER, mean :: FLOAT)",
-  "name" : "apoc.stats.degrees",
-  "description" : "Returns the percentile groupings of the degrees on the `NODE` values connected by the given `RELATIONSHIP` types.",
-  "returnDescription" : [ {
-    "name" : "type",
-    "description" : "The type of the relationship.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "direction",
-    "description" : "The direction of the relationship.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "total",
-    "description" : "The total observed relationships.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "p50",
-    "description" : "The 50th percentile grouping.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "p75",
-    "description" : "The 75th percentile grouping.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "p90",
-    "description" : "The 90th percentile grouping.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "p95",
-    "description" : "The 95th percentile grouping.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "p99",
-    "description" : "The 99th percentile grouping.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "p999",
-    "description" : "The 99.9th percentile grouping.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "max",
-    "description" : "The max value.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "min",
-    "description" : "The min value.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  }, {
-    "name" : "mean",
-    "description" : "The mean value.",
-    "isDeprecated" : false,
-    "type" : "FLOAT"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "relTypes",
-    "description" : "The relationship types to calculate the percentile grouping over. If this is empty or omitted, all relationships are used.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value=, type=STRING}",
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.text.phoneticDelta(text1 :: STRING, text2 :: STRING) :: (phonetic1 :: STRING, phonetic2 :: STRING, delta :: INTEGER)",
-  "name" : "apoc.text.phoneticDelta",
-  "description" : "Returns the US_ENGLISH soundex character difference between the two given `STRING` values.",
-  "returnDescription" : [ {
-    "name" : "phonetic1",
-    "description" : "The phonetic representation of the first string.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "phonetic2",
-    "description" : "The phonetic representation of the second string.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "delta",
-    "description" : "The soundex character difference between the two given strings.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "text1",
-    "description" : "The first string to be compared against the second.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "text2",
-    "description" : "The second string to be compared against the first.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.trigger.drop(databaseName :: STRING, name :: STRING) :: (name :: STRING, query :: STRING, selector :: MAP, params :: MAP, installed :: BOOLEAN, paused :: BOOLEAN)",
-  "name" : "apoc.trigger.drop",
-  "description" : "Eventually removes the given trigger.",
-  "returnDescription" : [ {
-    "name" : "name",
-    "description" : "The name of the trigger.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "query",
-    "description" : "The query belonging to the trigger.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "selector",
-    "description" : "{ phase = \"before\" :: [\"before\", \"rollback\", \"after\", \"afterAsync\"] }",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "params",
-    "description" : "The parameters for the given Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "installed",
-    "description" : "Whether or not the trigger was installed.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "paused",
-    "description" : "Whether or not the trigger was paused.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "databaseName",
-    "description" : "The name of the database to drop the trigger from.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "name",
-    "description" : "The name of the trigger to drop.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.trigger.dropAll(databaseName :: STRING) :: (name :: STRING, query :: STRING, selector :: MAP, params :: MAP, installed :: BOOLEAN, paused :: BOOLEAN)",
-  "name" : "apoc.trigger.dropAll",
-  "description" : "Eventually removes all triggers from the given database.",
-  "returnDescription" : [ {
-    "name" : "name",
-    "description" : "The name of the trigger.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "query",
-    "description" : "The query belonging to the trigger.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "selector",
-    "description" : "{ phase = \"before\" :: [\"before\", \"rollback\", \"after\", \"afterAsync\"] }",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "params",
-    "description" : "The parameters for the given Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "installed",
-    "description" : "Whether or not the trigger was installed.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "paused",
-    "description" : "Whether or not the trigger was paused.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "databaseName",
-    "description" : "The name of the database to drop the triggers from.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.trigger.install(databaseName :: STRING, name :: STRING, statement :: STRING, selector :: MAP, config = {} :: MAP) :: (name :: STRING, query :: STRING, selector :: MAP, params :: MAP, installed :: BOOLEAN, paused :: BOOLEAN)",
-  "name" : "apoc.trigger.install",
-  "description" : "Eventually adds a trigger for a given database which is invoked when a successful transaction occurs.",
-  "returnDescription" : [ {
-    "name" : "name",
-    "description" : "The name of the trigger.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "query",
-    "description" : "The query belonging to the trigger.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "selector",
-    "description" : "{ phase = \"before\" :: [\"before\", \"rollback\", \"after\", \"afterAsync\"] }",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "params",
-    "description" : "The parameters for the given Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "installed",
-    "description" : "Whether or not the trigger was installed.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "paused",
-    "description" : "Whether or not the trigger was paused.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "databaseName",
-    "description" : "The name of the database to add the trigger to.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "name",
-    "description" : "The name of the trigger to add.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "statement",
-    "description" : "The query to run when triggered.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "selector",
-    "description" : "{ phase = \"before\" :: [\"before\", \"rollback\", \"after\", \"afterAsync\"] }",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "config",
-    "description" : "The parameters for the given Cypher statement.",
-    "isDeprecated" : false,
-    "default" : "DefaultParameterValue{value={}, type=MAP}",
-    "type" : "MAP"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.trigger.list() :: (name :: STRING, query :: STRING, selector :: MAP, params :: MAP, installed :: BOOLEAN, paused :: BOOLEAN)",
-  "name" : "apoc.trigger.list",
-  "description" : "Lists all currently installed triggers for the session database.",
-  "returnDescription" : [ {
-    "name" : "name",
-    "description" : "The name of the trigger.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "query",
-    "description" : "The query belonging to the trigger.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "selector",
-    "description" : "{ phase = \"before\" :: [\"before\", \"rollback\", \"after\", \"afterAsync\"] }",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "params",
-    "description" : "The parameters for the given Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "installed",
-    "description" : "Whether or not the trigger was installed.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "paused",
-    "description" : "Whether or not the trigger was paused.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.trigger.show(databaseName :: STRING) :: (name :: STRING, query :: STRING, selector :: MAP, params :: MAP, installed :: BOOLEAN, paused :: BOOLEAN)",
-  "name" : "apoc.trigger.show",
-  "description" : "Lists all eventually installed triggers for a database.",
-  "returnDescription" : [ {
-    "name" : "name",
-    "description" : "The name of the trigger.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "query",
-    "description" : "The query belonging to the trigger.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "selector",
-    "description" : "{ phase = \"before\" :: [\"before\", \"rollback\", \"after\", \"afterAsync\"] }",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "params",
-    "description" : "The parameters for the given Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "installed",
-    "description" : "Whether or not the trigger was installed.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "paused",
-    "description" : "Whether or not the trigger was paused.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "databaseName",
-    "description" : "The name of the database to show triggers on.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.trigger.start(databaseName :: STRING, name :: STRING) :: (name :: STRING, query :: STRING, selector :: MAP, params :: MAP, installed :: BOOLEAN, paused :: BOOLEAN)",
-  "name" : "apoc.trigger.start",
-  "description" : "Eventually restarts the given paused trigger.",
-  "returnDescription" : [ {
-    "name" : "name",
-    "description" : "The name of the trigger.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "query",
-    "description" : "The query belonging to the trigger.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "selector",
-    "description" : "{ phase = \"before\" :: [\"before\", \"rollback\", \"after\", \"afterAsync\"] }",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "params",
-    "description" : "The parameters for the given Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "installed",
-    "description" : "Whether or not the trigger was installed.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "paused",
-    "description" : "Whether or not the trigger was paused.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "databaseName",
-    "description" : "The name of the database the trigger is on.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "name",
-    "description" : "The name of the trigger to resume.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.trigger.stop(databaseName :: STRING, name :: STRING) :: (name :: STRING, query :: STRING, selector :: MAP, params :: MAP, installed :: BOOLEAN, paused :: BOOLEAN)",
-  "name" : "apoc.trigger.stop",
-  "description" : "Eventually stops the given trigger.",
-  "returnDescription" : [ {
-    "name" : "name",
-    "description" : "The name of the trigger.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "query",
-    "description" : "The query belonging to the trigger.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "selector",
-    "description" : "{ phase = \"before\" :: [\"before\", \"rollback\", \"after\", \"afterAsync\"] }",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "params",
-    "description" : "The parameters for the given Cypher statement.",
-    "isDeprecated" : false,
-    "type" : "MAP"
-  }, {
-    "name" : "installed",
-    "description" : "Whether or not the trigger was installed.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "paused",
-    "description" : "Whether or not the trigger was paused.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  } ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "databaseName",
-    "description" : "The name of the database the trigger is on.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "name",
-    "description" : "The name of the trigger to drop.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.util.sleep(duration :: INTEGER)",
-  "name" : "apoc.util.sleep",
-  "description" : "Causes the currently running Cypher to sleep for the given duration of milliseconds (the transaction termination is honored).",
-  "returnDescription" : [ ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "duration",
-    "description" : "The milliseconds to sleep.",
-    "isDeprecated" : false,
-    "type" : "INTEGER"
-  } ]
-}, {
-  "isDeprecated" : false,
-  "signature" : "apoc.util.validate(predicate :: BOOLEAN, message :: STRING, params :: LIST<ANY>)",
-  "name" : "apoc.util.validate",
-  "description" : "If the given predicate is true an exception is thrown.",
-  "returnDescription" : [ ],
-  "deprecatedBy" : null,
-  "argumentDescription" : [ {
-    "name" : "predicate",
-    "description" : "The predicate to check against.",
-    "isDeprecated" : false,
-    "type" : "BOOLEAN"
-  }, {
-    "name" : "message",
-    "description" : "The error message to throw if the given predicate evaluates to true.",
-    "isDeprecated" : false,
-    "type" : "STRING"
-  }, {
-    "name" : "params",
-    "description" : "The parameters for the given error message.",
-    "isDeprecated" : false,
-    "type" : "LIST<ANY>"
-  } ]
-}]
+[
+  {
+    "isDeprecated": false,
+    "signature": "apoc.algo.aStar(startNode :: NODE, endNode :: NODE, relTypesAndDirections :: STRING, weightPropertyName :: STRING, latPropertyName :: STRING, lonPropertyName :: STRING) :: (path :: PATH, weight :: FLOAT)",
+    "name": "apoc.algo.aStar",
+    "description": "Runs the A* search algorithm to find the optimal path between two `NODE` values, using the given `RELATIONSHIP` property name for the cost function.",
+    "returnDescription": [
+      {
+        "name": "path",
+        "description": "The path result.",
+        "isDeprecated": false,
+        "type": "PATH"
+      },
+      {
+        "name": "weight",
+        "description": "The weight of the given path.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "startNode",
+        "description": "The node to start the search from.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "endNode",
+        "description": "The node to end the search on.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relTypesAndDirections",
+        "description": "The relationship types to restrict the algorithm to. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "weightPropertyName",
+        "description": "The name of the property to use as the weight.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "latPropertyName",
+        "description": "The name of the property to use as the latitude.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "lonPropertyName",
+        "description": "The name of the property to use as the longitude.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.algo.aStarConfig(startNode :: NODE, endNode :: NODE, relTypesAndDirections :: STRING, config :: MAP) :: (path :: PATH, weight :: FLOAT)",
+    "name": "apoc.algo.aStarConfig",
+    "description": "Runs the A* search algorithm to find the optimal path between two `NODE` values, using the given `RELATIONSHIP` property name for the cost function.\nThis procedure looks for weight, latitude and longitude properties in the config.",
+    "returnDescription": [
+      {
+        "name": "path",
+        "description": "The path result.",
+        "isDeprecated": false,
+        "type": "PATH"
+      },
+      {
+        "name": "weight",
+        "description": "The weight of the given path.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "startNode",
+        "description": "The node to start the search from.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "endNode",
+        "description": "The node to end the search on.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relTypesAndDirections",
+        "description": "The relationship types to restrict the algorithm to. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{ weight = 'distance' :: STRING, default = Double.MAX_VALUE :: FLOAT, y = 'latitude' :: STRING, x = 'longitude' :: STRING, pointPropName :: STRING }",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.algo.allSimplePaths(startNode :: NODE, endNode :: NODE, relTypesAndDirections :: STRING, maxNodes :: INTEGER) :: (path :: PATH)",
+    "name": "apoc.algo.allSimplePaths",
+    "description": "Runs a search algorithm to find all of the simple paths between the given `RELATIONSHIP` values, up to a max depth described by `maxNodes`.\nThe returned paths will not contain loops.",
+    "returnDescription": [
+      {
+        "name": "path",
+        "description": "The path result.",
+        "isDeprecated": false,
+        "type": "PATH"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "startNode",
+        "description": "The node to start the search from.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "endNode",
+        "description": "The node to end the search on.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relTypesAndDirections",
+        "description": "The relationship types to restrict the algorithm to. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "maxNodes",
+        "description": "The max depth (in terms of nodes) the algorithm will explore.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.algo.dijkstra(startNode :: NODE, endNode :: NODE, relTypesAndDirections :: STRING, weightPropertyName :: STRING, defaultWeight = NaN :: FLOAT, numberOfWantedPaths = 1 :: INTEGER) :: (path :: PATH, weight :: FLOAT)",
+    "name": "apoc.algo.dijkstra",
+    "description": "Runs Dijkstra's algorithm using the given `RELATIONSHIP` property as the cost function.",
+    "returnDescription": [
+      {
+        "name": "path",
+        "description": "The path result.",
+        "isDeprecated": false,
+        "type": "PATH"
+      },
+      {
+        "name": "weight",
+        "description": "The weight of the given path.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "startNode",
+        "description": "The node to start the search from.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "endNode",
+        "description": "The node to end the search on.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relTypesAndDirections",
+        "description": "The relationship types to restrict the algorithm to. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "weightPropertyName",
+        "description": "The name of the property to use as the weight.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "defaultWeight",
+        "description": "The `defaultWeight` is used when no specific weight is provided for the given relationship or node. The default value for defaultWeight is NaN.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=NaN, type=FLOAT}",
+        "type": "FLOAT"
+      },
+      {
+        "name": "numberOfWantedPaths",
+        "description": "The number of wanted paths to return.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=1, type=INTEGER}",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.atomic.add(container :: ANY, propertyName :: STRING, number :: INTEGER | FLOAT, retryAttempts = 5 :: INTEGER) :: (container :: ANY, property :: STRING, oldValue :: ANY, newValue :: ANY)",
+    "name": "apoc.atomic.add",
+    "description": "Sets the given property to the sum of itself and the given `INTEGER` or `FLOAT` value.\nThe procedure then sets the property to the returned sum.",
+    "returnDescription": [
+      {
+        "name": "container",
+        "description": "The updated node or relationship.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "property",
+        "description": "The name of the updated property.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "oldValue",
+        "description": "The original value on the property.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "newValue",
+        "description": "The new value on the property.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "container",
+        "description": "The node or relationship that contains the property to which the value will be added.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "propertyName",
+        "description": "The name of the property whose value will be added to.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "number",
+        "description": "The number to add.",
+        "isDeprecated": false,
+        "type": "INTEGER | FLOAT"
+      },
+      {
+        "name": "retryAttempts",
+        "description": "The max retry attempts.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=5, type=INTEGER}",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.atomic.concat(container :: ANY, propertyName :: STRING, string :: STRING, retryAttempts = 5 :: INTEGER) :: (container :: ANY, property :: STRING, oldValue :: ANY, newValue :: ANY)",
+    "name": "apoc.atomic.concat",
+    "description": "Sets the given property to the concatenation of itself and the `STRING` value.\nThe procedure then sets the property to the returned `STRING`.",
+    "returnDescription": [
+      {
+        "name": "container",
+        "description": "The updated node or relationship.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "property",
+        "description": "The name of the updated property.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "oldValue",
+        "description": "The original value on the property.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "newValue",
+        "description": "The new value on the property.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "container",
+        "description": "The node or relationship that contains the property to which the value will be concatenated.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "propertyName",
+        "description": "The name of the property to be concatenated.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "string",
+        "description": "The string value to concatenate with the property.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "retryAttempts",
+        "description": "The max retry attempts.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=5, type=INTEGER}",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.atomic.insert(container :: ANY, propertyName :: STRING, position :: INTEGER, value :: ANY, retryAttempts = 5 :: INTEGER) :: (container :: ANY, property :: STRING, oldValue :: ANY, newValue :: ANY)",
+    "name": "apoc.atomic.insert",
+    "description": "Inserts a value at position into the `LIST<ANY>` value of a property.\nThe procedure then sets the result back on the property.",
+    "returnDescription": [
+      {
+        "name": "container",
+        "description": "The updated node or relationship.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "property",
+        "description": "The name of the updated property.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "oldValue",
+        "description": "The original value on the property.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "newValue",
+        "description": "The new value on the property.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "container",
+        "description": "The node or relationship that has a property containing a list.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "propertyName",
+        "description": "The name of the property into which the value will be inserted.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "position",
+        "description": "The position in the list to insert the item into.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "value",
+        "description": "The value to insert.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "retryAttempts",
+        "description": "The max retry attempts.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=5, type=INTEGER}",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.atomic.remove(container :: ANY, propertyName :: STRING, position :: INTEGER, retryAttempts = 5 :: INTEGER) :: (container :: ANY, property :: STRING, oldValue :: ANY, newValue :: ANY)",
+    "name": "apoc.atomic.remove",
+    "description": "Removes the element at position from the `LIST<ANY>` value of a property.\nThe procedure then sets the property to the resulting `LIST<ANY>` value.",
+    "returnDescription": [
+      {
+        "name": "container",
+        "description": "The updated node or relationship.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "property",
+        "description": "The name of the updated property.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "oldValue",
+        "description": "The original value on the property.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "newValue",
+        "description": "The new value on the property.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "container",
+        "description": "The node or relationship that has a property containing a list.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "propertyName",
+        "description": "The name of the property from which the value will be removed.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "position",
+        "description": "The position in the list to remove the item from.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "retryAttempts",
+        "description": "The max retry attempts.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=5, type=INTEGER}",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.atomic.subtract(container :: ANY, propertyName :: STRING, number :: INTEGER | FLOAT, retryAttempts = 5 :: INTEGER) :: (container :: ANY, property :: STRING, oldValue :: ANY, newValue :: ANY)",
+    "name": "apoc.atomic.subtract",
+    "description": "Sets the property of a value to itself minus the given `INTEGER` or `FLOAT` value.\nThe procedure then sets the property to the returned sum.",
+    "returnDescription": [
+      {
+        "name": "container",
+        "description": "The updated node or relationship.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "property",
+        "description": "The name of the updated property.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "oldValue",
+        "description": "The original value on the property.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "newValue",
+        "description": "The new value on the property.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "container",
+        "description": "The node or relationship that contains the property from which the value will be subtracted.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "propertyName",
+        "description": "The name of the property from which the value will be subtracted.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "number",
+        "description": "The number to subtract.",
+        "isDeprecated": false,
+        "type": "INTEGER | FLOAT"
+      },
+      {
+        "name": "retryAttempts",
+        "description": "The max retry attempts.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=5, type=INTEGER}",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.atomic.update(container :: ANY, propertyName :: STRING, operation :: STRING, retryAttempts = 5 :: INTEGER) :: (container :: ANY, property :: STRING, oldValue :: ANY, newValue :: ANY)",
+    "name": "apoc.atomic.update",
+    "description": "Updates the value of a property with a Cypher operation.",
+    "returnDescription": [
+      {
+        "name": "container",
+        "description": "The updated node or relationship.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "property",
+        "description": "The name of the updated property.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "oldValue",
+        "description": "The original value on the property.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "newValue",
+        "description": "The new value on the property.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "container",
+        "description": "The node or relationship with the property to be updated.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "propertyName",
+        "description": "The name of the property to be updated.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "operation",
+        "description": "The operation to perform to update the property.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "retryAttempts",
+        "description": "The max retry attempts.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=5, type=INTEGER}",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.coll.elements(coll :: LIST<ANY>, limit = -1 :: INTEGER, offset = 0 :: INTEGER) :: (_1 :: ANY, _2 :: ANY, _3 :: ANY, _4 :: ANY, _5 :: ANY, _6 :: ANY, _7 :: ANY, _8 :: ANY, _9 :: ANY, _10 :: ANY, _1s :: STRING, _2s :: STRING, _3s :: STRING, _4s :: STRING, _5s :: STRING, _6s :: STRING, _7s :: STRING, _8s :: STRING, _9s :: STRING, _10s :: STRING, _1i :: INTEGER, _2i :: INTEGER, _3i :: INTEGER, _4i :: INTEGER, _5i :: INTEGER, _6i :: INTEGER, _7i :: INTEGER, _8i :: INTEGER, _9i :: INTEGER, _10i :: INTEGER, _1f :: FLOAT, _2f :: FLOAT, _3f :: FLOAT, _4f :: FLOAT, _5f :: FLOAT, _6f :: FLOAT, _7f :: FLOAT, _8f :: FLOAT, _9f :: FLOAT, _10f :: FLOAT, _1b :: BOOLEAN, _2b :: BOOLEAN, _3b :: BOOLEAN, _4b :: BOOLEAN, _5b :: BOOLEAN, _6b :: BOOLEAN, _7b :: BOOLEAN, _8b :: BOOLEAN, _9b :: BOOLEAN, _10b :: BOOLEAN, _1l :: LIST<ANY>, _2l :: LIST<ANY>, _3l :: LIST<ANY>, _4l :: LIST<ANY>, _5l :: LIST<ANY>, _6l :: LIST<ANY>, _7l :: LIST<ANY>, _8l :: LIST<ANY>, _9l :: LIST<ANY>, _10l :: LIST<ANY>, _1m :: MAP, _2m :: MAP, _3m :: MAP, _4m :: MAP, _5m :: MAP, _6m :: MAP, _7m :: MAP, _8m :: MAP, _9m :: MAP, _10m :: MAP, _1n :: NODE, _2n :: NODE, _3n :: NODE, _4n :: NODE, _5n :: NODE, _6n :: NODE, _7n :: NODE, _8n :: NODE, _9n :: NODE, _10n :: NODE, _1r :: RELATIONSHIP, _2r :: RELATIONSHIP, _3r :: RELATIONSHIP, _4r :: RELATIONSHIP, _5r :: RELATIONSHIP, _6r :: RELATIONSHIP, _7r :: RELATIONSHIP, _8r :: RELATIONSHIP, _9r :: RELATIONSHIP, _10r :: RELATIONSHIP, _1p :: PATH, _2p :: PATH, _3p :: PATH, _4p :: PATH, _5p :: PATH, _6p :: PATH, _7p :: PATH, _8p :: PATH, _9p :: PATH, _10p :: PATH, elements :: INTEGER)",
+    "name": "apoc.coll.elements",
+    "description": "Deconstructs a `LIST<ANY>` into identifiers indicating their specific type.",
+    "returnDescription": [
+      {
+        "name": "_1",
+        "description": "The value of the first item.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "_2",
+        "description": "The value of the second item.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "_3",
+        "description": "The value of the third item.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "_4",
+        "description": "The value of the fourth item.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "_5",
+        "description": "The value of the fifth item.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "_6",
+        "description": "The value of the sixth item.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "_7",
+        "description": "The value of the seventh item.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "_8",
+        "description": "The value of the eighth item.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "_9",
+        "description": "The value of the ninth item.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "_10",
+        "description": "The value of the tenth item.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "_1s",
+        "description": "The value of the first item, if it is a string value.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "_2s",
+        "description": "The value of the second item, if it is a string value.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "_3s",
+        "description": "The value of the third item, if it is a string value.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "_4s",
+        "description": "The value of the fourth item, if it is a string value.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "_5s",
+        "description": "The value of the fifth item, if it is a string value.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "_6s",
+        "description": "The value of the sixth item, if it is a string value.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "_7s",
+        "description": "The value of the seventh item, if it is a string value.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "_8s",
+        "description": "The value of the eighth item, if it is a string value.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "_9s",
+        "description": "The value of the ninth item, if it is a string value.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "_10s",
+        "description": "The value of the tenth item, if it is a string value.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "_1i",
+        "description": "The value of the first item, if it is an integer value.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "_2i",
+        "description": "The value of the second item, if it is an integer value.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "_3i",
+        "description": "The value of the third item, if it is an integer value.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "_4i",
+        "description": "The value of the fourth item, if it is an integer value.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "_5i",
+        "description": "The value of the fifth item, if it is an integer value.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "_6i",
+        "description": "The value of the sixth item, if it is an integer value.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "_7i",
+        "description": "The value of the seventh item, if it is an integer value.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "_8i",
+        "description": "The value of the eighth item, if it is an integer value.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "_9i",
+        "description": "The value of the ninth item, if it is an integer value.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "_10i",
+        "description": "The value of the tenth item, if it is an integer value.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "_1f",
+        "description": "The value of the first item, if it is a float value.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "_2f",
+        "description": "The value of the second item, if it is a float value.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "_3f",
+        "description": "The value of the third item, if it is a float value.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "_4f",
+        "description": "The value of the fourth item, if it is a float value.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "_5f",
+        "description": "The value of the fifth item, if it is a float value.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "_6f",
+        "description": "The value of the sixth item, if it is a float value.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "_7f",
+        "description": "The value of the seventh item, if it is a float value.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "_8f",
+        "description": "The value of the eighth item, if it is a float value.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "_9f",
+        "description": "The value of the ninth item, if it is a float value.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "_10f",
+        "description": "The value of the tenth item, if it is a float value.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "_1b",
+        "description": "The value of the first item, if it is a boolean value.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "_2b",
+        "description": "The value of the second item, if it is a boolean value.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "_3b",
+        "description": "The value of the third item, if it is a boolean value.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "_4b",
+        "description": "The value of the fourth item, if it is a boolean value.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "_5b",
+        "description": "The value of the fifth item, if it is a boolean value.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "_6b",
+        "description": "The value of the sixth item, if it is a boolean value.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "_7b",
+        "description": "The value of the seventh item, if it is a boolean value.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "_8b",
+        "description": "The value of the eighth item, if it is a boolean value.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "_9b",
+        "description": "The value of the ninth item, if it is a boolean value.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "_10b",
+        "description": "The value of the tenth item, if it is a boolean value.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "_1l",
+        "description": "The value of the first item, if it is a list value.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "_2l",
+        "description": "The value of the second item, if it is a list value.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "_3l",
+        "description": "The value of the third item, if it is a list value.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "_4l",
+        "description": "The value of the fourth item, if it is a list value.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "_5l",
+        "description": "The value of the fifth item, if it is a list value.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "_6l",
+        "description": "The value of the sixth item, if it is a list value.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "_7l",
+        "description": "The value of the seventh item, if it is a list value.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "_8l",
+        "description": "The value of the eighth item, if it is a list value.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "_9l",
+        "description": "The value of the ninth item, if it is a list value.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "_10l",
+        "description": "The value of the tenth item, if it is a list value.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "_1m",
+        "description": "The value of the first item, if it is a map value.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "_2m",
+        "description": "The value of the second item, if it is a map value.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "_3m",
+        "description": "The value of the third item, if it is a map value.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "_4m",
+        "description": "The value of the fourth item, if it is a map value.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "_5m",
+        "description": "The value of the fifth item, if it is a map value.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "_6m",
+        "description": "The value of the sixth item, if it is a map value.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "_7m",
+        "description": "The value of the seventh item, if it is a map value.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "_8m",
+        "description": "The value of the eighth item, if it is a map value.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "_9m",
+        "description": "The value of the ninth item, if it is a map value.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "_10m",
+        "description": "The value of the tenth item, if it is a map value.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "_1n",
+        "description": "The value of the first item, if it is a node value.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "_2n",
+        "description": "The value of the second item, if it is a node value.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "_3n",
+        "description": "The value of the third item, if it is a node value.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "_4n",
+        "description": "The value of the fourth item, if it is a node value.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "_5n",
+        "description": "The value of the fifth item, if it is a node value.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "_6n",
+        "description": "The value of the sixth item, if it is a node value.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "_7n",
+        "description": "The value of the seventh item, if it is a node value.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "_8n",
+        "description": "The value of the eighth item, if it is a node value.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "_9n",
+        "description": "The value of the ninth item, if it is a node value.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "_10n",
+        "description": "The value of the tenth item, if it is a node value.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "_1r",
+        "description": "The value of the first item, if it is a relationship value.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "_2r",
+        "description": "The value of the second item, if it is a relationship value.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "_3r",
+        "description": "The value of the third item, if it is a relationship value.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "_4r",
+        "description": "The value of the fourth item, if it is a relationship value.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "_5r",
+        "description": "The value of the fifth item, if it is a relationship value.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "_6r",
+        "description": "The value of the sixth item, if it is a relationship value.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "_7r",
+        "description": "The value of the seventh item, if it is a relationship value.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "_8r",
+        "description": "The value of the eighth item, if it is a relationship value.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "_9r",
+        "description": "The value of the ninth item, if it is a relationship value.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "_10r",
+        "description": "The value of the tenth item, if it is a relationship value.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "_1p",
+        "description": "The value of the first item, if it is a path value.",
+        "isDeprecated": false,
+        "type": "PATH"
+      },
+      {
+        "name": "_2p",
+        "description": "The value of the second item, if it is a path value.",
+        "isDeprecated": false,
+        "type": "PATH"
+      },
+      {
+        "name": "_3p",
+        "description": "The value of the third item, if it is a path value.",
+        "isDeprecated": false,
+        "type": "PATH"
+      },
+      {
+        "name": "_4p",
+        "description": "The value of the fourth item, if it is a path value.",
+        "isDeprecated": false,
+        "type": "PATH"
+      },
+      {
+        "name": "_5p",
+        "description": "The value of the fifth item, if it is a path value.",
+        "isDeprecated": false,
+        "type": "PATH"
+      },
+      {
+        "name": "_6p",
+        "description": "The value of the sixth item, if it is a path value.",
+        "isDeprecated": false,
+        "type": "PATH"
+      },
+      {
+        "name": "_7p",
+        "description": "The value of the seventh item, if it is a path value.",
+        "isDeprecated": false,
+        "type": "PATH"
+      },
+      {
+        "name": "_8p",
+        "description": "The value of the eighth item, if it is a path value.",
+        "isDeprecated": false,
+        "type": "PATH"
+      },
+      {
+        "name": "_9p",
+        "description": "The value of the ninth item, if it is a path value.",
+        "isDeprecated": false,
+        "type": "PATH"
+      },
+      {
+        "name": "_10p",
+        "description": "The value of the tenth item, if it is a path value.",
+        "isDeprecated": false,
+        "type": "PATH"
+      },
+      {
+        "name": "elements",
+        "description": "The number of deconstructed elements.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "A list of values to deconstruct.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "limit",
+        "description": "The maximum size of elements to deconstruct from the given list.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=-1, type=INTEGER}",
+        "type": "INTEGER"
+      },
+      {
+        "name": "offset",
+        "description": "The offset to start deconstructing from.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=0, type=INTEGER}",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.coll.split(coll :: LIST<ANY>, value :: ANY) :: (value :: LIST<ANY>)",
+    "name": "apoc.coll.split",
+    "description": "Splits a collection by the given value.\nThe value itself will not be part of the resulting `LIST<ANY>` values.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The split list.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list to split into parts.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "value",
+        "description": "The value to split the given list by.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.convert.setJsonProperty(node :: NODE, key :: STRING, value :: ANY)",
+    "name": "apoc.convert.setJsonProperty",
+    "description": "Serializes the given JSON object and sets it as a property on the given `NODE`.",
+    "returnDescription": [],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "node",
+        "description": "The node to set the JSON property on.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "key",
+        "description": "The name of the property to set.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "value",
+        "description": "The property to serialize as a JSON object.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.create.clonePathToVirtual(path :: PATH) :: (path :: PATH)",
+    "name": "apoc.create.clonePathToVirtual",
+    "description": "Takes the given `PATH` and returns a virtual representation of it.",
+    "returnDescription": [
+      {
+        "name": "path",
+        "description": "The path result.",
+        "isDeprecated": false,
+        "type": "PATH"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "path",
+        "description": "The path to create a virtual path from.",
+        "isDeprecated": false,
+        "type": "PATH"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.create.clonePathsToVirtual(paths :: LIST<PATH>) :: (path :: PATH)",
+    "name": "apoc.create.clonePathsToVirtual",
+    "description": "Takes the given `LIST<PATH>` and returns a virtual representation of them.",
+    "returnDescription": [
+      {
+        "name": "path",
+        "description": "The path result.",
+        "isDeprecated": false,
+        "type": "PATH"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "paths",
+        "description": "The paths to create virtual paths from.",
+        "isDeprecated": false,
+        "type": "LIST<PATH>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.create.vNode(labels :: LIST<STRING>, props :: MAP) :: (node :: NODE)",
+    "name": "apoc.create.vNode",
+    "description": "Returns a virtual `NODE`.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The created virtual node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "labels",
+        "description": "The labels to assign to the new virtual node.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "props",
+        "description": "The properties to assign to the new virtual node.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.create.vNodes(labels :: LIST<STRING>, props :: LIST<MAP>) :: (node :: NODE)",
+    "name": "apoc.create.vNodes",
+    "description": "Returns virtual `NODE` values.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The created virtual node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "labels",
+        "description": "The labels to assign to the new virtual node.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "props",
+        "description": "The properties to assign to the new virtual nodes.",
+        "isDeprecated": false,
+        "type": "LIST<MAP>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.create.vRelationship(from :: NODE, relType :: STRING, props :: MAP, to :: NODE) :: (rel :: RELATIONSHIP)",
+    "name": "apoc.create.vRelationship",
+    "description": "Returns a virtual `RELATIONSHIP`.",
+    "returnDescription": [
+      {
+        "name": "rel",
+        "description": "The created virtual relationship.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "from",
+        "description": "The node to connect the outgoing virtual relationship from.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relType",
+        "description": "The type to assign to the new virtual relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "props",
+        "description": "The properties to assign to the new virtual relationship.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "to",
+        "description": "The node to which the incoming virtual relationship will be connected.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.create.virtualPath(labelsN :: LIST<STRING>, n :: MAP, arelType :: STRING, props :: MAP, labelsM :: LIST<STRING>, m :: MAP) :: (from :: NODE, rel :: RELATIONSHIP, to :: NODE)",
+    "name": "apoc.create.virtualPath",
+    "description": "Returns a virtual `PATH`.",
+    "returnDescription": [
+      {
+        "name": "from",
+        "description": "The created virtual start node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "rel",
+        "description": "The created virtual relationship.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "to",
+        "description": "The created virtual end node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "labelsN",
+        "description": "The labels to assign to the new virtual start node.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "n",
+        "description": "The properties to assign to the new virtual start node.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "arelType",
+        "description": "The type to assign to the new virtual relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "props",
+        "description": "The properties to assign to the new virtual relationship.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "labelsM",
+        "description": "The labels to assign to the new virtual node.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "m",
+        "description": "The properties to assign to the new virtual node.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.cypher.doIt(statement :: STRING, params :: MAP) :: (value :: MAP)",
+    "name": "apoc.cypher.doIt",
+    "description": "Runs a dynamically constructed statement with the given parameters. This procedure allows for both read and write statements.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The result returned from the Cypher statement.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "statement",
+        "description": "The Cypher statement to run.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statement.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.cypher.run(statement :: STRING, params :: MAP) :: (value :: MAP)",
+    "name": "apoc.cypher.run",
+    "description": "Runs a dynamically constructed read-only statement with the given parameters.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The result returned from the Cypher statement.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "statement",
+        "description": "The Cypher statement to run.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statement.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.cypher.runMany(statement :: STRING, params :: MAP, config = {} :: MAP) :: (row :: INTEGER, result :: MAP)",
+    "name": "apoc.cypher.runMany",
+    "description": "Runs each semicolon separated statement and returns a summary of the statement outcomes.",
+    "returnDescription": [
+      {
+        "name": "row",
+        "description": "The row number of the run Cypher statement.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "result",
+        "description": "The result returned from the Cypher statement.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "statement",
+        "description": "The Cypher statements to run, semicolon separated (;).",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statements.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "config",
+        "description": "{ statistics = true :: BOOLEAN }",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.cypher.runManyReadOnly(statement :: STRING, params :: MAP, config = {} :: MAP) :: (row :: INTEGER, result :: MAP)",
+    "name": "apoc.cypher.runManyReadOnly",
+    "description": "Runs each semicolon separated read-only statement and returns a summary of the statement outcomes.",
+    "returnDescription": [
+      {
+        "name": "row",
+        "description": "The row number of the run Cypher statement.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "result",
+        "description": "The result returned from the Cypher statement.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "statement",
+        "description": "The Cypher statements to run, semicolon separated (;).",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statements.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "config",
+        "description": "{ statistics = true :: BOOLEAN }",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.cypher.runSchema(statement :: STRING, params :: MAP) :: (value :: MAP)",
+    "name": "apoc.cypher.runSchema",
+    "description": "Runs the given query schema statement with the given parameters.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The result returned from the Cypher statement.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "statement",
+        "description": "The Cypher schema statement to run.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statement.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.cypher.runWrite(statement :: STRING, params :: MAP) :: (value :: MAP)",
+    "name": "apoc.cypher.runWrite",
+    "description": "Alias for `apoc.cypher.doIt`.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The result returned from the Cypher statement.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "statement",
+        "description": "The Cypher statement to run.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statement.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.example.movies() :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
+    "name": "apoc.example.movies",
+    "description": "Seeds the database with the Neo4j movie dataset.",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file containing the movies example.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "source",
+        "description": "Where the examples were sourced from.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format the movies file was in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of nodes imported.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of relationships imported.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of properties imported.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the import.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the import was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the import was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "Whether the import ran successfully.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "data",
+        "description": "The data returned by the import.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": []
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.export.csv.all(file :: STRING, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
+    "name": "apoc.export.csv.all",
+    "description": "Exports the full database to the provided CSV file.",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data was exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "source",
+        "description": "A summary of the exported data.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format the file is exported in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of exported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of exported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of exported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the export.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "Whether the export ran successfully.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "data",
+        "description": "The data returned by the export.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data will be exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        quotes = 'always' :: ['always', 'none', 'ifNeeded'],\n        differentiateNulls = false :: BOOLEAN,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.export.csv.data(nodes :: LIST<NODE>, rels :: LIST<RELATIONSHIP>, file :: STRING, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
+    "name": "apoc.export.csv.data",
+    "description": "Exports the given `NODE` and `RELATIONSHIP` values to the provided CSV file.",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data was exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "source",
+        "description": "A summary of the exported data.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format the file is exported in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of exported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of exported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of exported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the export.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "Whether the export ran successfully.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "data",
+        "description": "The data returned by the export.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "A list of nodes to export.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "rels",
+        "description": "A list of relationships to export.",
+        "isDeprecated": false,
+        "type": "LIST<RELATIONSHIP>"
+      },
+      {
+        "name": "file",
+        "description": "The name of the file to which the data will be exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        quotes = 'always' :: ['always', 'none', 'ifNeeded'],\n        differentiateNulls = false :: BOOLEAN,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.export.csv.graph(graph :: MAP, file :: STRING, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
+    "name": "apoc.export.csv.graph",
+    "description": "Exports the given graph to the provided CSV file.",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data was exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "source",
+        "description": "A summary of the exported data.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format the file is exported in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of exported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of exported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of exported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the export.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "Whether the export ran successfully.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "data",
+        "description": "The data returned by the export.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "graph",
+        "description": "The graph to export.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "file",
+        "description": "The name of the file to which the data will be exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        quotes = 'always' :: ['always', 'none', 'ifNeeded'],\n        differentiateNulls = false :: BOOLEAN,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.export.csv.query(query :: STRING, file :: STRING, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
+    "name": "apoc.export.csv.query",
+    "description": "Exports the results from running the given Cypher query to the provided CSV file.",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data was exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "source",
+        "description": "A summary of the exported data.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format the file is exported in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of exported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of exported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of exported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the export.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "Whether the export ran successfully.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "data",
+        "description": "The data returned by the export.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "query",
+        "description": "The query used to collect the data for export.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "file",
+        "description": "The name of the file to which the data will be exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None':: STRING,\n        charset = 'UTF_8' :: STRING,\n        quotes = 'always' :: ['always', 'none', 'ifNeeded'],\n        differentiateNulls = false :: BOOLEAN,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.export.cypher.all(file =  :: STRING, config = {} :: MAP) :: (file :: STRING, batches :: INTEGER, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, cypherStatements :: ANY, nodeStatements :: ANY, relationshipStatements :: ANY, schemaStatements :: ANY, cleanupStatements :: ANY)",
+    "name": "apoc.export.cypher.all",
+    "description": "Exports the full database (incl. indexes) as Cypher statements to the provided file (default: Cypher Shell).",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data was exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "source",
+        "description": "A summary of the exported data.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format the file is exported in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of exported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of exported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of exported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the export.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "cypherStatements",
+        "description": "The executed Cypher Statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "nodeStatements",
+        "description": "The executed node statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "relationshipStatements",
+        "description": "The executed relationship statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "schemaStatements",
+        "description": "The executed schema statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "cleanupStatements",
+        "description": "The executed cleanup statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data will be exported.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.export.cypher.data(nodes :: LIST<NODE>, rels :: LIST<RELATIONSHIP>, file =  :: STRING, config = {} :: MAP) :: (file :: STRING, batches :: INTEGER, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, cypherStatements :: ANY, nodeStatements :: ANY, relationshipStatements :: ANY, schemaStatements :: ANY, cleanupStatements :: ANY)",
+    "name": "apoc.export.cypher.data",
+    "description": "Exports the given `NODE` and `RELATIONSHIP` values (incl. indexes) as Cypher statements to the provided file (default: Cypher Shell).",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data was exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "source",
+        "description": "A summary of the exported data.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format the file is exported in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of exported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of exported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of exported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the export.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "cypherStatements",
+        "description": "The executed Cypher Statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "nodeStatements",
+        "description": "The executed node statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "relationshipStatements",
+        "description": "The executed relationship statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "schemaStatements",
+        "description": "The executed schema statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "cleanupStatements",
+        "description": "The executed cleanup statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "A list of nodes to export.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "rels",
+        "description": "A list of relationships to export.",
+        "isDeprecated": false,
+        "type": "LIST<RELATIONSHIP>"
+      },
+      {
+        "name": "file",
+        "description": "The name of the file to which the data will be exported.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.export.cypher.graph(graph :: MAP, file :: STRING, config = {} :: MAP) :: (file :: STRING, batches :: INTEGER, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, cypherStatements :: ANY, nodeStatements :: ANY, relationshipStatements :: ANY, schemaStatements :: ANY, cleanupStatements :: ANY)",
+    "name": "apoc.export.cypher.graph",
+    "description": "Exports the given graph (incl. indexes) as Cypher statements to the provided file (default: Cypher Shell).",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data was exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "source",
+        "description": "A summary of the exported data.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format the file is exported in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of exported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of exported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of exported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the export.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "cypherStatements",
+        "description": "The executed Cypher Statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "nodeStatements",
+        "description": "The executed node statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "relationshipStatements",
+        "description": "The executed relationship statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "schemaStatements",
+        "description": "The executed schema statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "cleanupStatements",
+        "description": "The executed cleanup statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "graph",
+        "description": "The graph to export.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "file",
+        "description": "The name of the file to which the data will be exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.export.cypher.query(statement :: STRING, file =  :: STRING, config = {} :: MAP) :: (file :: STRING, batches :: INTEGER, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, cypherStatements :: ANY, nodeStatements :: ANY, relationshipStatements :: ANY, schemaStatements :: ANY, cleanupStatements :: ANY)",
+    "name": "apoc.export.cypher.query",
+    "description": "Exports the `NODE` and `RELATIONSHIP` values from the given Cypher query (incl. indexes) as Cypher statements to the provided file (default: Cypher Shell).",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data was exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "source",
+        "description": "A summary of the exported data.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format the file is exported in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of exported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of exported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of exported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the export.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "cypherStatements",
+        "description": "The executed Cypher Statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "nodeStatements",
+        "description": "The executed node statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "relationshipStatements",
+        "description": "The executed relationship statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "schemaStatements",
+        "description": "The executed schema statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "cleanupStatements",
+        "description": "The executed cleanup statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "statement",
+        "description": "The query used to collect the data for export.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "file",
+        "description": "The name of the file to which the data will be exported.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.export.cypher.schema(file =  :: STRING, config = {} :: MAP) :: (file :: STRING, batches :: INTEGER, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, cypherStatements :: ANY, nodeStatements :: ANY, relationshipStatements :: ANY, schemaStatements :: ANY, cleanupStatements :: ANY)",
+    "name": "apoc.export.cypher.schema",
+    "description": "Exports all schema indexes and constraints to Cypher statements.",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data was exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "source",
+        "description": "A summary of the exported data.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format the file is exported in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of exported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of exported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of exported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the export.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "cypherStatements",
+        "description": "The executed Cypher Statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "nodeStatements",
+        "description": "The executed node statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "relationshipStatements",
+        "description": "The executed relationship statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "schemaStatements",
+        "description": "The executed schema statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "cleanupStatements",
+        "description": "The executed cleanup statements.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data will be exported.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n        stream = false :: BOOLEAN,\n        batchSize = 20000 :: INTEGER,\n        bulkImport = false :: BOOLEAN,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING,\n        sampling = false :: BOOLEAN,\n        samplingConfig :: MAP\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.export.graphml.all(file :: STRING, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
+    "name": "apoc.export.graphml.all",
+    "description": "Exports the full database to the provided GraphML file.",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data was exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "source",
+        "description": "A summary of the exported data.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format the file is exported in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of exported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of exported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of exported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the export.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "Whether the export ran successfully.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "data",
+        "description": "The data returned by the export.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data will be exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n        stream = false :: BOOLEAN,\n        format = 'cypher-shell' :: STRING,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'NONE' :: ['NONE', 'BYTES', 'GZIP', 'BZIP2', 'DEFLATE', 'BLOCK_LZ4', 'FRAMED_SNAPPY'],\n        charset = 'UTF_8' :: STRING,\n        source :: MAP,\n        target :: MAP,\n        useTypes :: BOOLEAN,\n        caption :: LIST<STRING>\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.export.graphml.data(nodes :: LIST<NODE>, rels :: LIST<RELATIONSHIP>, file :: STRING, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
+    "name": "apoc.export.graphml.data",
+    "description": "Exports the given `NODE` and `RELATIONSHIP` values to the provided GraphML file.",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data was exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "source",
+        "description": "A summary of the exported data.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format the file is exported in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of exported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of exported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of exported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the export.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "Whether the export ran successfully.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "data",
+        "description": "The data returned by the export.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "A list of nodes to export.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "rels",
+        "description": "A list of relationships to export.",
+        "isDeprecated": false,
+        "type": "LIST<RELATIONSHIP>"
+      },
+      {
+        "name": "file",
+        "description": "The name of the file to which the data will be exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n        stream = false :: BOOLEAN,\n        format = 'cypher-shell' :: STRING,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'NONE' :: ['NONE', 'BYTES', 'GZIP', 'BZIP2', 'DEFLATE', 'BLOCK_LZ4', 'FRAMED_SNAPPY'],\n        charset = 'UTF_8' :: STRING,\n        source :: MAP,\n        target :: MAP,\n        useTypes :: BOOLEAN,\n        caption :: LIST<STRING>\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.export.graphml.graph(graph :: MAP, file :: STRING, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
+    "name": "apoc.export.graphml.graph",
+    "description": "Exports the given graph to the provided GraphML file.",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data was exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "source",
+        "description": "A summary of the exported data.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format the file is exported in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of exported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of exported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of exported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the export.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "Whether the export ran successfully.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "data",
+        "description": "The data returned by the export.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "graph",
+        "description": "The graph to export.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "file",
+        "description": "The name of the file to which the data will be exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n        stream = false :: BOOLEAN,\n        format = 'cypher-shell' :: STRING,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'NONE' :: ['NONE', 'BYTES', 'GZIP', 'BZIP2', 'DEFLATE', 'BLOCK_LZ4', 'FRAMED_SNAPPY'],\n        charset = 'UTF_8' :: STRING,\n        source :: MAP,\n        target :: MAP,\n        useTypes :: BOOLEAN,\n        caption :: LIST<STRING>\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.export.graphml.query(statement :: STRING, file :: STRING, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
+    "name": "apoc.export.graphml.query",
+    "description": "Exports the given `NODE` and `RELATIONSHIP` values from the Cypher statement to the provided GraphML file.",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data was exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "source",
+        "description": "A summary of the exported data.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format the file is exported in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of exported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of exported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of exported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the export.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "Whether the export ran successfully.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "data",
+        "description": "The data returned by the export.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "statement",
+        "description": "The query used to collect the data for export.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "file",
+        "description": "The name of the file to which the data will be exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n        stream = false :: BOOLEAN,\n        format = 'cypher-shell' :: STRING,\n        timeoutSeconds = 100 :: INTEGER,\n        compression = 'NONE' :: ['NONE', 'BYTES', 'GZIP', 'BZIP2', 'DEFLATE', 'BLOCK_LZ4', 'FRAMED_SNAPPY'],\n        charset = 'UTF_8' :: STRING,\n        source :: MAP,\n        target :: MAP,\n        useTypes :: BOOLEAN,\n        caption :: LIST<STRING>,\n        nodesOfRelationships = false :: BOOLEAN\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.export.json.all(file :: STRING, config = {} :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
+    "name": "apoc.export.json.all",
+    "description": "Exports the full database to the provided JSON file.",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data was exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "source",
+        "description": "A summary of the exported data.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format the file is exported in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of exported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of exported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of exported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the export.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "Whether the export ran successfully.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "data",
+        "description": "The data returned by the export.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data will be exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n        stream = false :: BOOLEAN,\n        writeNodeProperties = true :: BOOLEAN,\n        writeRelationshipProperties = writeNodeProperties :: BOOLEAN,\n        jsonFormat = 'JSON_LINES' :: STRING,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.export.json.data(nodes :: LIST<NODE>, rels :: LIST<RELATIONSHIP>, file :: STRING, config = {} :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
+    "name": "apoc.export.json.data",
+    "description": "Exports the given `NODE` and `RELATIONSHIP` values to the provided JSON file.",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data was exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "source",
+        "description": "A summary of the exported data.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format the file is exported in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of exported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of exported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of exported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the export.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "Whether the export ran successfully.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "data",
+        "description": "The data returned by the export.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "A list of nodes to export.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "rels",
+        "description": "A list of relationships to export.",
+        "isDeprecated": false,
+        "type": "LIST<RELATIONSHIP>"
+      },
+      {
+        "name": "file",
+        "description": "The name of the file to which the data will be exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n        stream = false :: BOOLEAN,\n        writeNodeProperties = true :: BOOLEAN,\n        writeRelationshipProperties = writeNodeProperties :: BOOLEAN,\n        jsonFormat = 'JSON_LINES' :: STRING,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.export.json.graph(graph :: MAP, file :: STRING, config = {} :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
+    "name": "apoc.export.json.graph",
+    "description": "Exports the given graph to the provided JSON file.",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data was exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "source",
+        "description": "A summary of the exported data.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format the file is exported in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of exported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of exported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of exported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the export.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "Whether the export ran successfully.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "data",
+        "description": "The data returned by the export.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "graph",
+        "description": "The graph to export.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "file",
+        "description": "The name of the file to which the data will be exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n        stream = false :: BOOLEAN,\n        writeNodeProperties = true :: BOOLEAN,\n        writeRelationshipProperties = writeNodeProperties :: BOOLEAN,\n        jsonFormat = 'JSON_LINES' :: STRING,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.export.json.query(statement :: STRING, file :: STRING, config = {} :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
+    "name": "apoc.export.json.query",
+    "description": "Exports the results from the Cypher statement to the provided JSON file.",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file to which the data was exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "source",
+        "description": "A summary of the exported data.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format the file is exported in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of exported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of exported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of exported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the export.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the export was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "Whether the export ran successfully.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "data",
+        "description": "The data returned by the export.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "statement",
+        "description": "The query used to collect the data for export.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "file",
+        "description": "The name of the file to which the data will be exported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n        stream = false :: BOOLEAN,\n        writeNodeProperties = true :: BOOLEAN,\n        writeRelationshipProperties = writeNodeProperties :: BOOLEAN,\n        jsonFormat = 'JSON_LINES' :: STRING,\n        compression = 'None' :: STRING,\n        charset = 'UTF_8' :: STRING\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.graph.from(data :: ANY, name :: STRING, props :: MAP) :: (graph :: MAP)",
+    "name": "apoc.graph.from",
+    "description": "Generates a virtual sub-graph by extracting all of the `NODE` and `RELATIONSHIP` values from the given data.",
+    "returnDescription": [
+      {
+        "name": "graph",
+        "description": "The resulting graph.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "data",
+        "description": "An object to extract nodes and relationships from. It can be of type; NODE | RELATIONSHIP | PATH | LIST<ANY>.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "name",
+        "description": "The name of the resulting graph.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "props",
+        "description": "The properties to be present in the resulting graph.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.graph.fromCypher(statement :: STRING, params :: MAP, name :: STRING, props :: MAP) :: (graph :: MAP)",
+    "name": "apoc.graph.fromCypher",
+    "description": "Generates a virtual sub-graph by extracting all of the `NODE` and `RELATIONSHIP` values from the data returned by the given Cypher statement.",
+    "returnDescription": [
+      {
+        "name": "graph",
+        "description": "The resulting graph.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "statement",
+        "description": "The Cypher statement to create the graph from.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statement.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "name",
+        "description": "The name of the resulting graph.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "props",
+        "description": "The properties to include in the resulting graph.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.graph.fromDB(name :: STRING, props :: MAP) :: (graph :: MAP)",
+    "name": "apoc.graph.fromDB",
+    "description": "Generates a virtual sub-graph by extracting all of the `NODE` and `RELATIONSHIP` values from the data returned by the given database.",
+    "returnDescription": [
+      {
+        "name": "graph",
+        "description": "The resulting graph.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "name",
+        "description": "The name of the resulting graph.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "props",
+        "description": "The properties to be present in the resulting graph.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.graph.fromData(nodes :: LIST<NODE>, rels :: LIST<RELATIONSHIP>, name :: STRING, props :: MAP) :: (graph :: MAP)",
+    "name": "apoc.graph.fromData",
+    "description": "Generates a virtual sub-graph by extracting all of the `NODE` and `RELATIONSHIP` values from the given data.",
+    "returnDescription": [
+      {
+        "name": "graph",
+        "description": "The resulting graph.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to include in the resulting graph.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "rels",
+        "description": "The relationship to include in the resulting graph.",
+        "isDeprecated": false,
+        "type": "LIST<RELATIONSHIP>"
+      },
+      {
+        "name": "name",
+        "description": "The name of the resulting graph.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "props",
+        "description": "The properties to include in the resulting graph.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.graph.fromDocument(json :: ANY, config = {} :: MAP) :: (graph :: MAP)",
+    "name": "apoc.graph.fromDocument",
+    "description": "Generates a virtual sub-graph by extracting all of the `NODE` and `RELATIONSHIP` values from the data returned by the given JSON file.",
+    "returnDescription": [
+      {
+        "name": "graph",
+        "description": "The resulting graph.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "json",
+        "description": "A JSON object to generate a graph from.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "config",
+        "description": "{\n        write = false :: BOOLEAN,\n        labelField = 'type' :: STRING.\n        idField = 'id' :: STRING,\n        generateID = true :: BOOLEAN,\n        defaultLabel = '' :: STRING,\n        skipValidation = false :: BOOLEAN,\n        mappings = {} :: MAP\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.graph.fromPath(path :: PATH, name :: STRING, props :: MAP) :: (graph :: MAP)",
+    "name": "apoc.graph.fromPath",
+    "description": "Generates a virtual sub-graph by extracting all of the `NODE` and `RELATIONSHIP` values from the data returned by the given `PATH`.",
+    "returnDescription": [
+      {
+        "name": "graph",
+        "description": "The resulting graph.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "path",
+        "description": "A path to extract the nodes and relationships from.",
+        "isDeprecated": false,
+        "type": "PATH"
+      },
+      {
+        "name": "name",
+        "description": "The name to give the resulting graph.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "props",
+        "description": "The properties to include in the resulting graph.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.graph.fromPaths(paths :: LIST<PATH>, name :: STRING, props :: MAP) :: (graph :: MAP)",
+    "name": "apoc.graph.fromPaths",
+    "description": "Generates a virtual sub-graph by extracting all of the `NODE` and `RELATIONSHIP` values from the data returned by the given `PATH` values.",
+    "returnDescription": [
+      {
+        "name": "graph",
+        "description": "The resulting graph.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "paths",
+        "description": "A list of paths to extract nodes and relationships from.",
+        "isDeprecated": false,
+        "type": "LIST<PATH>"
+      },
+      {
+        "name": "name",
+        "description": "The name of the resulting graph.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "props",
+        "description": "The properties to include in the resulting graph.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.graph.validateDocument(json :: ANY, config = {} :: MAP) :: (row :: MAP)",
+    "name": "apoc.graph.validateDocument",
+    "description": "Validates the JSON file and returns the result of the validation.",
+    "returnDescription": [
+      {
+        "name": "row",
+        "description": "The result of the validation.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "json",
+        "description": "The JSON object to validate.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "config",
+        "description": "{\n        write = false :: BOOLEAN,\n        labelField = 'type' :: STRING.\n        idField = 'id' :: STRING,\n        generateID = true :: BOOLEAN,\n        defaultLabel = '' :: STRING,\n        skipValidation = false :: BOOLEAN,\n        mappings = {} :: MAP\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.help(proc :: STRING) :: (type :: STRING, name :: STRING, text :: STRING, signature :: STRING, roles :: LIST<STRING>, writes :: BOOLEAN, core :: BOOLEAN, isDeprecated :: BOOLEAN)",
+    "name": "apoc.help",
+    "description": "Returns descriptions of the available APOC procedures and functions. If a keyword is provided, it will return only those procedures and functions that have the keyword in their name.",
+    "returnDescription": [
+      {
+        "name": "type",
+        "description": "Whether it is a function or a procedure.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "name",
+        "description": "The name of the function or procedure.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "text",
+        "description": "The description of the function or procedure.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "signature",
+        "description": "The signature of the function or procedure.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "roles",
+        "description": "This value is always null.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "writes",
+        "description": "This value is always null.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "core",
+        "description": "If the function or procedure belongs to APOC Core.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "isDeprecated",
+        "description": "If the function or procedure is deprecated.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "proc",
+        "description": "A keyword to filter the results by.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.import.csv(nodes :: LIST<MAP>, rels :: LIST<MAP>, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
+    "name": "apoc.import.csv",
+    "description": "Imports `NODE` and `RELATIONSHIP` values with the given labels and types from the provided CSV file.",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file from which the data was imported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "source",
+        "description": "The source of the imported data: \"file\", \"binary\" or \"file/binary\".",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format of the file: [\"csv\", \"graphml\", \"json\"].",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of imported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of imported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of imported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the import.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the import was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the import was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "Whether the import ran successfully.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "data",
+        "description": "The data returned by the import.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "List of map values of where to import the node values from; { fileName :: STRING, data :: BYTEARRAY, labels :: LIST<STRING> }.",
+        "isDeprecated": false,
+        "type": "LIST<MAP>"
+      },
+      {
+        "name": "rels",
+        "description": "List of map values specifying where to import relationship values from: { fileName :: STRING, data :: BYTEARRAY, type :: STRING }.",
+        "isDeprecated": false,
+        "type": "LIST<MAP>"
+      },
+      {
+        "name": "config",
+        "description": "{\n    delimiter = \",\" :: STRING,\n    arrayDelimiter = \";\" :: STRING,\n    ignoreDuplicateNodes = false :: BOOLEAN,\n    quotationCharacter = \"\"\" :: STRING,\n    stringIds = true :: BOOLEAN,\n    skipLines = 1 :: INTEGER,\n    ignoreBlankString = false :: BOOLEAN,\n    ignoreEmptyCellArray = false :: BOOLEAN,\n    compression = \"NONE\" :: [\"NONE\", \"BYTES\", \"GZIP\", \"BZIP2\", \"DEFLATE\", \"BLOCK_LZ4\", \"FRAMED_SNAPPY\"],\n    charset = \"UTF-8\" :: STRING,\n    batchSize = 2000 :: INTEGER\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.import.graphml(urlOrBinaryFile :: ANY, config :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
+    "name": "apoc.import.graphml",
+    "description": "Imports a graph from the provided GraphML file.",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file from which the data was imported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "source",
+        "description": "The source of the imported data: \"file\", \"binary\" or \"file/binary\".",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format of the file: [\"csv\", \"graphml\", \"json\"].",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of imported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of imported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of imported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the import.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the import was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the import was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "Whether the import ran successfully.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "data",
+        "description": "The data returned by the import.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "urlOrBinaryFile",
+        "description": "The name of the file or binary data to import the data from.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "config",
+        "description": "{\n    readLabels = false :: BOOLEAN,\n    defaultRelationshipType = \"RELATED\" :: STRING,\n    storeNodeIds = false :: BOOLEAN,\n    batchSize = 20000 :: INTEGER,\n    compression = \"NONE\" :: [\"NONE\", \"BYTES\", \"GZIP\", \"BZIP2\", \"DEFLATE\", \"BLOCK_LZ4\", \"FRAMED_SNAPPY\"],\n    source = {} :: MAP,\n    target = {} :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.import.json(urlOrBinaryFile :: ANY, config = {} :: MAP) :: (file :: STRING, source :: STRING, format :: STRING, nodes :: INTEGER, relationships :: INTEGER, properties :: INTEGER, time :: INTEGER, rows :: INTEGER, batchSize :: INTEGER, batches :: INTEGER, done :: BOOLEAN, data :: ANY)",
+    "name": "apoc.import.json",
+    "description": "Imports a graph from the provided JSON file.",
+    "returnDescription": [
+      {
+        "name": "file",
+        "description": "The name of the file from which the data was imported.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "source",
+        "description": "The source of the imported data: \"file\", \"binary\" or \"file/binary\".",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format of the file: [\"csv\", \"graphml\", \"json\"].",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The number of imported nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relationships",
+        "description": "The number of imported relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "properties",
+        "description": "The number of imported properties.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "time",
+        "description": "The duration of the import.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rows",
+        "description": "The number of rows returned.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchSize",
+        "description": "The size of the batches the import was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batches",
+        "description": "The number of batches the import was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "Whether the import ran successfully.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "data",
+        "description": "The data returned by the import.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "urlOrBinaryFile",
+        "description": "The name of the file or binary data to import the data from.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "config",
+        "description": "{\n    unwindBatchSize = 5000 :: INTEGER,\n    txBatchSize = 5000 :: INTEGER,\n    importIdName = \"neo4jImportId\" :: STRING,\n    nodePropertyMappings = {} :: MAP,\n    relPropertyMappings = {} :: MAP,\n    compression = \"NONE\" :: [\"NONE\", \"BYTES\", \"GZIP\", \"BZIP2\", \"DEFLATE\", \"BLOCK_LZ4\", \"FRAMED_SNAPPY\"],\n    cleanup = false :: BOOLEAN,\n    nodePropFilter = {} :: MAP,\n    relPropFilter = {} :: MAP\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.import.xml(urlOrBinary :: ANY, config = {} :: MAP) :: (node :: NODE)",
+    "name": "apoc.import.xml",
+    "description": "Imports a graph from the provided XML file.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "An imported node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "urlOrBinary",
+        "description": "The name of the file or binary data to import the data from.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "config",
+        "description": "{\n    connectCharacters = false :: BOOLEAN,\n    filterLeadingWhitespace = false :: BOOLEAN,\n    delimiter = \" \" :: STRING,\n    label :: STRING,\n    relType :: STRING,\n    charactersForTag :: MAP\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.load.json(urlOrKeyOrBinary :: ANY, path =  :: STRING, config = {} :: MAP) :: (value :: MAP)",
+    "name": "apoc.load.json",
+    "description": "Imports JSON file as a stream of values if the given JSON file is a `LIST<ANY>`.\nIf the given JSON file is a `MAP`, this procedure imports a single value instead.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "A map of data loaded from the given file.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "urlOrKeyOrBinary",
+        "description": "The name of the file or binary data to import the data from.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "path",
+        "description": "A JSON path expression used to extract a certain part from the list.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n    failOnError = true :: BOOLEAN,\n    pathOptions :: LIST<STRING>,\n    compression = \"NONE\" :: [\"NONE\", \"BYTES\", \"GZIP\", \"BZIP2\", \"DEFLATE\", \"BLOCK_LZ4\", \"FRAMED_SNAPPY\"]\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.load.jsonArray(url :: STRING, path =  :: STRING, config = {} :: MAP) :: (value :: ANY)",
+    "name": "apoc.load.jsonArray",
+    "description": "Loads array from a JSON URL (e.g. web-API) to then import the given JSON file as a stream of values.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "Data loaded from the given file.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "url",
+        "description": "The path to the JSON file.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "path",
+        "description": "A JSON path expression used to extract a certain part from the list.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n    failOnError = true :: BOOLEAN,\n    pathOptions :: LIST<STRING>,\n    compression = \"NONE\" :: [\"NONE\", \"BYTES\", \"GZIP\", \"BZIP2\"\", \"DEFLATE\", \"BLOCK_LZ4\", \"FRAMED_SNAPPY\"]\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.load.xml(urlOrBinary :: ANY, path = / :: STRING, config = {} :: MAP, simple = false :: BOOLEAN) :: (value :: MAP)",
+    "name": "apoc.load.xml",
+    "description": "Loads a single nested `MAP` from an XML URL (e.g. web-API).",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "A map of data loaded from the given file.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "urlOrBinary",
+        "description": "The name of the file or binary data to import the data from.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "path",
+        "description": "An xPath expression to select nodes from the given XML document.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=/, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n    failOnError = true :: BOOLEAN,\n    headers = {} :: MAP,\n    compression = \"NONE\" :: [\"NONE\", \"BYTES\", \"GZIP\", \"BZIP2\", \"DEFLATE\", \"BLOCK_LZ4\", \"FRAMED_SNAPPY\"]\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      },
+      {
+        "name": "simple",
+        "description": "Whether or not to parse the given XML in simple mode.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=false, type=BOOLEAN}",
+        "type": "BOOLEAN"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.lock.all(nodes :: LIST<NODE>, rels :: LIST<RELATIONSHIP>)",
+    "name": "apoc.lock.all",
+    "description": "Acquires a write lock on the given `NODE` and `RELATIONSHIP` values.",
+    "returnDescription": [],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The list of nodes to acquire a write lock on.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "rels",
+        "description": "The list of relationships to acquire a write lock on.",
+        "isDeprecated": false,
+        "type": "LIST<RELATIONSHIP>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.lock.nodes(nodes :: LIST<NODE>)",
+    "name": "apoc.lock.nodes",
+    "description": "Acquires a write lock on the given `NODE` values.",
+    "returnDescription": [],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The list of nodes to acquire a write lock on.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.lock.read.nodes(nodes :: LIST<NODE>)",
+    "name": "apoc.lock.read.nodes",
+    "description": "Acquires a read lock on the given `NODE` values.",
+    "returnDescription": [],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The list of nodes to acquire a read lock on.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.lock.read.rels(rels :: LIST<RELATIONSHIP>)",
+    "name": "apoc.lock.read.rels",
+    "description": "Acquires a read lock on the given `RELATIONSHIP` values.",
+    "returnDescription": [],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "rels",
+        "description": "The list of relationships to acquire a read lock on.",
+        "isDeprecated": false,
+        "type": "LIST<RELATIONSHIP>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.lock.rels(rels :: LIST<RELATIONSHIP>)",
+    "name": "apoc.lock.rels",
+    "description": "Acquires a write lock on the given `RELATIONSHIP` values.",
+    "returnDescription": [],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "rels",
+        "description": "The list of relationships to acquire a write lock on.",
+        "isDeprecated": false,
+        "type": "LIST<RELATIONSHIP>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.math.regr(label :: STRING, propertyY :: STRING, propertyX :: STRING) :: (r2 :: FLOAT, avgX :: FLOAT, avgY :: FLOAT, slope :: FLOAT)",
+    "name": "apoc.math.regr",
+    "description": "Returns the coefficient of determination (R-squared) for the values of propertyY and propertyX in the given label.",
+    "returnDescription": [
+      {
+        "name": "r2",
+        "description": "The coefficient of determination.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "avgX",
+        "description": "The average of the x values.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "avgY",
+        "description": "The average of the y values.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "slope",
+        "description": "The calculated slope.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "label",
+        "description": "The label of the nodes to perform the regression on.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "propertyY",
+        "description": "The name of the y property.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "propertyX",
+        "description": "The name of the x property.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.merge.node(labels :: LIST<STRING>, identProps :: MAP, onCreateProps = {} :: MAP, onMatchProps = {} :: MAP) :: (node :: NODE)",
+    "name": "apoc.merge.node",
+    "description": "Merges the given `NODE` values with the given dynamic labels.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The updated node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "labels",
+        "description": "The list of labels used for the generated MERGE statement.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "identProps",
+        "description": "Properties on the node that are always merged.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "onCreateProps",
+        "description": "Properties that are merged when a node is created.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      },
+      {
+        "name": "onMatchProps",
+        "description": "Properties that are merged when a node is matched.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.merge.node.eager(labels :: LIST<STRING>, identProps :: MAP, onCreateProps = {} :: MAP, onMatchProps = {} :: MAP) :: (node :: NODE)",
+    "name": "apoc.merge.node.eager",
+    "description": "Merges the given `NODE` values with the given dynamic labels eagerly.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The updated node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "labels",
+        "description": "The list of labels used for the generated MERGE statement.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "identProps",
+        "description": "Properties on the node that are always merged.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "onCreateProps",
+        "description": "Properties that are merged when a node is created.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      },
+      {
+        "name": "onMatchProps",
+        "description": "Properties that are merged when a node is matched.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.merge.nodeWithStats(labels :: LIST<STRING>, identProps :: MAP, onCreateProps = {} :: MAP, onMatchProps = {} :: MAP) :: (stats :: MAP, node :: NODE)",
+    "name": "apoc.merge.nodeWithStats",
+    "description": "Merges the given `NODE` values with the given dynamic labels. Provides queryStatistics in the result.",
+    "returnDescription": [
+      {
+        "name": "stats",
+        "description": "The returned query statistics.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "node",
+        "description": "The updated node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "labels",
+        "description": "The list of labels used for the generated MERGE statement.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "identProps",
+        "description": "Properties on the node that are always merged.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "onCreateProps",
+        "description": "Properties that are merged when a node is created.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      },
+      {
+        "name": "onMatchProps",
+        "description": "Properties that are merged when a node is matched.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.merge.nodeWithStats.eager(labels :: LIST<STRING>, identProps :: MAP, onCreateProps = {} :: MAP, onMatchProps = {} :: MAP) :: (stats :: MAP, node :: NODE)",
+    "name": "apoc.merge.nodeWithStats.eager",
+    "description": "Merges the given `NODE` values with the given dynamic labels eagerly. Provides queryStatistics in the result.",
+    "returnDescription": [
+      {
+        "name": "stats",
+        "description": "The returned query statistics.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "node",
+        "description": "The updated node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "labels",
+        "description": "The list of labels used for the generated MERGE statement.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "identProps",
+        "description": "Properties on the node that are always merged.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "onCreateProps",
+        "description": "Properties that are merged when a node is created.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      },
+      {
+        "name": "onMatchProps",
+        "description": "Properties that are merged when a node is matched.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.merge.relationship(startNode :: NODE, relType :: STRING, identProps :: MAP, onCreateProps :: MAP, endNode :: NODE, onMatchProps = {} :: MAP) :: (rel :: RELATIONSHIP)",
+    "name": "apoc.merge.relationship",
+    "description": "Merges the given `RELATIONSHIP` values with the given dynamic types/properties.",
+    "returnDescription": [
+      {
+        "name": "rel",
+        "description": "The updated relationship.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "startNode",
+        "description": "The start node of the relationship.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relType",
+        "description": "The type of the relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "identProps",
+        "description": "Properties on the relationship that are always merged.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "onCreateProps",
+        "description": "Properties that are merged when a relationship is created.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "endNode",
+        "description": "The end node of the relationship.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "onMatchProps",
+        "description": "Properties that are merged when a relationship is matched.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.merge.relationship.eager(startNode :: NODE, relType :: STRING, identProps :: MAP, onCreateProps :: MAP, endNode :: NODE, onMatchProps = {} :: MAP) :: (rel :: RELATIONSHIP)",
+    "name": "apoc.merge.relationship.eager",
+    "description": "Merges the given `RELATIONSHIP` values with the given dynamic types/properties eagerly.",
+    "returnDescription": [
+      {
+        "name": "rel",
+        "description": "The updated relationship.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "startNode",
+        "description": "The start node of the relationship.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relType",
+        "description": "The type of the relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "identProps",
+        "description": "Properties on the relationship that are always merged.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "onCreateProps",
+        "description": "Properties that are merged when a relationship is created.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "endNode",
+        "description": "The end node of the relationship.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "onMatchProps",
+        "description": "Properties that are merged when a relationship is matched.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.merge.relationshipWithStats(startNode :: NODE, relType :: STRING, identProps :: MAP, onCreateProps :: MAP, endNode :: NODE, onMatchProps = {} :: MAP) :: (stats :: MAP, rel :: RELATIONSHIP)",
+    "name": "apoc.merge.relationshipWithStats",
+    "description": "Merges the given `RELATIONSHIP` values with the given dynamic types/properties. Provides queryStatistics in the result.",
+    "returnDescription": [
+      {
+        "name": "stats",
+        "description": "The returned query statistics.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "rel",
+        "description": "The updated relationship.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "startNode",
+        "description": "The start node of the relationship.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relType",
+        "description": "The type of the relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "identProps",
+        "description": "Properties on the relationship that are always merged.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "onCreateProps",
+        "description": "Properties that are merged when a relationship is created.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "endNode",
+        "description": "The end node of the relationship.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "onMatchProps",
+        "description": "Properties that are merged when a relationship is matched.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.merge.relationshipWithStats.eager(startNode :: NODE, relType :: STRING, identProps :: MAP, onCreateProps :: MAP, endNode :: NODE, onMatchProps = {} :: MAP) :: (stats :: MAP, rel :: RELATIONSHIP)",
+    "name": "apoc.merge.relationshipWithStats.eager",
+    "description": "Merges the given `RELATIONSHIP` values with the given dynamic types/properties eagerly. Provides queryStatistics in the result.",
+    "returnDescription": [
+      {
+        "name": "stats",
+        "description": "The returned query statistics.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "rel",
+        "description": "The updated relationship.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "startNode",
+        "description": "The start node of the relationship.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relType",
+        "description": "The type of the relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "identProps",
+        "description": "Properties on the relationship that are always merged.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "onCreateProps",
+        "description": "Properties that are merged when a relationship is created.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "endNode",
+        "description": "The end node of the relationship.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "onMatchProps",
+        "description": "Properties that are merged when a relationship is matched.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.meta.data(config = {} :: MAP) :: (label :: STRING, property :: STRING, count :: INTEGER, unique :: BOOLEAN, index :: BOOLEAN, existence :: BOOLEAN, type :: STRING, array :: BOOLEAN, sample :: LIST<ANY>, left :: INTEGER, right :: INTEGER, other :: LIST<STRING>, otherLabels :: LIST<STRING>, elementType :: STRING)",
+    "name": "apoc.meta.data",
+    "description": "Examines the full graph and returns a table of metadata.",
+    "returnDescription": [
+      {
+        "name": "label",
+        "description": "The label or type name.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "property",
+        "description": "The property name.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "count",
+        "description": "The count of seen values.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "unique",
+        "description": "If all seen values are unique.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "index",
+        "description": "If an index exists for this property.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "existence",
+        "description": "If an existence constraint exists for this property.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "type",
+        "description": "The type represented by this row.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "array",
+        "description": "Indicates whether the property is an array. If the type column is \"RELATIONSHIP,\" this will be true if there is at least one node with two outgoing relationships of the type specified by the label or property column.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "sample",
+        "description": "This is always null.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "left",
+        "description": "The ratio (rounded down) of the count of outgoing relationships for a specific label and relationship type relative to the total count of those patterns.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "right",
+        "description": "The ratio (rounded down) of the count of incoming relationships for a specific label and relationship type relative to the total count of those patterns.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "other",
+        "description": "The labels of connect nodes.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "otherLabels",
+        "description": "For uniqueness constraints, this field shows other labels present on nodes that also contain the uniqueness constraint.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "elementType",
+        "description": "Whether this refers to a node or a relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "config",
+        "description": "Number of nodes to sample, setting sample to `-1` will remove sampling; { sample = 1000 :: INTEGER }",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.meta.data.of(graph :: ANY, config = {} :: MAP) :: (label :: STRING, property :: STRING, count :: INTEGER, unique :: BOOLEAN, index :: BOOLEAN, existence :: BOOLEAN, type :: STRING, array :: BOOLEAN, sample :: LIST<ANY>, left :: INTEGER, right :: INTEGER, other :: LIST<STRING>, otherLabels :: LIST<STRING>, elementType :: STRING)",
+    "name": "apoc.meta.data.of",
+    "description": "Examines the given sub-graph and returns a table of metadata.",
+    "returnDescription": [
+      {
+        "name": "label",
+        "description": "The label or type name.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "property",
+        "description": "The property name.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "count",
+        "description": "The count of seen values.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "unique",
+        "description": "If all seen values are unique.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "index",
+        "description": "If an index exists for this property.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "existence",
+        "description": "If an existence constraint exists for this property.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "type",
+        "description": "The type represented by this row.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "array",
+        "description": "Indicates whether the property is an array. If the type column is \"RELATIONSHIP,\" this will be true if there is at least one node with two outgoing relationships of the type specified by the label or property column.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "sample",
+        "description": "This is always null.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "left",
+        "description": "The ratio (rounded down) of the count of outgoing relationships for a specific label and relationship type relative to the total count of those patterns.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "right",
+        "description": "The ratio (rounded down) of the count of incoming relationships for a specific label and relationship type relative to the total count of those patterns.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "other",
+        "description": "The labels of connect nodes.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "otherLabels",
+        "description": "For uniqueness constraints, this field shows other labels present on nodes that also contain the uniqueness constraint.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "elementType",
+        "description": "Whether this refers to a node or a relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "graph",
+        "description": "The graph to extract metadata from.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "config",
+        "description": "Number of nodes to sample, setting sample to `-1` will remove sampling; { sample = 1000 :: INTEGER }",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.meta.graph(config = {} :: MAP) :: (nodes :: LIST<NODE>, relationships :: LIST<RELATIONSHIP>)",
+    "name": "apoc.meta.graph",
+    "description": "Examines the full graph and returns a meta-graph.",
+    "returnDescription": [
+      {
+        "name": "nodes",
+        "description": "Nodes representing the meta data.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "relationships",
+        "description": "Relationships representing the meta data.",
+        "isDeprecated": false,
+        "type": "LIST<RELATIONSHIP>"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "config",
+        "description": "The number of nodes whose relationships are checked to remove false positives and the number of relationships to read per sampled node. A value of -1 will read all; { sample = 1 :: INTEGER, maxRels = -1 :: INTEGER }",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.meta.graph.of(graph = {} :: ANY, config = {} :: MAP) :: (nodes :: LIST<NODE>, relationships :: LIST<RELATIONSHIP>)",
+    "name": "apoc.meta.graph.of",
+    "description": "Examines the given sub-graph and returns a meta-graph.",
+    "returnDescription": [
+      {
+        "name": "nodes",
+        "description": "Nodes representing the meta data.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "relationships",
+        "description": "Relationships representing the meta data.",
+        "isDeprecated": false,
+        "type": "LIST<RELATIONSHIP>"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "graph",
+        "description": "The graph to extract metadata from.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=ANY}",
+        "type": "ANY"
+      },
+      {
+        "name": "config",
+        "description": "The number of nodes whose relationships are checked to remove false positives and the number of relationships to read per sampled node. A value of -1 will read all; { sample = 1 :: INTEGER, maxRels = -1 :: INTEGER, addRelationshipsBetweenNodes = true :: BOOLEAN }",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.meta.graphSample(config = {} :: MAP) :: (nodes :: LIST<NODE>, relationships :: LIST<RELATIONSHIP>)",
+    "name": "apoc.meta.graphSample",
+    "description": "Examines the full graph and returns a meta-graph.\nUnlike `apoc.meta.graph`, this procedure does not filter away non-existing paths.",
+    "returnDescription": [
+      {
+        "name": "nodes",
+        "description": "Nodes representing the meta data.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "relationships",
+        "description": "Relationships representing the meta data.",
+        "isDeprecated": false,
+        "type": "LIST<RELATIONSHIP>"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "config",
+        "description": "Empty map (deprecated).",
+        "isDeprecated": true,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.meta.nodeTypeProperties(config = {} :: MAP) :: (nodeType :: STRING, nodeLabels :: LIST<STRING>, propertyName :: STRING, propertyTypes :: LIST<STRING>, mandatory :: BOOLEAN, propertyObservations :: INTEGER, totalObservations :: INTEGER)",
+    "name": "apoc.meta.nodeTypeProperties",
+    "description": "Examines the full graph and returns a table of metadata with information about the `NODE` values therein.",
+    "returnDescription": [
+      {
+        "name": "nodeType",
+        "description": "The type of the node.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodeLabels",
+        "description": "The labels on the node.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "propertyName",
+        "description": "The name of the property.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "propertyTypes",
+        "description": "The types this property has.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "mandatory",
+        "description": "Whether or not this property exists on all nodes of the given type.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "propertyObservations",
+        "description": "The number of times this property was observed.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "totalObservations",
+        "description": "The number of times the label was seen.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "config",
+        "description": "{\n        includeLabels = [] :: LIST<STRING>,\n        includeRels = [] :: LIST<STRING>,\n        excludeLabels = [] :: LIST<STRING>,\n        excludeRels = [] :: LIST<STRING>,\n        sample = 1000 :: INTEGER,\n        maxRels = 100 :: INTEGER\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.meta.relTypeProperties(config = {} :: MAP) :: (relType :: STRING, sourceNodeLabels :: LIST<STRING>, targetNodeLabels :: LIST<STRING>, propertyName :: STRING, propertyTypes :: LIST<STRING>, mandatory :: BOOLEAN, propertyObservations :: INTEGER, totalObservations :: INTEGER)",
+    "name": "apoc.meta.relTypeProperties",
+    "description": "Examines the full graph and returns a table of metadata with information about the `RELATIONSHIP` values therein.",
+    "returnDescription": [
+      {
+        "name": "relType",
+        "description": "The type of the relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "sourceNodeLabels",
+        "description": "The labels belonging to the start node.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "targetNodeLabels",
+        "description": "The labels belonging to the end node.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "propertyName",
+        "description": "The name of the property.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "propertyTypes",
+        "description": "The types this property has.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "mandatory",
+        "description": "Whether or not this property exists on all nodes of the given type.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "propertyObservations",
+        "description": "The number of times this property was observed.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "totalObservations",
+        "description": "The number of times the label was seen.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "config",
+        "description": "{\n        includeLabels = [] :: LIST<STRING>,\n        includeRels = [] :: LIST<STRING>,\n        excludeLabels = [] :: LIST<STRING>,\n        excludeRels = [] :: LIST<STRING>,\n        sample = 1000 :: INTEGER,\n        maxRels = 100 :: INTEGER\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.meta.schema(config = {} :: MAP) :: (value :: MAP)",
+    "name": "apoc.meta.schema",
+    "description": "Examines the given sub-graph and returns metadata as a `MAP`.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "Meta information represented as a map.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "config",
+        "description": "Number of nodes to sample, setting sample to `-1` will remove sampling; { sample = 1000 :: INTEGER }",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.meta.stats() :: (labelCount :: INTEGER, relTypeCount :: INTEGER, propertyKeyCount :: INTEGER, nodeCount :: INTEGER, relCount :: INTEGER, labels :: MAP, relTypes :: MAP, relTypesCount :: MAP, stats :: MAP)",
+    "name": "apoc.meta.stats",
+    "description": "Returns the metadata stored in the transactional database statistics.",
+    "returnDescription": [
+      {
+        "name": "labelCount",
+        "description": "The total number of distinct node labels.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relTypeCount",
+        "description": "The total number of distinct relationship types.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "propertyKeyCount",
+        "description": "The count of property keys.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "nodeCount",
+        "description": "The total number of nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "relCount",
+        "description": "The total number of relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "labels",
+        "description": "A map of labels to their count.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "relTypes",
+        "description": "A map of relationship types per start or end node label.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "relTypesCount",
+        "description": "A map of relationship types to their count.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "stats",
+        "description": "A map containing all the given return fields from this procedure.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": []
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.meta.subGraph(config :: MAP) :: (nodes :: LIST<NODE>, relationships :: LIST<RELATIONSHIP>)",
+    "name": "apoc.meta.subGraph",
+    "description": "Examines the given sub-graph and returns a meta-graph.",
+    "returnDescription": [
+      {
+        "name": "nodes",
+        "description": "Nodes representing the meta data.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "relationships",
+        "description": "Relationships representing the meta data.",
+        "isDeprecated": false,
+        "type": "LIST<RELATIONSHIP>"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "config",
+        "description": "{\n    excludeLabels :: LIST<STRING>,\n    includeLabels :: LIST<STRING>,\n    includeRels :: LIST<STRING>,\n    maxRels = -1 :: INTEGER,\n    sample = 1 :: INTEGER\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.neighbors.athop(node :: NODE, relTypes =  :: STRING, distance = 1 :: INTEGER) :: (node :: NODE)",
+    "name": "apoc.neighbors.athop",
+    "description": "Returns all `NODE` values connected by the given `RELATIONSHIP` types at the specified distance.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "A neighboring node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "node",
+        "description": "The starting node for the algorithm.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relTypes",
+        "description": "A list of relationship types to follow. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "distance",
+        "description": "The number of hops to take.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=1, type=INTEGER}",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.neighbors.athop.count(node :: NODE, relTypes =  :: STRING, distance = 1 :: INTEGER) :: (value :: INTEGER)",
+    "name": "apoc.neighbors.athop.count",
+    "description": "Returns the count of all `NODE` values connected by the given `RELATIONSHIP` types at the specified distance.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The total count of neighboring nodes at the given hop distance.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "node",
+        "description": "The starting node for the algorithm.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relTypes",
+        "description": "A list of relationship types to follow. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "distance",
+        "description": "The number of hops to take.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=1, type=INTEGER}",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.neighbors.byhop(node :: NODE, relTypes =  :: STRING, distance = 1 :: INTEGER) :: (nodes :: LIST<NODE>)",
+    "name": "apoc.neighbors.byhop",
+    "description": "Returns all `NODE` values connected by the given `RELATIONSHIP` types within the specified distance. Returns `LIST<NODE>` values, where each `PATH` of `NODE` values represents one row of the `LIST<NODE>` values.",
+    "returnDescription": [
+      {
+        "name": "nodes",
+        "description": "A list of neighboring nodes at a distinct hop distance.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "node",
+        "description": "The starting node for the algorithm.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relTypes",
+        "description": "A list of relationship types to follow. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "distance",
+        "description": "The max number of hops to take.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=1, type=INTEGER}",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.neighbors.byhop.count(node :: NODE, relTypes =  :: STRING, distance = 1 :: INTEGER) :: (value :: LIST<ANY>)",
+    "name": "apoc.neighbors.byhop.count",
+    "description": "Returns the count of all `NODE` values connected by the given `RELATIONSHIP` types within the specified distance.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "A list of neighbor counts for each distinct hop distance.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "node",
+        "description": "The starting node for the algorithm.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relTypes",
+        "description": "A list of relationship types to follow. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "distance",
+        "description": "The max number of hops to take.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=1, type=INTEGER}",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.neighbors.tohop(node :: NODE, relTypes =  :: STRING, distance = 1 :: INTEGER) :: (node :: NODE)",
+    "name": "apoc.neighbors.tohop",
+    "description": "Returns all `NODE` values connected by the given `RELATIONSHIP` types within the specified distance.\n`NODE` values are returned individually for each row.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "A neighboring node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "node",
+        "description": "The starting node for the algorithm.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relTypes",
+        "description": "A list of relationship types to follow. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "distance",
+        "description": "The max number of hops to take.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=1, type=INTEGER}",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.neighbors.tohop.count(node :: NODE, relTypes =  :: STRING, distance = 1 :: INTEGER) :: (value :: INTEGER)",
+    "name": "apoc.neighbors.tohop.count",
+    "description": "Returns the count of all `NODE` values connected by the given `RELATIONSHIP` values in the pattern within the specified distance.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The total count of neighboring nodes within the given hop distance.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "node",
+        "description": "The starting node for the algorithm.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relTypes",
+        "description": "A list of relationship types to follow. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "distance",
+        "description": "The max number of hops to take.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=1, type=INTEGER}",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.nodes.collapse(nodes :: LIST<NODE>, config = {} :: MAP) :: (from :: NODE, rel :: RELATIONSHIP, to :: NODE)",
+    "name": "apoc.nodes.collapse",
+    "description": "Merges `NODE` values together in the given `LIST<NODE>`.\nThe `NODE` values are then combined to become one `NODE`, with all labels of the previous `NODE` values attached to it, and all `RELATIONSHIP` values pointing to it.",
+    "returnDescription": [
+      {
+        "name": "from",
+        "description": "The recently collapsed virtual node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "rel",
+        "description": "A relationship connected to the collapsed node.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "to",
+        "description": "A node connected to the other end of the relationship.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The list of node values to merge.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "config",
+        "description": "{\n    mergeRels :: BOOLEAN,\n    selfRef :: BOOLEAN,\n    produceSelfRef = true :: BOOLEAN,\n    preserveExistingSelfRels = true :: BOOLEAN,\n    countMerge = true :: BOOLEAN,\n    collapsedLabel :: BOOLEAN,\n    singleElementAsArray = false :: BOOLEAN,\n    avoidDuplicates = false :: BOOLEAN,\n    relationshipSelectionStrategy = \"incoming\" :: [\"incoming\", \"outgoing\", \"merge\"]\n    properties :: [\"overwrite\", \"discard\", \"combine\"]\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.nodes.cycles(nodes :: LIST<NODE>, config = {} :: MAP) :: (path :: PATH)",
+    "name": "apoc.nodes.cycles",
+    "description": "Detects all `PATH` cycles in the given `LIST<NODE>`.\nThis procedure can be limited on `RELATIONSHIP` values as well.",
+    "returnDescription": [
+      {
+        "name": "path",
+        "description": "A path containing a found cycle.",
+        "isDeprecated": false,
+        "type": "PATH"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The list of nodes to check for path cycles.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "config",
+        "description": "{\n    maxDepth :: INTEGER,\n    relTypes = [] :: LIST<STRING>\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.nodes.get(nodes :: ANY) :: (node :: NODE)",
+    "name": "apoc.nodes.get",
+    "description": "Returns all `NODE` values with the given ids.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "A node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to be returned. Nodes can be of type `STRING` (elementId()), `INTEGER` (id()), `NODE`, or `LIST<STRING | INTEGER | NODE>`.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.nodes.group(labels :: LIST<STRING>, groupByProperties :: LIST<STRING>, aggregations = [{*=count}, {*=count}] :: LIST<MAP>, config = {} :: MAP) :: (nodes :: LIST<NODE>, relationships :: LIST<RELATIONSHIP>, node :: NODE, relationship :: RELATIONSHIP)",
+    "name": "apoc.nodes.group",
+    "description": "Allows for the aggregation of `NODE` values based on the given properties.\nThis procedure returns virtual `NODE` values.",
+    "returnDescription": [
+      {
+        "name": "nodes",
+        "description": "A list of grouped nodes represented as virtual nodes.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "relationships",
+        "description": "A list of grouped relationships represented as virtual relationships.",
+        "isDeprecated": false,
+        "type": "LIST<RELATIONSHIP>"
+      },
+      {
+        "name": "node",
+        "description": "The grouping node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relationship",
+        "description": "The grouping relationship.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "labels",
+        "description": "The list of node labels to aggregate over. Use `['*']` to indicate all node labels should be looked at.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "groupByProperties",
+        "description": "The property keys to group the nodes by.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "aggregations",
+        "description": "The first map specifies the node properties to aggregate with their corresponding aggregation functions, while the second map specifies the relationship properties for aggregation.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=[{*=count}, {*=count}], type=LIST<MAP>}",
+        "type": "LIST<MAP>"
+      },
+      {
+        "name": "config",
+        "description": "{\n    includeRels :: STRING | LIST<STRING>\n    excludeRels :: STRING | LIST<STRING>,\n    orphans = true :: BOOLEAN,\n    selfRels = true :: BOOLEAN,\n    limitNodes = -1 :: INTEGER,\n    limitRels = -1 :: INTEGER,\n    relsPerNode = -1 :: INTEGER,\n    filter :: MAP\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.nodes.link(nodes :: LIST<NODE>, type :: STRING, config = {} :: MAP)",
+    "name": "apoc.nodes.link",
+    "description": "Creates a linked list of the given `NODE` values connected by the given `RELATIONSHIP` type.",
+    "returnDescription": [],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The list of nodes to be linked.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "type",
+        "description": "The relationship type name to link the nodes with.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{ avoidDuplicates = false :: BOOLEAN }",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.nodes.rels(rels :: ANY) :: (rel :: RELATIONSHIP)",
+    "name": "apoc.nodes.rels",
+    "description": "Returns all `RELATIONSHIP` values with the given ids.",
+    "returnDescription": [
+      {
+        "name": "rel",
+        "description": "A relationship.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "rels",
+        "description": "The relationships to be returned. Relationships can be of type `STRING` (elementId()), `INTEGER` (id()), `RELATIONSHIP`, or `LIST<STRING | INTEGER | RELATIONSHIP>",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.path.expand(startNode :: ANY, relFilter :: STRING, labelFilter :: STRING, minDepth :: INTEGER, maxDepth :: INTEGER) :: (path :: PATH)",
+    "name": "apoc.path.expand",
+    "description": "Returns `PATH` values expanded from the start `NODE` following the given `RELATIONSHIP` types from min-depth to max-depth.",
+    "returnDescription": [
+      {
+        "name": "path",
+        "description": "The expanded path.",
+        "isDeprecated": false,
+        "type": "PATH"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "startNode",
+        "description": "The node to start the algorithm from. `startNode` can be of type `STRING` (elementId()), `INTEGER` (id()), `NODE`, or `LIST<STRING | INTEGER | NODE>`.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "relFilter",
+        "description": "An allow list of types allowed on the returned relationships.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "labelFilter",
+        "description": "An allow list of labels allowed on the returned nodes.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "minDepth",
+        "description": "The minimum number of hops allowed in the returned paths.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "maxDepth",
+        "description": "The maximum number of hops allowed in the returned paths.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.path.expandConfig(startNode :: ANY, config :: MAP) :: (path :: PATH)",
+    "name": "apoc.path.expandConfig",
+    "description": "Returns `PATH` values expanded from the start `NODE` with the given `RELATIONSHIP` types from min-depth to max-depth.",
+    "returnDescription": [
+      {
+        "name": "path",
+        "description": "The expanded path.",
+        "isDeprecated": false,
+        "type": "PATH"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "startNode",
+        "description": "The node to start the algorithm from. `startNode` can be of type `STRING` (elementId()), `INTEGER` (id()), `NODE`, or `LIST<STRING | INTEGER | NODE>.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "config",
+        "description": "{\n    minLevel = -1 :: INTEGER,\n    maxLevel = -1 :: INTEGER,\n    relationshipFilter :: STRING,\n    labelFilter :: STRING,\n    beginSequenceAtStart = true :: BOOLEAN,\n    uniqueness = \"RELATIONSHIP_PATH\" :: STRING,\n    bfs = true :: BOOLEAN,\n    filterStartNode = false :: BOOLEAN,\n    limit = -1 :: INTEGER,\n    optional = false :: BOOLEAN,\n    endNodes :: LIST<NODES>,\n    terminatorNodes:: LIST<NODES>,\n    allowlistNodes:: LIST<NODES>,\n    denylistNodes:: LIST<NODES>\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.path.spanningTree(startNode :: ANY, config :: MAP) :: (path :: PATH)",
+    "name": "apoc.path.spanningTree",
+    "description": "Returns spanning tree `PATH` values expanded from the start `NODE` following the given `RELATIONSHIP` types to max-depth.",
+    "returnDescription": [
+      {
+        "name": "path",
+        "description": "A spanning tree path.",
+        "isDeprecated": false,
+        "type": "PATH"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "startNode",
+        "description": "The node to start the algorithm from. `startNode` can be of type `STRING` (elementId()), `INTEGER` (id()), `NODE`, or `LIST<STRING | INTEGER | NODE>.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "config",
+        "description": "{\n    minLevel = -1 :: INTEGER,\n    maxLevel = -1 :: INTEGER,\n    relationshipFilter :: STRING,\n    labelFilter :: STRING,\n    beginSequenceAtStart = true :: BOOLEAN,\n    uniqueness = \"RELATIONSHIP_PATH\" :: STRING,\n    bfs = true :: BOOLEAN,\n    filterStartNode = false :: BOOLEAN,\n    limit = -1 :: INTEGER,\n    optional = false :: BOOLEAN,\n    endNodes :: LIST<NODES>,\n    terminatorNodes:: LIST<NODES>,\n    allowlistNodes:: LIST<NODES>,\n    denylistNodes:: LIST<NODES>\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.path.subgraphAll(startNode :: ANY, config :: MAP) :: (nodes :: LIST<NODE>, relationships :: LIST<RELATIONSHIP>)",
+    "name": "apoc.path.subgraphAll",
+    "description": "Returns the sub-graph reachable from the start `NODE` following the given `RELATIONSHIP` types to max-depth.",
+    "returnDescription": [
+      {
+        "name": "nodes",
+        "description": "Nodes part of the returned subgraph.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "relationships",
+        "description": "Relationships part of the returned subgraph.",
+        "isDeprecated": false,
+        "type": "LIST<RELATIONSHIP>"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "startNode",
+        "description": "The node to start the algorithm from. `startNode` can be of type `STRING` (elementId()), `INTEGER` (id()), `NODE`, or `LIST<STRING | INTEGER | NODE>.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "config",
+        "description": "{\n    minLevel = -1 :: INTEGER,\n    maxLevel = -1 :: INTEGER,\n    relationshipFilter :: STRING,\n    labelFilter :: STRING,\n    beginSequenceAtStart = true :: BOOLEAN,\n    uniqueness = \"RELATIONSHIP_PATH\" :: STRING,\n    bfs = true :: BOOLEAN,\n    filterStartNode = false :: BOOLEAN,\n    limit = -1 :: INTEGER,\n    optional = false :: BOOLEAN,\n    endNodes :: LIST<NODES>,\n    terminatorNodes:: LIST<NODES>,\n    allowlistNodes:: LIST<NODES>,\n    denylistNodes:: LIST<NODES>\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.path.subgraphNodes(startNode :: ANY, config :: MAP) :: (node :: NODE)",
+    "name": "apoc.path.subgraphNodes",
+    "description": "Returns the `NODE` values in the sub-graph reachable from the start `NODE` following the given `RELATIONSHIP` types to max-depth.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "Nodes part of the returned subgraph.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "startNode",
+        "description": "The node to start the algorithm from. `startNode` can be of type `STRING` (elementId()), `INTEGER` (id()), `NODE`, or `LIST<STRING | INTEGER | NODE>`.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "config",
+        "description": "{\n    minLevel = -1 :: INTEGER,\n    maxLevel = -1 :: INTEGER,\n    relationshipFilter :: STRING,\n    labelFilter :: STRING,\n    beginSequenceAtStart = true :: BOOLEAN,\n    uniqueness = \"RELATIONSHIP_PATH\" :: STRING,\n    bfs = true :: BOOLEAN,\n    filterStartNode = false :: BOOLEAN,\n    limit = -1 :: INTEGER,\n    optional = false :: BOOLEAN,\n    endNodes :: LIST<NODES>,\n    terminatorNodes:: LIST<NODES>,\n    allowlistNodes:: LIST<NODES>,\n    denylistNodes:: LIST<NODES>\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.paths.toJsonTree(paths :: LIST<PATH>, lowerCaseRels = true :: BOOLEAN, config = {} :: MAP) :: (value :: MAP)",
+    "name": "apoc.paths.toJsonTree",
+    "description": "Creates a stream of nested documents representing the graph as a tree by traversing outgoing relationships.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The resulting tree.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "paths",
+        "description": "A list of paths to convert into a tree.",
+        "isDeprecated": false,
+        "type": "LIST<PATH>"
+      },
+      {
+        "name": "lowerCaseRels",
+        "description": "Whether or not to convert relationship types to lower case.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=true, type=BOOLEAN}",
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "config",
+        "description": "{ nodes = {} :: MAP, rels = {} :: MAP, sortPaths = true :: BOOLEAN }",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.periodic.cancel(name :: STRING) :: (name :: STRING, delay :: INTEGER, rate :: INTEGER, done :: BOOLEAN, cancelled :: BOOLEAN)",
+    "name": "apoc.periodic.cancel",
+    "description": "Cancels the given background job.",
+    "returnDescription": [
+      {
+        "name": "name",
+        "description": "The name of the job.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "delay",
+        "description": "The delay on the job.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rate",
+        "description": "The rate of the job.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "If the job has completed.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "cancelled",
+        "description": "If the job has been cancelled.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "name",
+        "description": "The name of the job to cancel.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.periodic.commit(statement :: STRING, params = {} :: MAP) :: (updates :: INTEGER, executions :: INTEGER, runtime :: INTEGER, batches :: INTEGER, failedBatches :: INTEGER, batchErrors :: MAP, failedCommits :: INTEGER, commitErrors :: MAP, wasTerminated :: BOOLEAN)",
+    "name": "apoc.periodic.commit",
+    "description": "Runs the given statement in separate batched transactions.",
+    "returnDescription": [
+      {
+        "name": "updates",
+        "description": "The total number of updates.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "executions",
+        "description": "The total number of executions.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "runtime",
+        "description": "The total time taken in nanoseconds.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batches",
+        "description": "The number of run batches.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "failedBatches",
+        "description": "The number of failed batches.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "batchErrors",
+        "description": "Errors returned from the failed batches.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "failedCommits",
+        "description": "The number of failed commits.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "commitErrors",
+        "description": "Errors returned from the failed commits.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "wasTerminated",
+        "description": "If the job was terminated.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "statement",
+        "description": "The Cypher statement to run.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statement.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.periodic.countdown(name :: STRING, statement :: STRING, delay :: INTEGER) :: (name :: STRING, delay :: INTEGER, rate :: INTEGER, done :: BOOLEAN, cancelled :: BOOLEAN)",
+    "name": "apoc.periodic.countdown",
+    "description": "Runs a repeatedly called background statement until it returns 0.",
+    "returnDescription": [
+      {
+        "name": "name",
+        "description": "The name of the job.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "delay",
+        "description": "The delay on the job.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rate",
+        "description": "The rate of the job.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "If the job has completed.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "cancelled",
+        "description": "If the job has been cancelled.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "name",
+        "description": "The name of the job.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "statement",
+        "description": "The Cypher statement to run, returning a count on each run indicating the remaining iterations.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "delay",
+        "description": "The delay in seconds to wait between each job execution.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.periodic.iterate(cypherIterate :: STRING, cypherAction :: STRING, config :: MAP) :: (batches :: INTEGER, total :: INTEGER, timeTaken :: INTEGER, committedOperations :: INTEGER, failedOperations :: INTEGER, failedBatches :: INTEGER, retries :: INTEGER, errorMessages :: MAP, batch :: MAP, operations :: MAP, wasTerminated :: BOOLEAN, failedParams :: MAP, updateStatistics :: MAP)",
+    "name": "apoc.periodic.iterate",
+    "description": "Runs the second statement for each item returned by the first statement.\nThis procedure returns the number of batches and the total number of processed rows.",
+    "returnDescription": [
+      {
+        "name": "batches",
+        "description": "The total number of batches.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "total",
+        "description": "The number of processed input rows.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "timeTaken",
+        "description": "The duration taken in seconds.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "committedOperations",
+        "description": "The number of successful inner queries (actions).",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "failedOperations",
+        "description": "The number of failed inner queries (actions).",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "failedBatches",
+        "description": "The number of failed batches.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "retries",
+        "description": "The number of retries.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "errorMessages",
+        "description": "A map of batch error messages paired with their corresponding error counts.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "batch",
+        "description": "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "operations",
+        "description": "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "wasTerminated",
+        "description": "If the transaction was terminated before completion.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "failedParams",
+        "description": "Parameters of failed batches. The key is the batch number as a STRING and the value is a list of batch parameters.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "updateStatistics",
+        "description": "{\n    nodesCreated :: INTEGER,\n    nodesDeleted :: INTEGER,\n    relationshipsCreated :: INTEGER,\n    relationshipsDeleted :: INTEGER,\n    propertiesSet :: INTEGER,\n    labelsAdded :: INTEGER,\n    labelsRemoved :: INTEGER\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "cypherIterate",
+        "description": "The first Cypher statement to be run.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "cypherAction",
+        "description": "The Cypher statement to run for each item returned by the initial Cypher statement.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n    batchSize = 10000 :: INTEGER,\n    parallel = false :: BOOLEAN,\n    retries = 0 :: INTEGER,\n    batchMode = \"BATCH\" :: STRING,\n    params = {} :: MAP,\n    concurrency :: INTEGER,\n    failedParams = -1 :: INTEGER,\n    planner = \"DEFAULT\" :: [\"DEFAULT\", \"COST\", \"IDP\", \"DP\"]\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.periodic.list() :: (name :: STRING, delay :: INTEGER, rate :: INTEGER, done :: BOOLEAN, cancelled :: BOOLEAN)",
+    "name": "apoc.periodic.list",
+    "description": "Returns a `LIST<ANY>` of all background jobs.",
+    "returnDescription": [
+      {
+        "name": "name",
+        "description": "The name of the job.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "delay",
+        "description": "The delay on the job.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rate",
+        "description": "The rate of the job.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "If the job has completed.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "cancelled",
+        "description": "If the job has been cancelled.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": []
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.periodic.repeat(name :: STRING, statement :: STRING, rate :: INTEGER, config = {} :: MAP) :: (name :: STRING, delay :: INTEGER, rate :: INTEGER, done :: BOOLEAN, cancelled :: BOOLEAN)",
+    "name": "apoc.periodic.repeat",
+    "description": "Runs a repeatedly called background job.\nTo stop this procedure, use `apoc.periodic.cancel`.",
+    "returnDescription": [
+      {
+        "name": "name",
+        "description": "The name of the job.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "delay",
+        "description": "The delay on the job.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rate",
+        "description": "The rate of the job.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "If the job has completed.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "cancelled",
+        "description": "If the job has been cancelled.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "name",
+        "description": "The name of the job.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "statement",
+        "description": "The Cypher statement to run.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "rate",
+        "description": "The delay in seconds to wait between each job execution.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "config",
+        "description": "{ params = {} :: MAP }",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.periodic.submit(name :: STRING, statement :: STRING, params = {} :: MAP) :: (name :: STRING, delay :: INTEGER, rate :: INTEGER, done :: BOOLEAN, cancelled :: BOOLEAN)",
+    "name": "apoc.periodic.submit",
+    "description": "Creates a background job which runs the given Cypher statement once.",
+    "returnDescription": [
+      {
+        "name": "name",
+        "description": "The name of the job.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "delay",
+        "description": "The delay on the job.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "rate",
+        "description": "The rate of the job.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "done",
+        "description": "If the job has completed.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "cancelled",
+        "description": "If the job has been cancelled.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "name",
+        "description": "The name of the job.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "statement",
+        "description": "The Cypher statement to run.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "params",
+        "description": "{ params = {} :: MAP }",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.periodic.truncate(config = {} :: MAP)",
+    "name": "apoc.periodic.truncate",
+    "description": "Removes all entities (and optionally indexes and constraints) from the database using the `apoc.periodic.iterate` procedure.",
+    "returnDescription": [],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "config",
+        "description": "{\n    dropSchema = true :: BOOLEAN,\n    batchSize = 10000 :: INTEGER,\n    parallel = false :: BOOLEAN,\n    retries = 0 :: INTEGER,\n    batchMode = \"BATCH\" :: STRING,\n    params = {} :: MAP,\n    concurrency :: INTEGER,\n    failedParams = -1 :: INTEGER,\n    planner = \"DEFAULT\" :: [\"DEFAULT\", \"COST\", \"IDP\", \"DP\"]\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.refactor.cloneNodes(nodes :: LIST<NODE>, withRelationships = false :: BOOLEAN, skipProperties = [] :: LIST<STRING>) :: (input :: INTEGER, output :: NODE, error :: STRING)",
+    "name": "apoc.refactor.cloneNodes",
+    "description": "Clones the given `NODE` values with their labels and properties.\nIt is possible to skip any `NODE` properties using skipProperties (note: this only skips properties on `NODE` values and not their `RELATIONSHIP` values).",
+    "returnDescription": [
+      {
+        "name": "input",
+        "description": "The internal id of the original entity.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "output",
+        "description": "The copied entity.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "error",
+        "description": "Any error that occurred during the copy process.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to be cloned.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "withRelationships",
+        "description": "Whether or not the connected relationships should also be cloned.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=false, type=BOOLEAN}",
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "skipProperties",
+        "description": "Whether or not to skip the node properties when cloning.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=[], type=LIST<STRING>}",
+        "type": "LIST<STRING>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.refactor.cloneSubgraph(nodes :: LIST<NODE>, rels = [] :: LIST<RELATIONSHIP>, config = {} :: MAP) :: (input :: INTEGER, output :: NODE, error :: STRING)",
+    "name": "apoc.refactor.cloneSubgraph",
+    "description": "Clones the given `NODE` values with their labels and properties (optionally skipping any properties in the `skipProperties` `LIST<STRING>` via the config `MAP`), and clones the given `RELATIONSHIP` values.\nIf no `RELATIONSHIP` values are provided, all existing `RELATIONSHIP` values between the given `NODE` values will be cloned.",
+    "returnDescription": [
+      {
+        "name": "input",
+        "description": "The internal id of the original entity.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "output",
+        "description": "The copied entity.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "error",
+        "description": "Any error that occurred during the copy process.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to be cloned.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "rels",
+        "description": "The relationships to be cloned. If left empty all relationships between the given nodes will be cloned.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=[], type=LIST<RELATIONSHIP>}",
+        "type": "LIST<RELATIONSHIP>"
+      },
+      {
+        "name": "config",
+        "description": "{\n    standinNodes :: LIST<LIST<NODE>>,\n    skipProperties :: LIST<STRING>,\n    createNodesInNewTransactions = false :: BOOLEAN\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.refactor.cloneSubgraphFromPaths(paths :: LIST<PATH>, config = {} :: MAP) :: (input :: INTEGER, output :: NODE, error :: STRING)",
+    "name": "apoc.refactor.cloneSubgraphFromPaths",
+    "description": "Clones a sub-graph defined by the given `LIST<PATH>` values.\nIt is possible to skip any `NODE` properties using the `skipProperties` `LIST<STRING>` via the config `MAP`.",
+    "returnDescription": [
+      {
+        "name": "input",
+        "description": "The internal id of the original entity.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "output",
+        "description": "The copied entity.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "error",
+        "description": "Any error that occurred during the copy process.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "paths",
+        "description": "The paths to be cloned.",
+        "isDeprecated": false,
+        "type": "LIST<PATH>"
+      },
+      {
+        "name": "config",
+        "description": "{\n    standinNodes :: LIST<LIST<NODE>>,\n    skipProperties :: LIST<STRING>\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.refactor.collapseNode(nodes :: ANY, relType :: STRING) :: (input :: INTEGER, output :: RELATIONSHIP, error :: STRING)",
+    "name": "apoc.refactor.collapseNode",
+    "description": "Collapses the given `NODE` and replaces it with a `RELATIONSHIP` of the given type.",
+    "returnDescription": [
+      {
+        "name": "input",
+        "description": "The id of the given relationship.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "output",
+        "description": "The id of the new relationship with the updated type.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "error",
+        "description": "The message if an error occurred.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to collapse. Nodes can be of type `STRING` (elementId()), `INTEGER` (id()), `NODE`, or `LIST<STRING | INTEGER | NODE>`.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "relType",
+        "description": "The name of the resulting relationship type.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.refactor.extractNode(rels :: ANY, labels :: LIST<STRING>, outType :: STRING, inType :: STRING) :: (input :: INTEGER, output :: NODE, error :: STRING)",
+    "name": "apoc.refactor.extractNode",
+    "description": "Expands the given `RELATIONSHIP` VALUES into intermediate `NODE` VALUES.\nThe intermediate `NODE` values are connected by the given `outType` and `inType`.",
+    "returnDescription": [
+      {
+        "name": "input",
+        "description": "The internal id of the original entity.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "output",
+        "description": "The copied entity.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "error",
+        "description": "Any error that occurred during the copy process.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "rels",
+        "description": "The relationships to turn into new nodes. Relationships can be of type `STRING` (elementId()), `INTEGER` (id()), `RELATIONSHIP`, or `LIST<STRING | INTEGER | RELATIONSHIP>`.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "labels",
+        "description": "The labels to be added to the new nodes.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "outType",
+        "description": "The type of the outgoing relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "inType",
+        "description": "The type of the ingoing relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.refactor.from(rel :: RELATIONSHIP, newNode :: NODE, config = {} :: MAP) :: (input :: INTEGER, output :: RELATIONSHIP, error :: STRING)",
+    "name": "apoc.refactor.from",
+    "description": "Redirects the given `RELATIONSHIP` to the given start `NODE`.",
+    "returnDescription": [
+      {
+        "name": "input",
+        "description": "The internal id of the original entity.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "output",
+        "description": "The copied entity.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "error",
+        "description": "Any error that occurred during the copy process.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "rel",
+        "description": "The relationship to redirect.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "newNode",
+        "description": "The node to redirect the given relationship to.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "config",
+        "description": "{\n    failOnErrors = false :: BOOLEAN\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.refactor.invert(rel :: RELATIONSHIP, config = {} :: MAP) :: (input :: INTEGER, output :: RELATIONSHIP, error :: STRING)",
+    "name": "apoc.refactor.invert",
+    "description": "Inverts the direction of the given `RELATIONSHIP`.",
+    "returnDescription": [
+      {
+        "name": "input",
+        "description": "The internal id of the original entity.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "output",
+        "description": "The copied entity.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "error",
+        "description": "Any error that occurred during the copy process.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "rel",
+        "description": "The relationship to reverse.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "config",
+        "description": "{\n    failOnErrors = false :: BOOLEAN\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.refactor.mergeNodes(nodes :: LIST<NODE>, config = {} :: MAP) :: (node :: NODE)",
+    "name": "apoc.refactor.mergeNodes",
+    "description": "Merges the given `LIST<NODE>` onto the first `NODE` in the `LIST<NODE>`.\nAll `RELATIONSHIP` values are merged onto that `NODE` as well.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The merged node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to be merged onto the first node.",
+        "isDeprecated": false,
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "config",
+        "description": "{\n    mergeRels :: BOOLEAN,\n    selfRef :: BOOLEAN,\n    produceSelfRef = true :: BOOLEAN,\n    preserveExistingSelfRels = true :: BOOLEAN,\n    countMerge = true :: BOOLEAN,\n    collapsedLabel :: BOOLEAN,\n    singleElementAsArray = false :: BOOLEAN,\n    avoidDuplicates = false :: BOOLEAN,\n    relationshipSelectionStrategy = \"incoming\" :: [\"incoming\", \"outgoing\", \"merge\"]\n    properties :: [\"overwrite\", \"\"discard\", \"combine\"]\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.refactor.mergeRelationships(rels :: LIST<RELATIONSHIP>, config = {} :: MAP) :: (rel :: RELATIONSHIP)",
+    "name": "apoc.refactor.mergeRelationships",
+    "description": "Merges the given `LIST<RELATIONSHIP>` onto the first `RELATIONSHIP` in the `LIST<RELATIONSHIP>`.",
+    "returnDescription": [
+      {
+        "name": "rel",
+        "description": "The merged relationship.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "rels",
+        "description": "The relationships to be merged onto the first relationship.",
+        "isDeprecated": false,
+        "type": "LIST<RELATIONSHIP>"
+      },
+      {
+        "name": "config",
+        "description": "{\n    mergeRels :: BOOLEAN,\n    selfRef :: BOOLEAN,\n    produceSelfRef = true :: BOOLEAN,\n    preserveExistingSelfRels = true :: BOOLEAN,\n    countMerge = true :: BOOLEAN,\n    collapsedLabel :: BOOLEAN,\n    singleElementAsArray = false :: BOOLEAN,\n    avoidDuplicates = false :: BOOLEAN,\n    relationshipSelectionStrategy = \"incoming\" :: [\"incoming\", \"outgoing\", \"merge\"]\n    properties :: [\"overwrite\", \"discard\", \"combine\"]\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.refactor.normalizeAsBoolean(entity :: ANY, propertyKey :: STRING, trueValues :: LIST<ANY>, falseValues :: LIST<ANY>)",
+    "name": "apoc.refactor.normalizeAsBoolean",
+    "description": "Refactors the given property to a `BOOLEAN`.",
+    "returnDescription": [],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "entity",
+        "description": "The node or relationship whose properties will be normalized to booleans.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "propertyKey",
+        "description": "The name of the property key to normalize.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "trueValues",
+        "description": "The possible representations of true values.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "falseValues",
+        "description": "The possible representations of false values.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.refactor.rename.nodeProperty(oldName :: STRING, newName :: STRING, nodes = [] :: LIST<NODE>, config = {} :: MAP) :: (batches :: INTEGER, total :: INTEGER, timeTaken :: INTEGER, committedOperations :: INTEGER, failedOperations :: INTEGER, failedBatches :: INTEGER, retries :: INTEGER, errorMessages :: MAP, batch :: MAP, operations :: MAP, constraints :: LIST<STRING>, indexes :: LIST<STRING>)",
+    "name": "apoc.refactor.rename.nodeProperty",
+    "description": "Renames the given property from `oldName` to `newName` for all `NODE` values.\nIf a `LIST<NODE>` is provided, the renaming is applied to the `NODE` values within this `LIST<NODE>` only.",
+    "returnDescription": [
+      {
+        "name": "batches",
+        "description": "The number of batches the operation was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "total",
+        "description": "The total number of renamings performed.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "timeTaken",
+        "description": "The time taken to complete the operation.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "committedOperations",
+        "description": "The total number of committed operations.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "failedOperations",
+        "description": "The total number of failed operations.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "failedBatches",
+        "description": "The total number of failed batches.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "retries",
+        "description": "The total number of retries.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "errorMessages",
+        "description": "The collected error messages.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "batch",
+        "description": "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "operations",
+        "description": "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "constraints",
+        "description": "Constraints associated with the given label or type.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "indexes",
+        "description": "Indexes associated with the given label or type.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "oldName",
+        "description": "The property to rename.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "newName",
+        "description": "The new name to give the property.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The nodes to apply the new name to. If this list is empty, all nodes with the old property name will be renamed.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=[], type=LIST<NODE>}",
+        "type": "LIST<NODE>"
+      },
+      {
+        "name": "config",
+        "description": "{\n    batchSize = 100000 :: INTEGER,\n    concurrency :: INTEGER,\n    retries = 0 :: INTEGER,\n    parallel = true :: BOOLEAN,\n    batchMode = \"BATCH\" :: STRING\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.refactor.rename.typeProperty(oldName :: STRING, newName :: STRING, rels = [] :: LIST<RELATIONSHIP>, config = {} :: MAP) :: (batches :: INTEGER, total :: INTEGER, timeTaken :: INTEGER, committedOperations :: INTEGER, failedOperations :: INTEGER, failedBatches :: INTEGER, retries :: INTEGER, errorMessages :: MAP, batch :: MAP, operations :: MAP, constraints :: LIST<STRING>, indexes :: LIST<STRING>)",
+    "name": "apoc.refactor.rename.typeProperty",
+    "description": "Renames the given property from `oldName` to `newName` for all `RELATIONSHIP` values.\nIf a `LIST<RELATIONSHIP>` is provided, the renaming is applied to the `RELATIONSHIP` values within this `LIST<RELATIONSHIP>` only.",
+    "returnDescription": [
+      {
+        "name": "batches",
+        "description": "The number of batches the operation was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "total",
+        "description": "The total number of renamings performed.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "timeTaken",
+        "description": "The time taken to complete the operation.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "committedOperations",
+        "description": "The total number of committed operations.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "failedOperations",
+        "description": "The total number of failed operations.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "failedBatches",
+        "description": "The total number of failed batches.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "retries",
+        "description": "The total number of retries.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "errorMessages",
+        "description": "The collected error messages.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "batch",
+        "description": "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "operations",
+        "description": "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "constraints",
+        "description": "Constraints associated with the given label or type.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "indexes",
+        "description": "Indexes associated with the given label or type.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "oldName",
+        "description": "The property to rename.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "newName",
+        "description": "The new name to give the property.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "rels",
+        "description": "The relationships to apply the new name to. If this list is empty, all relationships with the old properties name will be renamed.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=[], type=LIST<RELATIONSHIP>}",
+        "type": "LIST<RELATIONSHIP>"
+      },
+      {
+        "name": "config",
+        "description": "{\n    batchSize = 100000 :: INTEGER,\n    concurrency :: INTEGER,\n    retries = 0 :: INTEGER,\n    parallel = true :: BOOLEAN,\n    batchMode = \"BATCH\" :: STRING\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.refactor.to(rel :: RELATIONSHIP, endNode :: NODE, config = {} :: MAP) :: (input :: INTEGER, output :: RELATIONSHIP, error :: STRING)",
+    "name": "apoc.refactor.to",
+    "description": "Redirects the given `RELATIONSHIP` to the given end `NODE`.",
+    "returnDescription": [
+      {
+        "name": "input",
+        "description": "The id of the given relationship.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "output",
+        "description": "The id of the new relationship with the updated type.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "error",
+        "description": "The message if an error occurred.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "rel",
+        "description": "The relationship to redirect.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "endNode",
+        "description": "The new end node the relationship should point to.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "config",
+        "description": "{\n    failOnErrors = false :: BOOLEAN\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.schema.assert(indexes :: MAP, constraints :: MAP, dropExisting = true :: BOOLEAN) :: (label :: ANY, key :: STRING, keys :: LIST<STRING>, unique :: BOOLEAN, action :: STRING)",
+    "name": "apoc.schema.assert",
+    "description": "Drops all other existing indexes and constraints when `dropExisting` is `true` (default is `true`).\nAsserts at the end of the operation that the given indexes and unique constraints are there.",
+    "returnDescription": [
+      {
+        "name": "label",
+        "description": "The label associated with the constraint or index.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "key",
+        "description": "The property key associated with the constraint or index.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "keys",
+        "description": "The property keys associated with the constraint or index.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "unique",
+        "description": "Whether or not this is a uniqueness constraint.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "action",
+        "description": "The action applied to this constraint or index; can be [\"KEPT\", \"CREATED\", \"DROPPED\"]",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "indexes",
+        "description": "A map that pairs labels with lists of properties to create indexes from.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "constraints",
+        "description": "A map that pairs labels with lists of properties to create constraints from.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "dropExisting",
+        "description": "Whether or not to drop all other existing indexes and constraints.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=true, type=BOOLEAN}",
+        "type": "BOOLEAN"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.schema.nodes(config = {} :: MAP) :: (name :: STRING, label :: ANY, properties :: LIST<STRING>, status :: STRING, type :: STRING, failure :: STRING, populationProgress :: FLOAT, size :: INTEGER, valuesSelectivity :: FLOAT, userDescription :: STRING)",
+    "name": "apoc.schema.nodes",
+    "description": "Returns all indexes and constraints information for all `NODE` labels in the database.\nIt is possible to define a set of labels to include or exclude in the config parameters.",
+    "returnDescription": [
+      {
+        "name": "name",
+        "description": "A generated name for the index or constraint.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "label",
+        "description": "The label associated with the constraint or index.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "properties",
+        "description": "The property keys associated with the constraint or index.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "status",
+        "description": "The status of the constraint or index.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "type",
+        "description": "The type of the index or constraint.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "failure",
+        "description": "If a failure has occurred.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "populationProgress",
+        "description": "The percentage of the constraint or index population. ",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "size",
+        "description": "The number of entries in the given constraint or index.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "valuesSelectivity",
+        "description": "A ratio between 0.0 and 1.0, representing how many unique values were seen from the sampling.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "userDescription",
+        "description": "A descriptor of the constraint or index.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "config",
+        "description": "{\n    labels :: LIST<STRING>,\n    excludeLabels :: LIST<STRING>,\n    relationships :: LIST<STRING>,\n    excludeRelationships :: LIST<STRING>\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.schema.properties.distinct(label :: STRING, key :: STRING) :: (value :: LIST<ANY>)",
+    "name": "apoc.schema.properties.distinct",
+    "description": "Returns all distinct `NODE` property values for the given key.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The list of distinct values for the given property.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "label",
+        "description": "The node label to find distinct properties on.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "key",
+        "description": "The name of the property to find distinct values of.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.schema.properties.distinctCount(label =  :: STRING, key =  :: STRING) :: (label :: STRING, key :: STRING, value :: ANY, count :: INTEGER)",
+    "name": "apoc.schema.properties.distinctCount",
+    "description": "Returns all distinct property values and counts for the given key.",
+    "returnDescription": [
+      {
+        "name": "label",
+        "description": "The label of the node.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "key",
+        "description": "The name of the property key.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "value",
+        "description": "The distinct value.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "count",
+        "description": "The number of occurrences of the value.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "label",
+        "description": "The node label to count distinct properties on.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "key",
+        "description": "The name of the property to count distinct values of.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.schema.relationships(config = {} :: MAP) :: (name :: STRING, type :: STRING, properties :: LIST<STRING>, status :: STRING, relationshipType :: ANY)",
+    "name": "apoc.schema.relationships",
+    "description": "Returns the indexes and constraints information for all the relationship types in the database.\nIt is possible to define a set of relationship types to include or exclude in the config parameters.",
+    "returnDescription": [
+      {
+        "name": "name",
+        "description": "A generated name for the index or constraint.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "type",
+        "description": "The type of the index or constraint.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "properties",
+        "description": "The property keys associated with the constraint or index.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "status",
+        "description": "The status of the constraint or index.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "relationshipType",
+        "description": "The relationship type associated with the constraint or index.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "config",
+        "description": "{\n    labels :: LIST<STRING>,\n    excludeLabels :: LIST<STRING>,\n    relationships :: LIST<STRING>,\n    excludeRelationships :: LIST<STRING>\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.search.multiSearchReduced(labelPropertyMap :: ANY, operator :: STRING, value :: STRING) :: (id :: INTEGER, labels :: LIST<STRING>, values :: MAP)",
+    "name": "apoc.search.multiSearchReduced",
+    "description": "Returns a reduced representation of the `NODE` values found after a parallel search over multiple indexes.\nThe reduced `NODE` values representation includes: node id, node labels, and the searched properties.",
+    "returnDescription": [
+      {
+        "name": "id",
+        "description": "The id of the found node.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "labels",
+        "description": "The labels of the found node.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "values",
+        "description": "The matched values of the found node.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "labelPropertyMap",
+        "description": "A map that pairs labels with lists of properties. This can also be represented as a JSON string.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "operator",
+        "description": "The search operator, can be one of: [\"exact\", \"starts with\", \"ends with\", \"contains\", \"<\", \">\", \"=\", \"<>\", \"<=\", \">=\", \"=~\"].",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "value",
+        "description": "The search value.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.search.node(labelPropertyMap :: ANY, operator :: STRING, value :: STRING) :: (node :: NODE)",
+    "name": "apoc.search.node",
+    "description": "Returns all the distinct `NODE` values found after a parallel search over multiple indexes.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The found node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "labelPropertyMap",
+        "description": "A map that pairs labels with lists of properties. This can also be represented as a JSON string.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "operator",
+        "description": "The search operator, can be one of: [\"exact\", \"starts with\", \"ends with\", \"contains\", \"<\", \">\", \"=\", \"<>\", \"<=\", \">=\", \"=~\"].",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "value",
+        "description": "The search value.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.search.nodeAll(labelPropertyMap :: ANY, operator :: STRING, value :: STRING) :: (node :: NODE)",
+    "name": "apoc.search.nodeAll",
+    "description": "Returns all the `NODE` values found after a parallel search over multiple indexes.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The found node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "labelPropertyMap",
+        "description": "A map that pairs labels with lists of properties. This can also be represented as a JSON string.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "operator",
+        "description": "The search operator, can be one of: [\"exact\", \"starts with\", \"ends with\", \"contains\", \"<\", \">\", \"=\", \"<>\", \"<=\", \">=\", \"=~\"].",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "value",
+        "description": "The search value.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.search.nodeAllReduced(labelPropertyMap :: ANY, operator :: STRING, value :: ANY) :: (id :: INTEGER, labels :: LIST<STRING>, values :: MAP)",
+    "name": "apoc.search.nodeAllReduced",
+    "description": "Returns a reduced representation of the `NODE` values found after a parallel search over multiple indexes.\nThe reduced `NODE` values representation includes: node id, node labels, and the searched properties.",
+    "returnDescription": [
+      {
+        "name": "id",
+        "description": "The id of the found node.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "labels",
+        "description": "The labels of the found node.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "values",
+        "description": "The matched values of the found node.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "labelPropertyMap",
+        "description": "A map that pairs labels with lists of properties. This can also be represented as a JSON string.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "operator",
+        "description": "The search operator, can be one of: [\"exact\", \"starts with\", \"ends with\", \"contains\", \"<\", \">\", \"=\", \"<>\", \"<=\", \">=\", \"=~\"].",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "value",
+        "description": "The search value.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.search.nodeReduced(labelPropertyMap :: ANY, operator :: STRING, value :: STRING) :: (id :: INTEGER, labels :: LIST<STRING>, values :: MAP)",
+    "name": "apoc.search.nodeReduced",
+    "description": "Returns a reduced representation of the distinct `NODE` values found after a parallel search over multiple indexes.\nThe reduced `NODE` values representation includes: node id, node labels, and the searched properties.",
+    "returnDescription": [
+      {
+        "name": "id",
+        "description": "The id of the found node.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "labels",
+        "description": "The labels of the found node.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "values",
+        "description": "The matched values of the found node.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "labelPropertyMap",
+        "description": "A map that pairs labels with lists of properties. This can also be represented as a JSON string.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "operator",
+        "description": "The search operator, can be one of: [\"exact\", \"starts with\", \"ends with\", \"contains\", \"<\", \">\", \"=\", \"<>\", \"<=\", \">=\", \"=~\"].",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "value",
+        "description": "The search value.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.spatial.geocode(location :: STRING, maxResults = 100 :: INTEGER, quotaException = false :: BOOLEAN, config = {} :: MAP) :: (location :: MAP, data :: MAP, latitude :: FLOAT, longitude :: FLOAT, description :: STRING)",
+    "name": "apoc.spatial.geocode",
+    "description": "Returns the geographic location (latitude, longitude, and description) of the given address using a geocoding service (default: OpenStreetMap).",
+    "returnDescription": [
+      {
+        "name": "location",
+        "description": "A detailed map of information on the found location.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "data",
+        "description": "A map of returned data from the given provider.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "latitude",
+        "description": "The latitude of the found location.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "longitude",
+        "description": "The longitude of the found location.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "description",
+        "description": "A description of the found location.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "location",
+        "description": "The location to search for.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "maxResults",
+        "description": "The maximum number of returned results.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=100, type=INTEGER}",
+        "type": "INTEGER"
+      },
+      {
+        "name": "quotaException",
+        "description": "Whether or not to throw an exception when the maximum request quota is reached.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=false, type=BOOLEAN}",
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "config",
+        "description": "{\n        provider = 'osm' :: STRING,\n        url :: STRING,\n        reverseUrl: :: STRING,\n        key :: STRING\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.spatial.geocodeOnce(location :: STRING, config = {} :: MAP) :: (location :: MAP, data :: MAP, latitude :: FLOAT, longitude :: FLOAT, description :: STRING)",
+    "name": "apoc.spatial.geocodeOnce",
+    "description": "Returns the geographic location (latitude, longitude, and description) of the given address using a geocoding service (default: OpenStreetMap).\nThis procedure returns at most one result.",
+    "returnDescription": [
+      {
+        "name": "location",
+        "description": "A detailed map of information on the found location.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "data",
+        "description": "A map of returned data from the given provider.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "latitude",
+        "description": "The latitude of the found location.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "longitude",
+        "description": "The longitude of the found location.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "description",
+        "description": "A description of the found location.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "location",
+        "description": "The location to search for.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "config",
+        "description": "{\n        provider = 'osm' :: STRING,\n        url :: STRING,\n        reverseUrl: :: STRING,\n        key :: STRING\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.spatial.reverseGeocode(latitude :: FLOAT, longitude :: FLOAT, quotaException = false :: BOOLEAN, config = {} :: MAP) :: (location :: MAP, data :: MAP, latitude :: FLOAT, longitude :: FLOAT, description :: STRING)",
+    "name": "apoc.spatial.reverseGeocode",
+    "description": "Returns a textual address from the given geographic location (latitude, longitude) using a geocoding service (default: OpenStreetMap).\nThis procedure returns at most one result.",
+    "returnDescription": [
+      {
+        "name": "location",
+        "description": "A detailed map of information on the found location.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "data",
+        "description": "A map of returned data from the given provider.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "latitude",
+        "description": "The latitude of the found location.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "longitude",
+        "description": "The longitude of the found location.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "description",
+        "description": "A description of the found location.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "latitude",
+        "description": "The latitude of the location.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "longitude",
+        "description": "The longitude of the location.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      },
+      {
+        "name": "quotaException",
+        "description": "Whether or not to throw an exception when the maximum request quota is reached.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=false, type=BOOLEAN}",
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "config",
+        "description": "{\n        provider = 'osm' :: STRING,\n        url :: STRING,\n        reverseUrl: :: STRING,\n        key :: STRING\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.spatial.sortByDistance(paths :: LIST<PATH>) :: (path :: PATH, distance :: FLOAT)",
+    "name": "apoc.spatial.sortByDistance",
+    "description": "Sorts the given collection of `PATH` values by the sum of their distance based on the latitude/longitude values in the `NODE` values.",
+    "returnDescription": [
+      {
+        "name": "path",
+        "description": "The sorted path result.",
+        "isDeprecated": false,
+        "type": "PATH"
+      },
+      {
+        "name": "distance",
+        "description": "The distance between the nodes.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "paths",
+        "description": "A list of paths to be sorted by the sum of distances, calculated based on the latitude/longitude values in the nodes.",
+        "isDeprecated": false,
+        "type": "LIST<PATH>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.stats.degrees(relTypes =  :: STRING) :: (type :: STRING, direction :: STRING, total :: INTEGER, p50 :: INTEGER, p75 :: INTEGER, p90 :: INTEGER, p95 :: INTEGER, p99 :: INTEGER, p999 :: INTEGER, max :: INTEGER, min :: INTEGER, mean :: FLOAT)",
+    "name": "apoc.stats.degrees",
+    "description": "Returns the percentile groupings of the degrees on the `NODE` values connected by the given `RELATIONSHIP` types.",
+    "returnDescription": [
+      {
+        "name": "type",
+        "description": "The type of the relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "direction",
+        "description": "The direction of the relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "total",
+        "description": "The total observed relationships.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "p50",
+        "description": "The 50th percentile grouping.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "p75",
+        "description": "The 75th percentile grouping.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "p90",
+        "description": "The 90th percentile grouping.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "p95",
+        "description": "The 95th percentile grouping.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "p99",
+        "description": "The 99th percentile grouping.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "p999",
+        "description": "The 99.9th percentile grouping.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "max",
+        "description": "The max value.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "min",
+        "description": "The min value.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "mean",
+        "description": "The mean value.",
+        "isDeprecated": false,
+        "type": "FLOAT"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "relTypes",
+        "description": "The relationship types to calculate the percentile grouping over. If this is empty or omitted, all relationships are used.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.text.phoneticDelta(text1 :: STRING, text2 :: STRING) :: (phonetic1 :: STRING, phonetic2 :: STRING, delta :: INTEGER)",
+    "name": "apoc.text.phoneticDelta",
+    "description": "Returns the US_ENGLISH soundex character difference between the two given `STRING` values.",
+    "returnDescription": [
+      {
+        "name": "phonetic1",
+        "description": "The phonetic representation of the first string.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "phonetic2",
+        "description": "The phonetic representation of the second string.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "delta",
+        "description": "The soundex character difference between the two given strings.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "text1",
+        "description": "The first string to be compared against the second.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "text2",
+        "description": "The second string to be compared against the first.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.trigger.drop(databaseName :: STRING, name :: STRING) :: (name :: STRING, query :: STRING, selector :: MAP, params :: MAP, installed :: BOOLEAN, paused :: BOOLEAN)",
+    "name": "apoc.trigger.drop",
+    "description": "Eventually removes the given trigger.",
+    "returnDescription": [
+      {
+        "name": "name",
+        "description": "The name of the trigger.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "query",
+        "description": "The query belonging to the trigger.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "selector",
+        "description": "{ phase = \"before\" :: [\"before\", \"rollback\", \"after\", \"afterAsync\"] }",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statement.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "installed",
+        "description": "Whether or not the trigger was installed.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "paused",
+        "description": "Whether or not the trigger was paused.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "databaseName",
+        "description": "The name of the database to drop the trigger from.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "name",
+        "description": "The name of the trigger to drop.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.trigger.dropAll(databaseName :: STRING) :: (name :: STRING, query :: STRING, selector :: MAP, params :: MAP, installed :: BOOLEAN, paused :: BOOLEAN)",
+    "name": "apoc.trigger.dropAll",
+    "description": "Eventually removes all triggers from the given database.",
+    "returnDescription": [
+      {
+        "name": "name",
+        "description": "The name of the trigger.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "query",
+        "description": "The query belonging to the trigger.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "selector",
+        "description": "{ phase = \"before\" :: [\"before\", \"rollback\", \"after\", \"afterAsync\"] }",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statement.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "installed",
+        "description": "Whether or not the trigger was installed.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "paused",
+        "description": "Whether or not the trigger was paused.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "databaseName",
+        "description": "The name of the database to drop the triggers from.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.trigger.install(databaseName :: STRING, name :: STRING, statement :: STRING, selector :: MAP, config = {} :: MAP) :: (name :: STRING, query :: STRING, selector :: MAP, params :: MAP, installed :: BOOLEAN, paused :: BOOLEAN)",
+    "name": "apoc.trigger.install",
+    "description": "Eventually adds a trigger for a given database which is invoked when a successful transaction occurs.",
+    "returnDescription": [
+      {
+        "name": "name",
+        "description": "The name of the trigger.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "query",
+        "description": "The query belonging to the trigger.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "selector",
+        "description": "{ phase = \"before\" :: [\"before\", \"rollback\", \"after\", \"afterAsync\"] }",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statement.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "installed",
+        "description": "Whether or not the trigger was installed.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "paused",
+        "description": "Whether or not the trigger was paused.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "databaseName",
+        "description": "The name of the database to add the trigger to.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "name",
+        "description": "The name of the trigger to add.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "statement",
+        "description": "The query to run when triggered.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "selector",
+        "description": "{ phase = \"before\" :: [\"before\", \"rollback\", \"after\", \"afterAsync\"] }",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "config",
+        "description": "The parameters for the given Cypher statement.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.trigger.list() :: (name :: STRING, query :: STRING, selector :: MAP, params :: MAP, installed :: BOOLEAN, paused :: BOOLEAN)",
+    "name": "apoc.trigger.list",
+    "description": "Lists all currently installed triggers for the session database.",
+    "returnDescription": [
+      {
+        "name": "name",
+        "description": "The name of the trigger.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "query",
+        "description": "The query belonging to the trigger.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "selector",
+        "description": "{ phase = \"before\" :: [\"before\", \"rollback\", \"after\", \"afterAsync\"] }",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statement.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "installed",
+        "description": "Whether or not the trigger was installed.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "paused",
+        "description": "Whether or not the trigger was paused.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": []
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.trigger.show(databaseName :: STRING) :: (name :: STRING, query :: STRING, selector :: MAP, params :: MAP, installed :: BOOLEAN, paused :: BOOLEAN)",
+    "name": "apoc.trigger.show",
+    "description": "Lists all eventually installed triggers for a database.",
+    "returnDescription": [
+      {
+        "name": "name",
+        "description": "The name of the trigger.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "query",
+        "description": "The query belonging to the trigger.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "selector",
+        "description": "{ phase = \"before\" :: [\"before\", \"rollback\", \"after\", \"afterAsync\"] }",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statement.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "installed",
+        "description": "Whether or not the trigger was installed.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "paused",
+        "description": "Whether or not the trigger was paused.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "databaseName",
+        "description": "The name of the database to show triggers on.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.trigger.start(databaseName :: STRING, name :: STRING) :: (name :: STRING, query :: STRING, selector :: MAP, params :: MAP, installed :: BOOLEAN, paused :: BOOLEAN)",
+    "name": "apoc.trigger.start",
+    "description": "Eventually restarts the given paused trigger.",
+    "returnDescription": [
+      {
+        "name": "name",
+        "description": "The name of the trigger.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "query",
+        "description": "The query belonging to the trigger.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "selector",
+        "description": "{ phase = \"before\" :: [\"before\", \"rollback\", \"after\", \"afterAsync\"] }",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statement.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "installed",
+        "description": "Whether or not the trigger was installed.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "paused",
+        "description": "Whether or not the trigger was paused.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "databaseName",
+        "description": "The name of the database the trigger is on.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "name",
+        "description": "The name of the trigger to resume.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.trigger.stop(databaseName :: STRING, name :: STRING) :: (name :: STRING, query :: STRING, selector :: MAP, params :: MAP, installed :: BOOLEAN, paused :: BOOLEAN)",
+    "name": "apoc.trigger.stop",
+    "description": "Eventually stops the given trigger.",
+    "returnDescription": [
+      {
+        "name": "name",
+        "description": "The name of the trigger.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "query",
+        "description": "The query belonging to the trigger.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "selector",
+        "description": "{ phase = \"before\" :: [\"before\", \"rollback\", \"after\", \"afterAsync\"] }",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given Cypher statement.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "installed",
+        "description": "Whether or not the trigger was installed.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "paused",
+        "description": "Whether or not the trigger was paused.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "databaseName",
+        "description": "The name of the database the trigger is on.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "name",
+        "description": "The name of the trigger to drop.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.util.sleep(duration :: INTEGER)",
+    "name": "apoc.util.sleep",
+    "description": "Causes the currently running Cypher to sleep for the given duration of milliseconds (the transaction termination is honored).",
+    "returnDescription": [],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "duration",
+        "description": "The milliseconds to sleep.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.util.validate(predicate :: BOOLEAN, message :: STRING, params :: LIST<ANY>)",
+    "name": "apoc.util.validate",
+    "description": "If the given predicate is true an exception is thrown.",
+    "returnDescription": [],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "predicate",
+        "description": "The predicate to check against.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "message",
+        "description": "The error message to throw if the given predicate evaluates to true.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "params",
+        "description": "The parameters for the given error message.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  }
+]

--- a/core/src/test/resources/procedures/cypher25/procedures.json
+++ b/core/src/test/resources/procedures/cypher25/procedures.json
@@ -1,6 +1,29 @@
 [
   {
     "isDeprecated": true,
+    "signature": "apoc.algo.cover(nodes :: ANY) :: (rel :: RELATIONSHIP)",
+    "name": "apoc.algo.cover",
+    "description": "Returns all `RELATIONSHIP` values connecting the given set of `NODE` values.",
+    "returnDescription": [
+      {
+        "name": "rel",
+        "description": "The relationships connected to the given nodes.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      }
+    ],
+    "deprecatedBy": "Cypher's `MATCH` and `IN` clauses.",
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to look for connected relationships on.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
     "signature": "apoc.case(conditionals :: LIST<ANY>, elseQuery =  :: STRING, params = {} :: MAP) :: (value :: MAP)",
     "name": "apoc.case",
     "description": "For each pair of conditional and read-only queries in the given `LIST<ANY>`, this procedure will run the first query for which the conditional is evaluated to true. If none of the conditionals are true, the `ELSE` query will run instead.",
@@ -33,6 +56,477 @@
         "isDeprecated": false,
         "default": "DefaultParameterValue{value={}, type=MAP}",
         "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.coll.pairWithOffset(coll :: LIST<ANY>, offset :: INTEGER) :: (value :: LIST<ANY>)",
+    "name": "apoc.coll.pairWithOffset",
+    "description": "Returns a `LIST<ANY>` of pairs defined by the offset.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The created pair.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ],
+    "deprecatedBy": "Cypher's list comprehension: `RETURN [i IN range(0, size(list) - 1) | [list[i], list[i + offset]]] AS value`.",
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list to create pairs from.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "offset",
+        "description": "The offset to make each pair with from the given list.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.coll.partition(coll :: LIST<ANY>, batchSize :: INTEGER) :: (value :: LIST<ANY>)",
+    "name": "apoc.coll.partition",
+    "description": "Partitions the original `LIST<ANY>` into a new `LIST<ANY>` of the given batch size.\nThe final `LIST<ANY>` may be smaller than the given batch size.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The partitioned list.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ],
+    "deprecatedBy": "Cypher's list comprehension: `RETURN [i IN range(0, size(list), offset) | list[i..i + offset]] AS value`.",
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list to partition into smaller sublists.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "batchSize",
+        "description": "The max size of each partitioned sublist.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.coll.zipToRows(list1 :: LIST<ANY>, list2 :: LIST<ANY>) :: (value :: LIST<ANY>)",
+    "name": "apoc.coll.zipToRows",
+    "description": "Returns the two `LIST<ANY>` values zipped together, with one row per zipped pair.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "A zipped pair.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ],
+    "deprecatedBy": "Cypher's `UNWIND` and `range()` function; `UNWIND range(0, size(list1) - 1) AS i RETURN [list1[i], list2[i]]`.",
+    "argumentDescription": [
+      {
+        "name": "list1",
+        "description": "The list to zip together with `list2`.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "list2",
+        "description": "The list to zip together with `list1`.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.create.addLabels(nodes :: ANY, labels :: LIST<STRING>) :: (node :: NODE)",
+    "name": "apoc.create.addLabels",
+    "description": "Adds the given labels to the given `NODE` values.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The updated node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": "Cypher's dynamic labels; `SET n:$(labels)`.",
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to add labels to.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "labels",
+        "description": "The labels to add to the nodes.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.create.node(labels :: LIST<STRING>, props :: MAP) :: (node :: NODE)",
+    "name": "apoc.create.node",
+    "description": "Creates a `NODE` with the given dynamic labels.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The created node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": "Cypher's dynamic labels: `CREATE (n:$(labels)) SET n = props`",
+    "argumentDescription": [
+      {
+        "name": "labels",
+        "description": "The labels to assign to the new node.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "props",
+        "description": "The properties to assign to the new node.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.create.nodes(labels :: LIST<STRING>, props :: LIST<MAP>) :: (node :: NODE)",
+    "name": "apoc.create.nodes",
+    "description": "Creates `NODE` values with the given dynamic labels.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The created node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": "Cypher's dynamic labels: `UNWIND props AS p CREATE (n:$(labels)) SET n = p`",
+    "argumentDescription": [
+      {
+        "name": "labels",
+        "description": "The labels to assign to the new nodes.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "props",
+        "description": "The properties to assign to the new nodes.",
+        "isDeprecated": false,
+        "type": "LIST<MAP>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.create.relationship(from :: NODE, relType :: STRING, props :: MAP, to :: NODE) :: (rel :: RELATIONSHIP)",
+    "name": "apoc.create.relationship",
+    "description": "Creates a `RELATIONSHIP` with the given dynamic relationship type.",
+    "returnDescription": [
+      {
+        "name": "rel",
+        "description": "The created relationship.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      }
+    ],
+    "deprecatedBy": "Cypher's dynamic types: `CREATE (from)-[n:$(relType)]->(to) SET n = props`",
+    "argumentDescription": [
+      {
+        "name": "from",
+        "description": "The node from which the outgoing relationship will start.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relType",
+        "description": "The type to assign to the new relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "props",
+        "description": "The properties to assign to the new relationship.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "to",
+        "description": "The node to which the incoming relationship will be connected.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.create.removeLabels(nodes :: ANY, labels :: LIST<STRING>) :: (node :: NODE)",
+    "name": "apoc.create.removeLabels",
+    "description": "Removes the given labels from the given `NODE` values.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The updated node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": "Cypher's dynamic labels: `REMOVE node:$(labels)`",
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The node to remove labels from.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "labels",
+        "description": "The labels to remove from the given node.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.create.removeProperties(nodes :: ANY, keys :: LIST<STRING>) :: (node :: NODE)",
+    "name": "apoc.create.removeProperties",
+    "description": "Removes the given properties from the given `NODE` values.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The updated node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": "Cypher's dynamic properties: `REMOVE node[key]`.",
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to remove properties from.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "keys",
+        "description": "The property keys to remove from the given nodes.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.create.removeRelProperties(rels :: ANY, keys :: LIST<STRING>) :: (rel :: RELATIONSHIP)",
+    "name": "apoc.create.removeRelProperties",
+    "description": "Removes the given properties from the given `RELATIONSHIP` values.",
+    "returnDescription": [
+      {
+        "name": "rel",
+        "description": "The updated relationship.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      }
+    ],
+    "deprecatedBy": "Cypher's dynamic properties: `REMOVE rel[key]`.",
+    "argumentDescription": [
+      {
+        "name": "rels",
+        "description": "The relationships to remove properties from.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "keys",
+        "description": "The property keys to remove from the given nodes.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.create.setLabels(nodes :: ANY, labels :: LIST<STRING>) :: (node :: NODE)",
+    "name": "apoc.create.setLabels",
+    "description": "Sets the given labels to the given `NODE` values. Non-matching labels are removed from the nodes.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The updated node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": "Cypher's dynamic labels; `SET n:$(labels)`.",
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to set labels on.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "labels",
+        "description": "The labels to set on the given nodes.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.create.setProperties(nodes :: ANY, keys :: LIST<STRING>, values :: LIST<ANY>) :: (node :: NODE)",
+    "name": "apoc.create.setProperties",
+    "description": "Sets the given properties to the given `NODE` values.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The updated node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": "Cypher's dynamic properties: `SET node[key] = value`.",
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to set properties on.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "keys",
+        "description": "The property keys to set on the given nodes.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "values",
+        "description": "The values to assign to the properties on the given nodes.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.create.setProperty(nodes :: ANY, key :: STRING, value :: ANY) :: (node :: NODE)",
+    "name": "apoc.create.setProperty",
+    "description": "Sets the given property to the given `NODE` values.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The updated node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": "Cypher's dynamic properties: `SET node[key] = value`.",
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to set a property on.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "key",
+        "description": "The name of the property key to set.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "value",
+        "description": "The value of the property to set.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.create.setRelProperties(rels :: ANY, keys :: LIST<STRING>, values :: LIST<ANY>) :: (rel :: RELATIONSHIP)",
+    "name": "apoc.create.setRelProperties",
+    "description": "Sets the given properties on the `RELATIONSHIP` values.",
+    "returnDescription": [
+      {
+        "name": "rel",
+        "description": "The updated relationship.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      }
+    ],
+    "deprecatedBy": "Cypher's dynamic properties: `SET rel[key] = value`.",
+    "argumentDescription": [
+      {
+        "name": "rels",
+        "description": "The relationships to set properties on.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "keys",
+        "description": "The keys of the properties to set on the given relationships.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "values",
+        "description": "The values of the properties to set on the given relationships.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.create.setRelProperty(rels :: ANY, key :: STRING, value :: ANY) :: (rel :: RELATIONSHIP)",
+    "name": "apoc.create.setRelProperty",
+    "description": "Sets the given property on the `RELATIONSHIP` values.",
+    "returnDescription": [
+      {
+        "name": "rel",
+        "description": "The updated relationship.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      }
+    ],
+    "deprecatedBy": "Cypher's dynamic properties: `SET rel[key] = value`.",
+    "argumentDescription": [
+      {
+        "name": "rels",
+        "description": "The relationships to set a property on.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "key",
+        "description": "The name of the property key to set.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "value",
+        "description": "The value of the property to set.",
+        "isDeprecated": false,
+        "type": "ANY"
       }
     ]
   },
@@ -159,6 +653,87 @@
   },
   {
     "isDeprecated": true,
+    "signature": "apoc.nodes.delete(nodes :: ANY, batchSize :: INTEGER) :: (value :: INTEGER)",
+    "name": "apoc.nodes.delete",
+    "description": "Deletes all `NODE` values with the given ids.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The number of deleted nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ],
+    "deprecatedBy": "Cypher's `CALL {...} IN TRANSACTIONS`.",
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to be deleted. Nodes can be of type `STRING` (elementId()), `INTEGER` (id()), `NODE`, or `LIST<STRING | INTEGER | NODE>`.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "batchSize",
+        "description": "The number of node values to delete in a single batch.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.refactor.categorize(sourceKey :: STRING, type :: STRING, outgoing :: BOOLEAN, label :: STRING, targetKey :: STRING, copiedKeys :: LIST<STRING>, batchSize :: INTEGER)",
+    "name": "apoc.refactor.categorize",
+    "description": "Creates new category `NODE` values from `NODE` values in the graph with the specified `sourceKey` as one of its property keys.\nThe new category `NODE` values are then connected to the original `NODE` values with a `RELATIONSHIP` of the given type.",
+    "returnDescription": [],
+    "deprecatedBy": "Cypher's CALL {} IN TRANSACTIONS and dynamic labels, see the docs for more information.",
+    "argumentDescription": [
+      {
+        "name": "sourceKey",
+        "description": "The property key to add to the on the new node.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "type",
+        "description": "The relationship type to connect to the new node.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "outgoing",
+        "description": "Whether the relationship should be outgoing or not.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "label",
+        "description": "The label of the new node.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "targetKey",
+        "description": "The name by which the source key value will be referenced on the new node.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "copiedKeys",
+        "description": "A list of additional property keys to be copied to the new node.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "batchSize",
+        "description": "The max size of each batch.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
     "signature": "apoc.refactor.deleteAndReconnect(path :: PATH, nodes :: LIST<NODE>, config = {} :: MAP) :: (nodes :: LIST<NODE>, relationships :: LIST<RELATIONSHIP>)",
     "name": "apoc.refactor.deleteAndReconnect",
     "description": "Removes the given `NODE` values from the `PATH` (and graph, including all of its relationships) and reconnects the remaining `NODE` values.\nNote, undefined behaviour for paths that visits the same node multiple times.\nNote, nodes that are not connected in the same direction as the path will not be reconnected, for example `MATCH p=(:A)-->(b:B)<--(:C) CALL apoc.refactor.deleteAndReconnect(p, [b]) ...` will not reconnect the :A and :C nodes.",
@@ -196,6 +771,258 @@
         "isDeprecated": false,
         "default": "DefaultParameterValue{value={}, type=MAP}",
         "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.refactor.rename.label(oldLabel :: STRING, newLabel :: STRING, nodes = [] :: LIST<NODE>) :: (batches :: INTEGER, total :: INTEGER, timeTaken :: INTEGER, committedOperations :: INTEGER, failedOperations :: INTEGER, failedBatches :: INTEGER, retries :: INTEGER, errorMessages :: MAP, batch :: MAP, operations :: MAP, constraints :: LIST<STRING>, indexes :: LIST<STRING>)",
+    "name": "apoc.refactor.rename.label",
+    "description": "Renames the given label from `oldLabel` to `newLabel` for all `NODE` values.\nIf a `LIST<NODE>` is provided, the renaming is applied to the `NODE` values within this `LIST<NODE>` only.",
+    "returnDescription": [
+      {
+        "name": "batches",
+        "description": "The number of batches the operation was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "total",
+        "description": "The total number of renamings performed.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "timeTaken",
+        "description": "The time taken to complete the operation.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "committedOperations",
+        "description": "The total number of committed operations.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "failedOperations",
+        "description": "The total number of failed operations.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "failedBatches",
+        "description": "The total number of failed batches.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "retries",
+        "description": "The total number of retries.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "errorMessages",
+        "description": "The collected error messages.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "batch",
+        "description": "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "operations",
+        "description": "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "constraints",
+        "description": "Constraints associated with the given label or type.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "indexes",
+        "description": "Indexes associated with the given label or type.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      }
+    ],
+    "deprecatedBy": "Cypher's dynamic labels; `REMOVE n:$(oldLabel) SET n:$(newLabel)`.",
+    "argumentDescription": [
+      {
+        "name": "oldLabel",
+        "description": "The label to rename.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "newLabel",
+        "description": "The new name to give the label.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The nodes to apply the new name to. If this list is empty, all nodes with the old label will be renamed.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=[], type=LIST<NODE>}",
+        "type": "LIST<NODE>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.refactor.rename.type(oldType :: STRING, newType :: STRING, rels = [] :: LIST<RELATIONSHIP>, config = {} :: MAP) :: (batches :: INTEGER, total :: INTEGER, timeTaken :: INTEGER, committedOperations :: INTEGER, failedOperations :: INTEGER, failedBatches :: INTEGER, retries :: INTEGER, errorMessages :: MAP, batch :: MAP, operations :: MAP, constraints :: LIST<STRING>, indexes :: LIST<STRING>)",
+    "name": "apoc.refactor.rename.type",
+    "description": "Renames all `RELATIONSHIP` values with type `oldType` to `newType`.\nIf a `LIST<RELATIONSHIP>` is provided, the renaming is applied to the `RELATIONSHIP` values within this `LIST<RELATIONSHIP>` only.",
+    "returnDescription": [
+      {
+        "name": "batches",
+        "description": "The number of batches the operation was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "total",
+        "description": "The total number of renamings performed.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "timeTaken",
+        "description": "The time taken to complete the operation.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "committedOperations",
+        "description": "The total number of committed operations.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "failedOperations",
+        "description": "The total number of failed operations.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "failedBatches",
+        "description": "The total number of failed batches.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "retries",
+        "description": "The total number of retries.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "errorMessages",
+        "description": "The collected error messages.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "batch",
+        "description": "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "operations",
+        "description": "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "constraints",
+        "description": "Constraints associated with the given label or type.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "indexes",
+        "description": "Indexes associated with the given label or type.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      }
+    ],
+    "deprecatedBy": "Cypher's dynamic types: `CREATE (from)-[newRel:$(newType)]->(to) SET newRel = properties(oldRel) DELETE oldRel`.",
+    "argumentDescription": [
+      {
+        "name": "oldType",
+        "description": "The type to rename.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "newType",
+        "description": "The new type for the relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "rels",
+        "description": "The relationships to apply the new name to. If this list is empty, all relationships with the old type will be renamed.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=[], type=LIST<RELATIONSHIP>}",
+        "type": "LIST<RELATIONSHIP>"
+      },
+      {
+        "name": "config",
+        "description": "{\n    batchSize = 100000 :: INTEGER,\n    concurrency :: INTEGER,\n    retries = 0 :: INTEGER,\n    parallel = true :: BOOLEAN,\n    batchMode = \"BATCH\" :: STRING\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "signature": "apoc.refactor.setType(rel :: RELATIONSHIP, newType :: STRING) :: (input :: INTEGER, output :: RELATIONSHIP, error :: STRING)",
+    "name": "apoc.refactor.setType",
+    "description": "Changes the type of the given `RELATIONSHIP`.",
+    "returnDescription": [
+      {
+        "name": "input",
+        "description": "The id of the given relationship.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "output",
+        "description": "The id of the new relationship with the updated type.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "error",
+        "description": "The message if an error occurred.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ],
+    "deprecatedBy": "Cypher's dynamic types: `CREATE (from)-[newRel:$(newType)]->(to) SET newRel = properties(oldRel) DELETE oldRel`.",
+    "argumentDescription": [
+      {
+        "name": "rel",
+        "description": "The relationship to change the type of.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "newType",
+        "description": "The new type for the relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
       }
     ]
   },

--- a/core/src/test/resources/procedures/cypher5/procedures.json
+++ b/core/src/test/resources/procedures/cypher5/procedures.json
@@ -1,6 +1,29 @@
 [
   {
     "isDeprecated": false,
+    "signature": "apoc.algo.cover(nodes :: ANY) :: (rel :: RELATIONSHIP)",
+    "name": "apoc.algo.cover",
+    "description": "Returns all `RELATIONSHIP` values connecting the given set of `NODE` values.",
+    "returnDescription": [
+      {
+        "name": "rel",
+        "description": "The relationships connected to the given nodes.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to look for connected relationships on.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
     "signature": "apoc.case(conditionals :: LIST<ANY>, elseQuery =  :: STRING, params = {} :: MAP) :: (value :: MAP)",
     "name": "apoc.case",
     "description": "For each pair of conditional and read-only queries in the given `LIST<ANY>`, this procedure will run the first query for which the conditional is evaluated to true. If none of the conditionals are true, the `ELSE` query will run instead.",
@@ -33,6 +56,93 @@
         "isDeprecated": false,
         "default": "DefaultParameterValue{value={}, type=MAP}",
         "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.coll.pairWithOffset(coll :: LIST<ANY>, offset :: INTEGER) :: (value :: LIST<ANY>)",
+    "name": "apoc.coll.pairWithOffset",
+    "description": "Returns a `LIST<ANY>` of pairs defined by the offset.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The created pair.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list to create pairs from.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "offset",
+        "description": "The offset to make each pair with from the given list.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.coll.partition(coll :: LIST<ANY>, batchSize :: INTEGER) :: (value :: LIST<ANY>)",
+    "name": "apoc.coll.partition",
+    "description": "Partitions the original `LIST<ANY>` into a new `LIST<ANY>` of the given batch size.\nThe final `LIST<ANY>` may be smaller than the given batch size.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The partitioned list.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "coll",
+        "description": "The list to partition into smaller sublists.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "batchSize",
+        "description": "The max size of each partitioned sublist.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.coll.zipToRows(list1 :: LIST<ANY>, list2 :: LIST<ANY>) :: (value :: LIST<ANY>)",
+    "name": "apoc.coll.zipToRows",
+    "description": "Returns the two `LIST<ANY>` values zipped together, with one row per zipped pair.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "A zipped pair.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "list1",
+        "description": "The list to zip together with `list2`.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      },
+      {
+        "name": "list2",
+        "description": "The list to zip together with `list1`.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
       }
     ]
   },
@@ -70,6 +180,390 @@
         "isDeprecated": false,
         "default": "DefaultParameterValue{value={}, type=MAP}",
         "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.create.addLabels(nodes :: ANY, labels :: LIST<STRING>) :: (node :: NODE)",
+    "name": "apoc.create.addLabels",
+    "description": "Adds the given labels to the given `NODE` values.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The updated node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to add labels to.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "labels",
+        "description": "The labels to add to the nodes.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.create.node(labels :: LIST<STRING>, props :: MAP) :: (node :: NODE)",
+    "name": "apoc.create.node",
+    "description": "Creates a `NODE` with the given dynamic labels.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The created node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "labels",
+        "description": "The labels to assign to the new node.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "props",
+        "description": "The properties to assign to the new node.",
+        "isDeprecated": false,
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.create.nodes(labels :: LIST<STRING>, props :: LIST<MAP>) :: (node :: NODE)",
+    "name": "apoc.create.nodes",
+    "description": "Creates `NODE` values with the given dynamic labels.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The created node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "labels",
+        "description": "The labels to assign to the new nodes.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "props",
+        "description": "The properties to assign to the new nodes.",
+        "isDeprecated": false,
+        "type": "LIST<MAP>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.create.relationship(from :: NODE, relType :: STRING, props :: MAP, to :: NODE) :: (rel :: RELATIONSHIP)",
+    "name": "apoc.create.relationship",
+    "description": "Creates a `RELATIONSHIP` with the given dynamic relationship type.",
+    "returnDescription": [
+      {
+        "name": "rel",
+        "description": "The created relationship.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "from",
+        "description": "The node from which the outgoing relationship will start.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "relType",
+        "description": "The type to assign to the new relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "props",
+        "description": "The properties to assign to the new relationship.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "to",
+        "description": "The node to which the incoming relationship will be connected.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.create.removeLabels(nodes :: ANY, labels :: LIST<STRING>) :: (node :: NODE)",
+    "name": "apoc.create.removeLabels",
+    "description": "Removes the given labels from the given `NODE` values.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The updated node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The node to remove labels from.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "labels",
+        "description": "The labels to remove from the given node.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.create.removeProperties(nodes :: ANY, keys :: LIST<STRING>) :: (node :: NODE)",
+    "name": "apoc.create.removeProperties",
+    "description": "Removes the given properties from the given `NODE` values.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The updated node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to remove properties from.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "keys",
+        "description": "The property keys to remove from the given nodes.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.create.removeRelProperties(rels :: ANY, keys :: LIST<STRING>) :: (rel :: RELATIONSHIP)",
+    "name": "apoc.create.removeRelProperties",
+    "description": "Removes the given properties from the given `RELATIONSHIP` values.",
+    "returnDescription": [
+      {
+        "name": "rel",
+        "description": "The updated relationship.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "rels",
+        "description": "The relationships to remove properties from.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "keys",
+        "description": "The property keys to remove from the given nodes.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.create.setLabels(nodes :: ANY, labels :: LIST<STRING>) :: (node :: NODE)",
+    "name": "apoc.create.setLabels",
+    "description": "Sets the given labels to the given `NODE` values. Non-matching labels are removed from the nodes.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The updated node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to set labels on.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "labels",
+        "description": "The labels to set on the given nodes.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.create.setProperties(nodes :: ANY, keys :: LIST<STRING>, values :: LIST<ANY>) :: (node :: NODE)",
+    "name": "apoc.create.setProperties",
+    "description": "Sets the given properties to the given `NODE` values.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The updated node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to set properties on.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "keys",
+        "description": "The property keys to set on the given nodes.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "values",
+        "description": "The values to assign to the properties on the given nodes.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.create.setProperty(nodes :: ANY, key :: STRING, value :: ANY) :: (node :: NODE)",
+    "name": "apoc.create.setProperty",
+    "description": "Sets the given property to the given `NODE` values.",
+    "returnDescription": [
+      {
+        "name": "node",
+        "description": "The updated node.",
+        "isDeprecated": false,
+        "type": "NODE"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to set a property on.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "key",
+        "description": "The name of the property key to set.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "value",
+        "description": "The value of the property to set.",
+        "isDeprecated": false,
+        "type": "ANY"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.create.setRelProperties(rels :: ANY, keys :: LIST<STRING>, values :: LIST<ANY>) :: (rel :: RELATIONSHIP)",
+    "name": "apoc.create.setRelProperties",
+    "description": "Sets the given properties on the `RELATIONSHIP` values.",
+    "returnDescription": [
+      {
+        "name": "rel",
+        "description": "The updated relationship.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "rels",
+        "description": "The relationships to set properties on.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "keys",
+        "description": "The keys of the properties to set on the given relationships.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "values",
+        "description": "The values of the properties to set on the given relationships.",
+        "isDeprecated": false,
+        "type": "LIST<ANY>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.create.setRelProperty(rels :: ANY, key :: STRING, value :: ANY) :: (rel :: RELATIONSHIP)",
+    "name": "apoc.create.setRelProperty",
+    "description": "Sets the given property on the `RELATIONSHIP` values.",
+    "returnDescription": [
+      {
+        "name": "rel",
+        "description": "The updated relationship.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "rels",
+        "description": "The relationships to set a property on.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "key",
+        "description": "The name of the property key to set.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "value",
+        "description": "The value of the property to set.",
+        "isDeprecated": false,
+        "type": "ANY"
       }
     ]
   },
@@ -753,6 +1247,87 @@
   },
   {
     "isDeprecated": false,
+    "signature": "apoc.nodes.delete(nodes :: ANY, batchSize :: INTEGER) :: (value :: INTEGER)",
+    "name": "apoc.nodes.delete",
+    "description": "Deletes all `NODE` values with the given ids.",
+    "returnDescription": [
+      {
+        "name": "value",
+        "description": "The number of deleted nodes.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "nodes",
+        "description": "The nodes to be deleted. Nodes can be of type `STRING` (elementId()), `INTEGER` (id()), `NODE`, or `LIST<STRING | INTEGER | NODE>`.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "batchSize",
+        "description": "The number of node values to delete in a single batch.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.refactor.categorize(sourceKey :: STRING, type :: STRING, outgoing :: BOOLEAN, label :: STRING, targetKey :: STRING, copiedKeys :: LIST<STRING>, batchSize :: INTEGER)",
+    "name": "apoc.refactor.categorize",
+    "description": "Creates new category `NODE` values from `NODE` values in the graph with the specified `sourceKey` as one of its property keys.\nThe new category `NODE` values are then connected to the original `NODE` values with a `RELATIONSHIP` of the given type.",
+    "returnDescription": [],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "sourceKey",
+        "description": "The property key to add to the on the new node.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "type",
+        "description": "The relationship type to connect to the new node.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "outgoing",
+        "description": "Whether the relationship should be outgoing or not.",
+        "isDeprecated": false,
+        "type": "BOOLEAN"
+      },
+      {
+        "name": "label",
+        "description": "The label of the new node.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "targetKey",
+        "description": "The name by which the source key value will be referenced on the new node.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "copiedKeys",
+        "description": "A list of additional property keys to be copied to the new node.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "batchSize",
+        "description": "The max size of each batch.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
     "signature": "apoc.refactor.deleteAndReconnect(path :: PATH, nodes :: LIST<NODE>, config = {} :: MAP) :: (nodes :: LIST<NODE>, relationships :: LIST<RELATIONSHIP>)",
     "name": "apoc.refactor.deleteAndReconnect",
     "description": "Removes the given `NODE` values from the `PATH` (and graph, including all of its relationships) and reconnects the remaining `NODE` values.\nNote, undefined behaviour for paths that visits the same node multiple times.\nNote, nodes that are not connected in the same direction as the path will not be reconnected, for example `MATCH p=(:A)-->(b:B)<--(:C) CALL apoc.refactor.deleteAndReconnect(p, [b]) ...` will not reconnect the :A and :C nodes.",
@@ -790,6 +1365,258 @@
         "isDeprecated": false,
         "default": "DefaultParameterValue{value={}, type=MAP}",
         "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.refactor.rename.label(oldLabel :: STRING, newLabel :: STRING, nodes = [] :: LIST<NODE>) :: (batches :: INTEGER, total :: INTEGER, timeTaken :: INTEGER, committedOperations :: INTEGER, failedOperations :: INTEGER, failedBatches :: INTEGER, retries :: INTEGER, errorMessages :: MAP, batch :: MAP, operations :: MAP, constraints :: LIST<STRING>, indexes :: LIST<STRING>)",
+    "name": "apoc.refactor.rename.label",
+    "description": "Renames the given label from `oldLabel` to `newLabel` for all `NODE` values.\nIf a `LIST<NODE>` is provided, the renaming is applied to the `NODE` values within this `LIST<NODE>` only.",
+    "returnDescription": [
+      {
+        "name": "batches",
+        "description": "The number of batches the operation was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "total",
+        "description": "The total number of renamings performed.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "timeTaken",
+        "description": "The time taken to complete the operation.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "committedOperations",
+        "description": "The total number of committed operations.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "failedOperations",
+        "description": "The total number of failed operations.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "failedBatches",
+        "description": "The total number of failed batches.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "retries",
+        "description": "The total number of retries.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "errorMessages",
+        "description": "The collected error messages.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "batch",
+        "description": "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "operations",
+        "description": "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "constraints",
+        "description": "Constraints associated with the given label or type.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "indexes",
+        "description": "Indexes associated with the given label or type.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "oldLabel",
+        "description": "The label to rename.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "newLabel",
+        "description": "The new name to give the label.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "nodes",
+        "description": "The nodes to apply the new name to. If this list is empty, all nodes with the old label will be renamed.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=[], type=LIST<NODE>}",
+        "type": "LIST<NODE>"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.refactor.rename.type(oldType :: STRING, newType :: STRING, rels = [] :: LIST<RELATIONSHIP>, config = {} :: MAP) :: (batches :: INTEGER, total :: INTEGER, timeTaken :: INTEGER, committedOperations :: INTEGER, failedOperations :: INTEGER, failedBatches :: INTEGER, retries :: INTEGER, errorMessages :: MAP, batch :: MAP, operations :: MAP, constraints :: LIST<STRING>, indexes :: LIST<STRING>)",
+    "name": "apoc.refactor.rename.type",
+    "description": "Renames all `RELATIONSHIP` values with type `oldType` to `newType`.\nIf a `LIST<RELATIONSHIP>` is provided, the renaming is applied to the `RELATIONSHIP` values within this `LIST<RELATIONSHIP>` only.",
+    "returnDescription": [
+      {
+        "name": "batches",
+        "description": "The number of batches the operation was run in.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "total",
+        "description": "The total number of renamings performed.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "timeTaken",
+        "description": "The time taken to complete the operation.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "committedOperations",
+        "description": "The total number of committed operations.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "failedOperations",
+        "description": "The total number of failed operations.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "failedBatches",
+        "description": "The total number of failed batches.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "retries",
+        "description": "The total number of retries.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "errorMessages",
+        "description": "The collected error messages.",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "batch",
+        "description": "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "operations",
+        "description": "{\n     total :: INTEGER,\n     failed :: INTEGER,\n     committed :: INTEGER,\n     errors :: MAP\n}\n",
+        "isDeprecated": false,
+        "type": "MAP"
+      },
+      {
+        "name": "constraints",
+        "description": "Constraints associated with the given label or type.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "indexes",
+        "description": "Indexes associated with the given label or type.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "oldType",
+        "description": "The type to rename.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "newType",
+        "description": "The new type for the relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "rels",
+        "description": "The relationships to apply the new name to. If this list is empty, all relationships with the old type will be renamed.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=[], type=LIST<RELATIONSHIP>}",
+        "type": "LIST<RELATIONSHIP>"
+      },
+      {
+        "name": "config",
+        "description": "{\n    batchSize = 100000 :: INTEGER,\n    concurrency :: INTEGER,\n    retries = 0 :: INTEGER,\n    parallel = true :: BOOLEAN,\n    batchMode = \"BATCH\" :: STRING\n}\n",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "signature": "apoc.refactor.setType(rel :: RELATIONSHIP, newType :: STRING) :: (input :: INTEGER, output :: RELATIONSHIP, error :: STRING)",
+    "name": "apoc.refactor.setType",
+    "description": "Changes the type of the given `RELATIONSHIP`.",
+    "returnDescription": [
+      {
+        "name": "input",
+        "description": "The id of the given relationship.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "output",
+        "description": "The id of the new relationship with the updated type.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "error",
+        "description": "The message if an error occurred.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ],
+    "deprecatedBy": null,
+    "argumentDescription": [
+      {
+        "name": "rel",
+        "description": "The relationship to change the type of.",
+        "isDeprecated": false,
+        "type": "RELATIONSHIP"
+      },
+      {
+        "name": "newType",
+        "description": "The new type for the relationship.",
+        "isDeprecated": false,
+        "type": "STRING"
       }
     ]
   },


### PR DESCRIPTION
Based on the benchmarking analysis, these are the procedures and functions that I deemed were easy to do in Cypher as well as showed a better performance in Cypher.

See [here](https://github.com/neo4j/docs-apoc/pull/439) for the docs