### PR TITLE
Update schema descriptor for disjunction of entity tokens for fulltext

### DIFF
--- a/core/src/test/java/apoc/schema/SchemasTest.java
+++ b/core/src/test/java/apoc/schema/SchemasTest.java
@@ -1169,7 +1169,7 @@ public class SchemasTest {
                                 "name",
                                 expectedName,
                                 "userDescription",
-                                "Index( id=%s, name='%s', type='FULLTEXT', schema=(:Blah:Moon {weightProp, anotherProp}), indexProvider='fulltext-2.0' )"
+                                "Index( id=%s, name='%s', type='FULLTEXT', schema=(:Blah|Moon {weightProp, anotherProp}), indexProvider='fulltext-2.0' )"
                                         .formatted(indexId, idxName)));
 
                 assertThat(tx.execute("CYPHER %s CALL apoc.schema.relationships()".formatted(cypherVersion)).stream())


### PR DESCRIPTION
`FULLTEXT` index descriptor strings now reflect the disjunction of multiple entry tokens.
Rather than: `(:Label1:Label2:Label3 {prop1, prop2, prop3})`  
It should be: `(:Label1|Label2|Label3 {prop1, prop2, prop3})`  
