### PR TITLE
Update method call from fulltext to forSemanticSearch

### DIFF
--- a/core/src/main/java/apoc/index/SchemaIndex.java
+++ b/core/src/main/java/apoc/index/SchemaIndex.java
@@ -148,7 +148,7 @@ public class SchemaIndex {
                         int[] labelIds = Iterables.stream(indexDefinition.getLabels())
                                 .mapToInt(lbl -> tokenRead.nodeLabel(lbl.name()))
                                 .toArray();
-                        schema = SchemaDescriptors.fulltext(EntityType.NODE, labelIds, propertyKeyIds);
+                        schema = SchemaDescriptors.forSemanticSearch(EntityType.NODE, labelIds, propertyKeyIds);
                     } else {
                         String label =
                                 Iterables.single(indexDefinition.getLabels()).name();


### PR DESCRIPTION
This particular schema descriptor will soon no longer be specific to the
fulltext index.

We have renamed (and aliased) this method and will be removing the
internal fulltext method alias after this is approved and merged.
