### PR TITLE
Make test more lenient and add assertion message.

### DIFF
--- a/core/src/test/java/apoc/util/UtilTest.java
+++ b/core/src/test/java/apoc/util/UtilTest.java
@@ -205,8 +205,7 @@ public class UtilTest {
 
         // The method should be run directly, after 200ms, after 400ms and after 800 ms when it will succeed
         // So the total time should be roughly 1400 ms
-        assertTrue(time > 1350);
-        assertTrue(time < 1450);
+        assertTrue(time > 1300 && time < 1500, "Expected time to be in the interval 1300 ms - 1500 ms but was " + time);
     }
 
     @Test


### PR DESCRIPTION
This test was flaky, with a single failing run.
Let's try to increase the allowed timespan and write out what the time was in case it fails again.
