### PR TITLE
Fix apoc.meta.schema adding incoming rels to outgoing list

### DIFF
--- a/core/src/main/java/apoc/meta/MetaRestricted.java
+++ b/core/src/main/java/apoc/meta/MetaRestricted.java
@@ -822,8 +822,14 @@ public class MetaRestricted {
                                     (Map<String, Object>) relationshipNameToRelationshipMap.get(relationshipName);
                             Map<String, Object> existingRel =
                                     (Map<String, Object>) actualRelationshipsList.get(relationshipName);
-                            List<String> labels = (List<String>) existingRel.get("labels");
-                            labels.addAll((List<String>) relToAdd.get("labels"));
+                            // If the map is showing outgoing rels, do not add incoming ones. The incoming ones for
+                            // that node are meant to be inferred by the user (this is a side effect of having the
+                            // type name as the key, it only gives one option of direction)
+                            if (relToAdd.getOrDefault("direction", "")
+                                    .equals(existingRel.getOrDefault("direction", ""))) {
+                                List<String> labels = (List<String>) existingRel.get("labels");
+                                labels.addAll((List<String>) relToAdd.get("labels"));
+                            }
                         } else
                             actualRelationshipsList.put(
                                     relationshipName, relationshipNameToRelationshipMap.get(relationshipName));


### PR DESCRIPTION
Fixes an issue where if a node has outgoing  and incoming relationships, the incoming ones were appended to the list of outgoing. Now incoming relationships are only showed if the node has no outgoing and that nodes incoming are thereby meant to be inferred by other nodes data.