### PR TITLE
Deprecate temporal formatting functions

### DIFF
--- a/core/src/main/java/apoc/date/Date.java
+++ b/core/src/main/java/apoc/date/Date.java
@@ -204,10 +204,11 @@ public class Date {
     }
 
     @UserFunction("apoc.date.format")
+    @QueryLanguageScope(scope = QueryLanguage.CYPHER_5)
     @Description(
             "Returns a `STRING` representation of the time value.\n"
                     + "The time unit (default: ms), date format (default: ISO), and time zone (default: current time zone) can all be changed.")
-    public String format(
+    public String formatCypher5(
             final @Name(value = "time", description = "The timestamp since epoch to format.") Long time,
             @Name(value = "unit", defaultValue = "ms", description = "The unit of the given timestamp.") String unit,
             @Name(
@@ -217,6 +218,24 @@ public class Date {
                     String format,
             @Name(value = "timezone", defaultValue = "", description = "The timezone the given timestamp is in.")
                     String timezone) {
+        return time == null ? null : parse(unit(unit).toMillis(time), format, timezone);
+    }
+
+    @UserFunction(value = "apoc.date.format", deprecatedBy = "Cypher's format function; format(input, format)")
+    @QueryLanguageScope(scope = QueryLanguage.CYPHER_25)
+    @Description(
+            "Returns a `STRING` representation of the time value.\n"
+                    + "The time unit (default: ms), date format (default: ISO), and time zone (default: current time zone) can all be changed.")
+    public String format(
+            final @Name(value = "time", description = "The timestamp since epoch to format.") Long time,
+            @Name(value = "unit", defaultValue = "ms", description = "The unit of the given timestamp.") String unit,
+            @Name(
+                    value = "format",
+                    defaultValue = DEFAULT_FORMAT,
+                    description = "The format to convert the given temporal value to.")
+            String format,
+            @Name(value = "timezone", defaultValue = "", description = "The timezone the given timestamp is in.")
+            String timezone) {
         return time == null ? null : parse(unit(unit).toMillis(time), format, timezone);
     }
 

--- a/core/src/test/resources/functions/common/functions.json
+++ b/core/src/test/resources/functions/common/functions.json
@@ -1736,46 +1736,6 @@
   {
     "isDeprecated": false,
     "aggregating": false,
-    "signature": "apoc.date.format(time :: INTEGER, unit = ms :: STRING, format = yyyy-MM-dd HH:mm:ss :: STRING, timezone =  :: STRING) :: STRING",
-    "name": "apoc.date.format",
-    "description": "Returns a `STRING` representation of the time value.\nThe time unit (default: ms), date format (default: ISO), and time zone (default: current time zone) can all be changed.",
-    "returnDescription": "STRING",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "time",
-        "description": "The timestamp since epoch to format.",
-        "isDeprecated": false,
-        "type": "INTEGER"
-      },
-      {
-        "name": "unit",
-        "description": "The unit of the given timestamp.",
-        "isDeprecated": false,
-        "default": "DefaultParameterValue{value=ms, type=STRING}",
-        "type": "STRING"
-      },
-      {
-        "name": "format",
-        "description": "The format to convert the given temporal value to.",
-        "isDeprecated": false,
-        "default": "DefaultParameterValue{value=yyyy-MM-dd HH:mm:ss, type=STRING}",
-        "type": "STRING"
-      },
-      {
-        "name": "timezone",
-        "description": "The timezone the given timestamp is in.",
-        "isDeprecated": false,
-        "default": "DefaultParameterValue{value=, type=STRING}",
-        "type": "STRING"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
     "signature": "apoc.date.parse(time :: STRING, unit = ms :: STRING, format = yyyy-MM-dd HH:mm:ss :: STRING, timezone =  :: STRING) :: INTEGER",
     "name": "apoc.date.parse",
     "description": "Parses the given date `STRING` from a specified format into the specified time unit.",
@@ -3753,57 +3713,6 @@
         "description": "The score.",
         "isDeprecated": false,
         "type": "INTEGER"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.temporal.format(temporal :: ANY, format = yyyy-MM-dd :: STRING) :: STRING",
-    "name": "apoc.temporal.format",
-    "description": "Formats the given temporal value into the given time format.",
-    "returnDescription": "STRING",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "temporal",
-        "description": "A temporal value to be formatted.",
-        "isDeprecated": false,
-        "type": "ANY"
-      },
-      {
-        "name": "format",
-        "description": "The format to return the temporal value in.",
-        "isDeprecated": false,
-        "default": "DefaultParameterValue{value=yyyy-MM-dd, type=STRING}",
-        "type": "STRING"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.temporal.formatDuration(input :: ANY, format :: STRING) :: STRING",
-    "name": "apoc.temporal.formatDuration",
-    "description": "Formats the given duration into the given time format.",
-    "returnDescription": "STRING",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "input",
-        "description": "The duration value to be formatted into a string.",
-        "isDeprecated": false,
-        "type": "ANY"
-      },
-      {
-        "name": "format",
-        "description": "The format to return the duration in.",
-        "isDeprecated": false,
-        "type": "STRING"
       }
     ]
   },

--- a/core/src/test/resources/functions/cypher25/functions.json
+++ b/core/src/test/resources/functions/cypher25/functions.json
@@ -488,6 +488,46 @@
   {
     "isDeprecated": true,
     "aggregating": false,
+    "signature": "apoc.date.format(time :: INTEGER, unit = ms :: STRING, format = yyyy-MM-dd HH:mm:ss :: STRING, timezone =  :: STRING) :: STRING",
+    "name": "apoc.date.format",
+    "description": "Returns a `STRING` representation of the time value.\nThe time unit (default: ms), date format (default: ISO), and time zone (default: current time zone) can all be changed.",
+    "returnDescription": "STRING",
+    "deprecatedBy": "Cypher's format function; format(input, format)",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "time",
+        "description": "The timestamp since epoch to format.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "unit",
+        "description": "The unit of the given timestamp.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=ms, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format to convert the given temporal value to.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=yyyy-MM-dd HH:mm:ss, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "timezone",
+        "description": "The timezone the given timestamp is in.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
     "signature": "apoc.date.fromISO8601(time :: STRING) :: INTEGER",
     "name": "apoc.date.fromISO8601",
     "description": "Converts the given date `STRING` (ISO8601) to an `INTEGER` representing the time value in milliseconds.",
@@ -750,6 +790,57 @@
         "description": "The relationship types to check for on the given node. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
         "isDeprecated": false,
         "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.temporal.format(temporal :: ANY, format = yyyy-MM-dd :: STRING) :: STRING",
+    "name": "apoc.temporal.format",
+    "description": "Formats the given temporal value into the given time format.",
+    "returnDescription": "STRING",
+    "deprecatedBy": "Cypher's format function; format(input, format)",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "temporal",
+        "description": "A temporal value to be formatted.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "format",
+        "description": "The format to return the temporal value in.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=yyyy-MM-dd, type=STRING}",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.temporal.formatDuration(input :: ANY, format :: STRING) :: STRING",
+    "name": "apoc.temporal.formatDuration",
+    "description": "Formats the given duration into the given time format.",
+    "returnDescription": "STRING",
+    "deprecatedBy": "Cypher's format function; format(input, format)",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "input",
+        "description": "The duration value to be formatted into a string.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "format",
+        "description": "The format to return the duration in.",
+        "isDeprecated": false,
         "type": "STRING"
       }
     ]

--- a/core/src/test/resources/functions/cypher5/functions.json
+++ b/core/src/test/resources/functions/cypher5/functions.json
@@ -500,6 +500,46 @@
   {
     "isDeprecated": false,
     "aggregating": false,
+    "signature": "apoc.date.format(time :: INTEGER, unit = ms :: STRING, format = yyyy-MM-dd HH:mm:ss :: STRING, timezone =  :: STRING) :: STRING",
+    "name": "apoc.date.format",
+    "description": "Returns a `STRING` representation of the time value.\nThe time unit (default: ms), date format (default: ISO), and time zone (default: current time zone) can all be changed.",
+    "returnDescription": "STRING",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "time",
+        "description": "The timestamp since epoch to format.",
+        "isDeprecated": false,
+        "type": "INTEGER"
+      },
+      {
+        "name": "unit",
+        "description": "The unit of the given timestamp.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=ms, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "format",
+        "description": "The format to convert the given temporal value to.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=yyyy-MM-dd HH:mm:ss, type=STRING}",
+        "type": "STRING"
+      },
+      {
+        "name": "timezone",
+        "description": "The timezone the given timestamp is in.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
     "signature": "apoc.date.fromISO8601(time :: STRING) :: INTEGER",
     "name": "apoc.date.fromISO8601",
     "description": "Converts the given date `STRING` (ISO8601) to an `INTEGER` representing the time value in milliseconds.",
@@ -793,6 +833,57 @@
         "description": "The relationship types to check for on the given node. Relationship types are represented using APOC's rel-direction-pattern syntax; `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`.",
         "isDeprecated": false,
         "default": "DefaultParameterValue{value=, type=STRING}",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.temporal.format(temporal :: ANY, format = yyyy-MM-dd :: STRING) :: STRING",
+    "name": "apoc.temporal.format",
+    "description": "Formats the given temporal value into the given time format.",
+    "returnDescription": "STRING",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "temporal",
+        "description": "A temporal value to be formatted.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "format",
+        "description": "The format to return the temporal value in.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=yyyy-MM-dd, type=STRING}",
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.temporal.formatDuration(input :: ANY, format :: STRING) :: STRING",
+    "name": "apoc.temporal.formatDuration",
+    "description": "Formats the given duration into the given time format.",
+    "returnDescription": "STRING",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "input",
+        "description": "The duration value to be formatted into a string.",
+        "isDeprecated": false,
+        "type": "ANY"
+      },
+      {
+        "name": "format",
+        "description": "The format to return the duration in.",
+        "isDeprecated": false,
         "type": "STRING"
       }
     ]


### PR DESCRIPTION
Deprecating `apoc.date.format`, `apoc.temporal.format`, and `apoc.temporal.formatDuration`.

[Docs PR](https://github.com/neo4j/docs-apoc/pull/464)