### PR TITLE
Migrate from deprecated neo4j-java-driver methods to new ones

### DIFF
--- a/it/src/test/java/apoc/it/core/ExportCypherEnterpriseFeaturesTest.java
+++ b/it/src/test/java/apoc/it/core/ExportCypherEnterpriseFeaturesTest.java
@@ -59,31 +59,17 @@ public class ExportCypherEnterpriseFeaturesTest {
     }
 
     private static void beforeTwoLabelsWithOneCompoundConstraintEach() {
-        session.writeTransaction(tx -> {
-            tx.run("CREATE CONSTRAINT compositeBase FOR (t:Base) REQUIRE (t.tenantId, t.id) IS NODE KEY");
-            tx.commit();
-            return null;
-        });
-        session.writeTransaction(tx -> {
-            tx.run("CREATE (a:Person:Base {name: 'Phil', surname: 'Meyer', tenantId: 'neo4j', id: 'waBfk3z'}) "
-                    + "CREATE (b:Person:Base {name: 'Silvia', surname: 'Jones', tenantId: 'random', id: 'waBfk3z'}) "
-                    + "CREATE (a)-[:KNOWS {foo:2}]->(b)");
-            tx.commit();
-            return null;
-        });
+        session.executeWriteWithoutResult(
+                tx -> tx.run("CREATE CONSTRAINT compositeBase FOR (t:Base) REQUIRE (t.tenantId, t.id) IS NODE KEY"));
+        session.executeWriteWithoutResult(tx ->
+                tx.run("CREATE (a:Person:Base {name: 'Phil', surname: 'Meyer', tenantId: 'neo4j', id: 'waBfk3z'}) "
+                        + "CREATE (b:Person:Base {name: 'Silvia', surname: 'Jones', tenantId: 'random', id: 'waBfk3z'}) "
+                        + "CREATE (a)-[:KNOWS {foo:2}]->(b)"));
     }
 
     private static void afterTwoLabelsWithOneCompoundConstraintEach() {
-        session.writeTransaction(tx -> {
-            tx.run("MATCH (a:Person:Base) DETACH DELETE a");
-            tx.commit();
-            return null;
-        });
-        session.writeTransaction(tx -> {
-            tx.run("DROP CONSTRAINT compositeBase");
-            tx.commit();
-            return null;
-        });
+        session.executeWriteWithoutResult(tx -> tx.run("MATCH (a:Person:Base) DETACH DELETE a"));
+        session.executeWriteWithoutResult(tx -> tx.run("DROP CONSTRAINT compositeBase"));
     }
 
     @Test

--- a/it/src/test/java/apoc/it/core/ImportJsonEnterpriseFeaturesTest.java
+++ b/it/src/test/java/apoc/it/core/ImportJsonEnterpriseFeaturesTest.java
@@ -47,11 +47,7 @@ public class ImportJsonEnterpriseFeaturesTest {
         neo4jContainer.start();
         session = neo4jContainer.getSession();
 
-        session.writeTransaction(tx -> {
-            tx.run("CREATE (u:User {name: \"Fred\"})");
-            tx.commit();
-            return null;
-        });
+        session.executeWriteWithoutResult(tx -> tx.run("CREATE (u:User {name: \"Fred\"})"));
 
         // First export a file that we can import
         String filename = "all.json";
@@ -62,17 +58,13 @@ public class ImportJsonEnterpriseFeaturesTest {
                 (r) -> Assert.assertTrue(r.hasNext()));
 
         // Remove node so we can import it after
-        session.writeTransaction(tx -> {
-            tx.run("MATCH (n) DETACH DELETE n");
-            tx.commit();
-            return null;
-        });
+        session.executeWriteWithoutResult(tx -> tx.run("MATCH (n) DETACH DELETE n"));
     }
 
     @Before
     public void cleanUpDb() {
         // Remove all current constraints/indexes
-        session.writeTransaction(tx -> {
+        session.executeWriteWithoutResult(tx -> {
             final List<String> constraints = tx.run("SHOW CONSTRAINTS YIELD name")
                     .list(i -> i.get("name").asString());
             constraints.forEach(name -> tx.run(String.format("DROP CONSTRAINT %s", name)));
@@ -80,16 +72,10 @@ public class ImportJsonEnterpriseFeaturesTest {
             final List<String> indexes =
                     tx.run("SHOW INDEXES YIELD name").list(i -> i.get("name").asString());
             indexes.forEach(name -> tx.run(String.format("DROP INDEX %s", name)));
-            tx.commit();
-            return null;
         });
 
         // Make sure we have no other nodes so all uniqueness constraints work
-        session.writeTransaction(tx -> {
-            tx.run("MATCH (n) DETACH DELETE n");
-            tx.commit();
-            return null;
-        });
+        session.executeWriteWithoutResult(tx -> tx.run("MATCH (n) DETACH DELETE n"));
     }
 
     @AfterClass
@@ -100,11 +86,9 @@ public class ImportJsonEnterpriseFeaturesTest {
 
     @Test
     public void shouldFailBecauseOfMissingUniqueConstraintException() {
-        session.writeTransaction(tx -> {
+        session.executeWriteWithoutResult(tx -> {
             tx.run("CREATE CONSTRAINT FOR (n:User) REQUIRE n.neo4jImportId IS NOT NULL");
             tx.run("CREATE CONSTRAINT FOR (n:User) REQUIRE (n.neo4jImportId, n.name) IS NODE KEY");
-            tx.commit();
-            return null;
         });
 
         String filename = "all.json";
@@ -119,11 +103,8 @@ public class ImportJsonEnterpriseFeaturesTest {
     @Test
     public void shouldWorkWithSingularNodeKeyAsConstraint() {
         // Add unique constraint (test if single node key works)
-        session.writeTransaction(tx -> {
-            tx.run("CREATE CONSTRAINT FOR (n:User) REQUIRE (n.neo4jImportId) IS NODE KEY");
-            tx.commit();
-            return null;
-        });
+        session.executeWriteWithoutResult(
+                tx -> tx.run("CREATE CONSTRAINT FOR (n:User) REQUIRE (n.neo4jImportId) IS NODE KEY"));
 
         // Test import procedure
         String filename = "all.json";

--- a/it/src/test/java/apoc/it/core/MetaEnterpriseFeaturesTest.java
+++ b/it/src/test/java/apoc/it/core/MetaEnterpriseFeaturesTest.java
@@ -75,16 +75,9 @@ public class MetaEnterpriseFeaturesTest {
 
     @Test
     public void testNodeTypePropertiesBasic() {
-        session.writeTransaction(tx -> {
-            tx.run("CREATE CONSTRAINT FOR (f:Foo) REQUIRE (f.s) IS NOT NULL;");
-            tx.commit();
-            return null;
-        });
-        session.writeTransaction(tx -> {
-            tx.run("CREATE (:Foo { l: 1, s: 'foo', d: datetime(), ll: ['a', 'b'], dl: [2.0, 3.0] });");
-            tx.commit();
-            return null;
-        });
+        session.executeWriteWithoutResult(tx -> tx.run("CREATE CONSTRAINT FOR (f:Foo) REQUIRE (f.s) IS NOT NULL;"));
+        session.executeWriteWithoutResult(
+                tx -> tx.run("CREATE (:Foo { l: 1, s: 'foo', d: datetime(), ll: ['a', 'b'], dl: [2.0, 3.0] });"));
         testResult(session, "CALL apoc.meta.nodeTypeProperties();", (r) -> {
             List<Map<String, Object>> records = gatherRecords(r);
             assertTrue(hasRecordMatching(

--- a/test-utils/src/main/java/apoc/util/Neo4jContainerExtension.java
+++ b/test-utils/src/main/java/apoc/util/Neo4jContainerExtension.java
@@ -137,11 +137,7 @@ public class Neo4jContainerExtension extends Neo4jContainer<Neo4jContainerExtens
                 if (statement.isEmpty()) {
                     continue;
                 }
-                session.writeTransaction(tx -> {
-                    tx.run(statement);
-                    tx.commit();
-                    return null;
-                });
+                session.executeWriteWithoutResult(tx -> tx.run(statement));
             }
         }
     }


### PR DESCRIPTION
The main objective is to stop using deprecated methods that have been removed in the next major driver version.
