### PR TITLE
Update startup test to not include arrow procedures in community

### DIFF
--- a/it/src/test/java/apoc/it/core/StartupTest.java
+++ b/it/src/test/java/apoc/it/core/StartupTest.java
@@ -101,7 +101,7 @@ public class StartupTest {
             // if Testcontainers wasn't able to retrieve the docker image we ignore the test
             if (TestContainerUtil.isDockerImageAvailable(ex)) {
                 ex.printStackTrace();
-                 fail("Should not have thrown exception when trying to start Neo4j: " + ex);
+                fail("Should not have thrown ex ception when trying to start Neo4j: " + ex);
             } else if (!TestUtil.isRunningInCI()) {
                 fail("The docker image " + dockerImageForNeo4j(version)
                         + " could not be loaded. Check whether it's available locally / in the CI. Exception:"


### PR DESCRIPTION
The dependencies for arrow are not bundled with APOC but needs to be provided explicitly. Before they were provided through both Neo4j enterprise and community, but now they are only in enterprise on 5.26. This means the arrow procedures are no longer packaged by default in a community docker image.