### PR TITLE
Add NAN support to graphml imports

### DIFF
--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
@@ -112,6 +112,9 @@ public class XmlGraphMLReader {
         },
         INT() {
             Object parse(String value) {
+                if (value.equalsIgnoreCase("NAN")) {
+                    return Float.NaN; // No Integer.NAN
+                }
                 return Integer.parseInt(value);
             }
 
@@ -121,6 +124,9 @@ public class XmlGraphMLReader {
         },
         LONG() {
             Object parse(String value) {
+                if (value.equalsIgnoreCase("NAN")) {
+                    return Float.NaN; // No Long.NAN
+                }
                 return Long.parseLong(value);
             }
 
@@ -130,6 +136,9 @@ public class XmlGraphMLReader {
         },
         FLOAT() {
             Object parse(String value) {
+                if (value.equalsIgnoreCase("NAN")) {
+                    return Float.NaN;
+                }
                 return Float.parseFloat(value);
             }
 
@@ -139,6 +148,9 @@ public class XmlGraphMLReader {
         },
         DOUBLE() {
             Object parse(String value) {
+                if (value.equalsIgnoreCase("NAN")) {
+                    return Double.NaN;
+                }
                 return Double.parseDouble(value);
             }
 


### PR DESCRIPTION
Fixes: https://github.com/neo4j/apoc/issues/444

Gives support for import Graphml with NAN values for number types. Int and Long in Java do not support NaN, so it will be a Float.NaN in this case, the only potential issue is if a user has a constraint on what they are importing for having it as an INTEGER, but I believe this is a better issue than the import just failing with an exception.