### PR TITLE
Update startup test to not include arrow procedures in community

### DIFF
--- a/it/src/test/java/apoc/it/core/StartupTest.java
+++ b/it/src/test/java/apoc/it/core/StartupTest.java
@@ -176,8 +176,7 @@ public class StartupTest {
                 // The apoc.load.arrow procedures requires the user to provide their own dependencies
                 // This is done through Neo4j in enterprise but not in community
                 if (version == Neo4jVersion.COMMUNITY) {
-                    expectedCypher5Procedures = expectedCypher5Procedures
-                            .stream()
+                    expectedCypher5Procedures = expectedCypher5Procedures.stream()
                             .filter(p -> !p.contains("apoc.load.arrow"))
                             .toList();
                 }


### PR DESCRIPTION
The dependencies for arrow are not bundled with APOC but needs to be provided explicitly. Before they were provided through both Neo4j enterprise and community, but now they are only in enterprise on 5.26. This means the arrow procedures are no longer packaged by default in a community docker image.