### PR TITLE
Bump Netty to 4.2.7.Final to mitigate CVE-2025-59419.

### DIFF
--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -24,7 +24,7 @@ Apache-2.0
   aws-java-sdk-core-1.12.643.jar
   aws-java-sdk-kms-1.12.643.jar
   aws-java-sdk-s3-1.12.643.jar
-  byte-buddy-1.18.1.jar
+  byte-buddy-1.18.2.jar
   byte-buddy-agent-1.17.7.jar
   cache-api-1.1.1.jar
   caffeine-3.2.3.jar
@@ -34,19 +34,19 @@ Apache-2.0
   commons-codec-1.20.0.jar
   commons-collections4-4.4.jar
   commons-compress-1.28.0.jar
-  commons-configuration2-2.12.0.jar
+  commons-configuration2-2.13.0.jar
   commons-csv-1.9.0.jar
   commons-daemon-1.0.13.jar
   commons-io-2.21.0.jar
   commons-lang-2.6.jar
   commons-lang3-3.18.0.jar
-  commons-lang3-3.19.0.jar
+  commons-lang3-3.20.0.jar
   commons-logging-1.3.5.jar
   commons-math3-3.6.1.jar
   commons-net-3.9.0.jar
   commons-pool-1.6.jar
   commons-text-1.10.0.jar
-  commons-text-1.14.0.jar
+  commons-text-1.15.0.jar
   curator-client-5.2.0.jar
   curator-framework-5.2.0.jar
   curator-recipes-5.2.0.jar
@@ -60,14 +60,14 @@ Apache-2.0
   flight-core-18.3.0.jar
   fst-2.50.jar
   gradle-tooling-api-7.3.jar
-  grpc-api-1.76.0.jar
-  grpc-context-1.76.0.jar
-  grpc-core-1.76.0.jar
-  grpc-netty-1.76.0.jar
-  grpc-protobuf-1.76.0.jar
-  grpc-protobuf-lite-1.76.0.jar
-  grpc-stub-1.76.0.jar
-  grpc-util-1.76.0.jar
+  grpc-api-1.77.0.jar
+  grpc-context-1.77.0.jar
+  grpc-core-1.77.0.jar
+  grpc-netty-1.77.0.jar
+  grpc-protobuf-1.77.0.jar
+  grpc-protobuf-lite-1.77.0.jar
+  grpc-stub-1.77.0.jar
+  grpc-util-1.77.0.jar
   gson-2.11.0.jar
   guava-33.4.8-jre.jar
   guice-4.2.3.jar
@@ -162,67 +162,67 @@ Apache-2.0
   kerby-pkix-2.0.3.jar
   kerby-util-2.0.3.jar
   listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
-  log4j-api-2.25.2.jar
-  log4j-core-2.25.2.jar
-  log4j-layout-template-json-2.25.2.jar
-  lucene-analysis-common-10.3.1.jar
-  lucene-backward-codecs-10.3.1.jar
-  lucene-core-10.3.1.jar
-  lucene-queryparser-10.3.1.jar
+  log4j-api-2.25.3.jar
+  log4j-core-2.25.3.jar
+  log4j-layout-template-json-2.25.3.jar
+  lucene-analysis-common-10.3.2.jar
+  lucene-backward-codecs-10.3.2.jar
+  lucene-core-10.3.2.jar
+  lucene-queryparser-10.3.2.jar
   magnolia_2.13-1.1.8.jar
   metrics-core-3.2.4.jar
-  netty-all-4.2.4.Final.jar
-  netty-buffer-4.2.7.Final.jar
-  netty-codec-4.2.4.Final.jar
-  netty-codec-base-4.2.7.Final.jar
-  netty-codec-classes-quic-4.2.4.Final.jar
-  netty-codec-compression-4.2.7.Final.jar
-  netty-codec-dns-4.2.4.Final.jar
-  netty-codec-haproxy-4.2.4.Final.jar
-  netty-codec-http-4.2.7.Final.jar
-  netty-codec-http2-4.2.7.Final.jar
-  netty-codec-http3-4.2.4.Final.jar
-  netty-codec-marshalling-4.2.4.Final.jar
-  netty-codec-memcache-4.2.4.Final.jar
-  netty-codec-mqtt-4.2.4.Final.jar
-  netty-codec-native-quic-4.2.4.Final-linux-aarch_64.jar
-  netty-codec-native-quic-4.2.4.Final-linux-x86_64.jar
-  netty-codec-native-quic-4.2.4.Final-osx-aarch_64.jar
-  netty-codec-native-quic-4.2.4.Final-osx-x86_64.jar
-  netty-codec-native-quic-4.2.4.Final-windows-x86_64.jar
-  netty-codec-protobuf-4.2.4.Final.jar
-  netty-codec-redis-4.2.4.Final.jar
-  netty-codec-smtp-4.2.4.Final.jar
-  netty-codec-socks-4.2.4.Final.jar
-  netty-codec-stomp-4.2.4.Final.jar
-  netty-codec-xml-4.2.4.Final.jar
-  netty-common-4.2.7.Final.jar
-  netty-handler-4.2.7.Final.jar
-  netty-handler-proxy-4.2.4.Final.jar
-  netty-handler-ssl-ocsp-4.2.4.Final.jar
-  netty-resolver-4.2.7.Final.jar
-  netty-resolver-dns-4.2.4.Final.jar
-  netty-resolver-dns-classes-macos-4.2.4.Final.jar
-  netty-resolver-dns-native-macos-4.2.4.Final-osx-aarch_64.jar
-  netty-resolver-dns-native-macos-4.2.4.Final-osx-x86_64.jar
+  netty-all-4.2.7.Final.jar
+  netty-buffer-4.2.9.Final.jar
+  netty-codec-4.2.7.Final.jar
+  netty-codec-base-4.2.9.Final.jar
+  netty-codec-classes-quic-4.2.7.Final.jar
+  netty-codec-compression-4.2.9.Final.jar
+  netty-codec-dns-4.2.7.Final.jar
+  netty-codec-haproxy-4.2.7.Final.jar
+  netty-codec-http-4.2.9.Final.jar
+  netty-codec-http2-4.2.9.Final.jar
+  netty-codec-http3-4.2.7.Final.jar
+  netty-codec-marshalling-4.2.7.Final.jar
+  netty-codec-memcache-4.2.7.Final.jar
+  netty-codec-mqtt-4.2.7.Final.jar
+  netty-codec-native-quic-4.2.7.Final-linux-aarch_64.jar
+  netty-codec-native-quic-4.2.7.Final-linux-x86_64.jar
+  netty-codec-native-quic-4.2.7.Final-osx-aarch_64.jar
+  netty-codec-native-quic-4.2.7.Final-osx-x86_64.jar
+  netty-codec-native-quic-4.2.7.Final-windows-x86_64.jar
+  netty-codec-protobuf-4.2.7.Final.jar
+  netty-codec-redis-4.2.7.Final.jar
+  netty-codec-smtp-4.2.7.Final.jar
+  netty-codec-socks-4.2.7.Final.jar
+  netty-codec-stomp-4.2.7.Final.jar
+  netty-codec-xml-4.2.7.Final.jar
+  netty-common-4.2.9.Final.jar
+  netty-handler-4.2.9.Final.jar
+  netty-handler-proxy-4.2.7.Final.jar
+  netty-handler-ssl-ocsp-4.2.7.Final.jar
+  netty-resolver-4.2.9.Final.jar
+  netty-resolver-dns-4.2.7.Final.jar
+  netty-resolver-dns-classes-macos-4.2.7.Final.jar
+  netty-resolver-dns-native-macos-4.2.7.Final-osx-aarch_64.jar
+  netty-resolver-dns-native-macos-4.2.7.Final-osx-x86_64.jar
   netty-tcnative-classes-2.0.74.Final.jar
-  netty-transport-4.2.7.Final.jar
-  netty-transport-classes-epoll-4.2.7.Final.jar
-  netty-transport-classes-io_uring-4.2.4.Final.jar
-  netty-transport-classes-kqueue-4.2.7.Final.jar
-  netty-transport-native-epoll-4.2.7.Final-linux-aarch_64.jar
-  netty-transport-native-epoll-4.2.7.Final-linux-riscv64.jar
-  netty-transport-native-epoll-4.2.7.Final-linux-x86_64.jar
-  netty-transport-native-epoll-4.2.7.Final.jar
-  netty-transport-native-io_uring-4.2.4.Final-linux-aarch_64.jar
-  netty-transport-native-io_uring-4.2.4.Final-linux-riscv64.jar
-  netty-transport-native-io_uring-4.2.4.Final-linux-x86_64.jar
-  netty-transport-native-kqueue-4.2.7.Final-osx-aarch_64.jar
-  netty-transport-native-kqueue-4.2.7.Final-osx-x86_64.jar
-  netty-transport-native-unix-common-4.2.7.Final.jar
-  netty-transport-rxtx-4.2.4.Final.jar
-  netty-transport-sctp-4.2.4.Final.jar
-  netty-transport-udt-4.2.4.Final.jar
+  netty-transport-4.2.9.Final.jar
+  netty-transport-classes-epoll-4.2.9.Final.jar
+  netty-transport-classes-io_uring-4.2.7.Final.jar
+  netty-transport-classes-kqueue-4.2.9.Final.jar
+  netty-transport-native-epoll-4.2.9.Final-linux-aarch_64.jar
+  netty-transport-native-epoll-4.2.9.Final-linux-riscv64.jar
+  netty-transport-native-epoll-4.2.9.Final-linux-x86_64.jar
+  netty-transport-native-epoll-4.2.9.Final.jar
+  netty-transport-native-io_uring-4.2.7.Final-linux-aarch_64.jar
+  netty-transport-native-io_uring-4.2.7.Final-linux-riscv64.jar
+  netty-transport-native-io_uring-4.2.7.Final-linux-x86_64.jar
+  netty-transport-native-kqueue-4.2.9.Final-osx-aarch_64.jar
+  netty-transport-native-kqueue-4.2.9.Final-osx-x86_64.jar
+  netty-transport-native-unix-common-4.2.9.Final.jar
+  netty-transport-rxtx-4.2.7.Final.jar
+  netty-transport-sctp-4.2.7.Final.jar
+  netty-transport-udt-4.2.7.Final.jar
   nimbus-jose-jwt-9.37.2.jar
   objenesis-3.3.jar
   opencsv-5.7.1.jar
@@ -2702,9 +2702,9 @@ and/or involve the use of third party software.
 
 ------------------------------------------------------------------------------
 MIT
-  bcpkix-jdk18on-1.82.jar
-  bcprov-jdk18on-1.82.jar
-  bcutil-jdk18on-1.82.jar
+  bcpkix-jdk18on-1.83.jar
+  bcprov-jdk18on-1.83.jar
+  bcutil-jdk18on-1.83.jar
   duct-tape-1.0.8.jar
   java-jwt-4.5.0.jar
   jersey-client-2.46.jar
@@ -2712,7 +2712,7 @@ MIT
   jersey-container-servlet-core-2.46.jar
   jersey-hk2-2.46.jar
   jnr-x86asm-1.0.2.jar
-  mockito-core-5.20.0.jar
+  mockito-core-5.21.0.jar
   mssql-jdbc-6.2.1.jre7.jar
   reactive-streams-1.0.4.jar
   slf4j-api-2.0.11.jar

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -54,7 +54,7 @@ Apache-2.0
   aws-java-sdk-core-1.12.643.jar
   aws-java-sdk-kms-1.12.643.jar
   aws-java-sdk-s3-1.12.643.jar
-  byte-buddy-1.18.1.jar
+  byte-buddy-1.18.2.jar
   byte-buddy-agent-1.17.7.jar
   cache-api-1.1.1.jar
   caffeine-3.2.3.jar
@@ -64,19 +64,19 @@ Apache-2.0
   commons-codec-1.20.0.jar
   commons-collections4-4.4.jar
   commons-compress-1.28.0.jar
-  commons-configuration2-2.12.0.jar
+  commons-configuration2-2.13.0.jar
   commons-csv-1.9.0.jar
   commons-daemon-1.0.13.jar
   commons-io-2.21.0.jar
   commons-lang-2.6.jar
   commons-lang3-3.18.0.jar
-  commons-lang3-3.19.0.jar
+  commons-lang3-3.20.0.jar
   commons-logging-1.3.5.jar
   commons-math3-3.6.1.jar
   commons-net-3.9.0.jar
   commons-pool-1.6.jar
   commons-text-1.10.0.jar
-  commons-text-1.14.0.jar
+  commons-text-1.15.0.jar
   curator-client-5.2.0.jar
   curator-framework-5.2.0.jar
   curator-recipes-5.2.0.jar
@@ -90,14 +90,14 @@ Apache-2.0
   flight-core-18.3.0.jar
   fst-2.50.jar
   gradle-tooling-api-7.3.jar
-  grpc-api-1.76.0.jar
-  grpc-context-1.76.0.jar
-  grpc-core-1.76.0.jar
-  grpc-netty-1.76.0.jar
-  grpc-protobuf-1.76.0.jar
-  grpc-protobuf-lite-1.76.0.jar
-  grpc-stub-1.76.0.jar
-  grpc-util-1.76.0.jar
+  grpc-api-1.77.0.jar
+  grpc-context-1.77.0.jar
+  grpc-core-1.77.0.jar
+  grpc-netty-1.77.0.jar
+  grpc-protobuf-1.77.0.jar
+  grpc-protobuf-lite-1.77.0.jar
+  grpc-stub-1.77.0.jar
+  grpc-util-1.77.0.jar
   gson-2.11.0.jar
   guava-33.4.8-jre.jar
   guice-4.2.3.jar
@@ -192,67 +192,67 @@ Apache-2.0
   kerby-pkix-2.0.3.jar
   kerby-util-2.0.3.jar
   listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
-  log4j-api-2.25.2.jar
-  log4j-core-2.25.2.jar
-  log4j-layout-template-json-2.25.2.jar
-  lucene-analysis-common-10.3.1.jar
-  lucene-backward-codecs-10.3.1.jar
-  lucene-core-10.3.1.jar
-  lucene-queryparser-10.3.1.jar
+  log4j-api-2.25.3.jar
+  log4j-core-2.25.3.jar
+  log4j-layout-template-json-2.25.3.jar
+  lucene-analysis-common-10.3.2.jar
+  lucene-backward-codecs-10.3.2.jar
+  lucene-core-10.3.2.jar
+  lucene-queryparser-10.3.2.jar
   magnolia_2.13-1.1.8.jar
   metrics-core-3.2.4.jar
-  netty-all-4.2.4.Final.jar
-  netty-buffer-4.2.7.Final.jar
-  netty-codec-4.2.4.Final.jar
-  netty-codec-base-4.2.7.Final.jar
-  netty-codec-classes-quic-4.2.4.Final.jar
-  netty-codec-compression-4.2.7.Final.jar
-  netty-codec-dns-4.2.4.Final.jar
-  netty-codec-haproxy-4.2.4.Final.jar
-  netty-codec-http-4.2.7.Final.jar
-  netty-codec-http2-4.2.7.Final.jar
-  netty-codec-http3-4.2.4.Final.jar
-  netty-codec-marshalling-4.2.4.Final.jar
-  netty-codec-memcache-4.2.4.Final.jar
-  netty-codec-mqtt-4.2.4.Final.jar
-  netty-codec-native-quic-4.2.4.Final-linux-aarch_64.jar
-  netty-codec-native-quic-4.2.4.Final-linux-x86_64.jar
-  netty-codec-native-quic-4.2.4.Final-osx-aarch_64.jar
-  netty-codec-native-quic-4.2.4.Final-osx-x86_64.jar
-  netty-codec-native-quic-4.2.4.Final-windows-x86_64.jar
-  netty-codec-protobuf-4.2.4.Final.jar
-  netty-codec-redis-4.2.4.Final.jar
-  netty-codec-smtp-4.2.4.Final.jar
-  netty-codec-socks-4.2.4.Final.jar
-  netty-codec-stomp-4.2.4.Final.jar
-  netty-codec-xml-4.2.4.Final.jar
-  netty-common-4.2.7.Final.jar
-  netty-handler-4.2.7.Final.jar
-  netty-handler-proxy-4.2.4.Final.jar
-  netty-handler-ssl-ocsp-4.2.4.Final.jar
-  netty-resolver-4.2.7.Final.jar
-  netty-resolver-dns-4.2.4.Final.jar
-  netty-resolver-dns-classes-macos-4.2.4.Final.jar
-  netty-resolver-dns-native-macos-4.2.4.Final-osx-aarch_64.jar
-  netty-resolver-dns-native-macos-4.2.4.Final-osx-x86_64.jar
+  netty-all-4.2.7.Final.jar
+  netty-buffer-4.2.9.Final.jar
+  netty-codec-4.2.7.Final.jar
+  netty-codec-base-4.2.9.Final.jar
+  netty-codec-classes-quic-4.2.7.Final.jar
+  netty-codec-compression-4.2.9.Final.jar
+  netty-codec-dns-4.2.7.Final.jar
+  netty-codec-haproxy-4.2.7.Final.jar
+  netty-codec-http-4.2.9.Final.jar
+  netty-codec-http2-4.2.9.Final.jar
+  netty-codec-http3-4.2.7.Final.jar
+  netty-codec-marshalling-4.2.7.Final.jar
+  netty-codec-memcache-4.2.7.Final.jar
+  netty-codec-mqtt-4.2.7.Final.jar
+  netty-codec-native-quic-4.2.7.Final-linux-aarch_64.jar
+  netty-codec-native-quic-4.2.7.Final-linux-x86_64.jar
+  netty-codec-native-quic-4.2.7.Final-osx-aarch_64.jar
+  netty-codec-native-quic-4.2.7.Final-osx-x86_64.jar
+  netty-codec-native-quic-4.2.7.Final-windows-x86_64.jar
+  netty-codec-protobuf-4.2.7.Final.jar
+  netty-codec-redis-4.2.7.Final.jar
+  netty-codec-smtp-4.2.7.Final.jar
+  netty-codec-socks-4.2.7.Final.jar
+  netty-codec-stomp-4.2.7.Final.jar
+  netty-codec-xml-4.2.7.Final.jar
+  netty-common-4.2.9.Final.jar
+  netty-handler-4.2.9.Final.jar
+  netty-handler-proxy-4.2.7.Final.jar
+  netty-handler-ssl-ocsp-4.2.7.Final.jar
+  netty-resolver-4.2.9.Final.jar
+  netty-resolver-dns-4.2.7.Final.jar
+  netty-resolver-dns-classes-macos-4.2.7.Final.jar
+  netty-resolver-dns-native-macos-4.2.7.Final-osx-aarch_64.jar
+  netty-resolver-dns-native-macos-4.2.7.Final-osx-x86_64.jar
   netty-tcnative-classes-2.0.74.Final.jar
-  netty-transport-4.2.7.Final.jar
-  netty-transport-classes-epoll-4.2.7.Final.jar
-  netty-transport-classes-io_uring-4.2.4.Final.jar
-  netty-transport-classes-kqueue-4.2.7.Final.jar
-  netty-transport-native-epoll-4.2.7.Final-linux-aarch_64.jar
-  netty-transport-native-epoll-4.2.7.Final-linux-riscv64.jar
-  netty-transport-native-epoll-4.2.7.Final-linux-x86_64.jar
-  netty-transport-native-epoll-4.2.7.Final.jar
-  netty-transport-native-io_uring-4.2.4.Final-linux-aarch_64.jar
-  netty-transport-native-io_uring-4.2.4.Final-linux-riscv64.jar
-  netty-transport-native-io_uring-4.2.4.Final-linux-x86_64.jar
-  netty-transport-native-kqueue-4.2.7.Final-osx-aarch_64.jar
-  netty-transport-native-kqueue-4.2.7.Final-osx-x86_64.jar
-  netty-transport-native-unix-common-4.2.7.Final.jar
-  netty-transport-rxtx-4.2.4.Final.jar
-  netty-transport-sctp-4.2.4.Final.jar
-  netty-transport-udt-4.2.4.Final.jar
+  netty-transport-4.2.9.Final.jar
+  netty-transport-classes-epoll-4.2.9.Final.jar
+  netty-transport-classes-io_uring-4.2.7.Final.jar
+  netty-transport-classes-kqueue-4.2.9.Final.jar
+  netty-transport-native-epoll-4.2.9.Final-linux-aarch_64.jar
+  netty-transport-native-epoll-4.2.9.Final-linux-riscv64.jar
+  netty-transport-native-epoll-4.2.9.Final-linux-x86_64.jar
+  netty-transport-native-epoll-4.2.9.Final.jar
+  netty-transport-native-io_uring-4.2.7.Final-linux-aarch_64.jar
+  netty-transport-native-io_uring-4.2.7.Final-linux-riscv64.jar
+  netty-transport-native-io_uring-4.2.7.Final-linux-x86_64.jar
+  netty-transport-native-kqueue-4.2.9.Final-osx-aarch_64.jar
+  netty-transport-native-kqueue-4.2.9.Final-osx-x86_64.jar
+  netty-transport-native-unix-common-4.2.9.Final.jar
+  netty-transport-rxtx-4.2.7.Final.jar
+  netty-transport-sctp-4.2.7.Final.jar
+  netty-transport-udt-4.2.7.Final.jar
   nimbus-jose-jwt-9.37.2.jar
   objenesis-3.3.jar
   opencsv-5.7.1.jar
@@ -465,9 +465,9 @@ LGPL-2.1-or-later
   jna-5.18.1.jar
 
 MIT
-  bcpkix-jdk18on-1.82.jar
-  bcprov-jdk18on-1.82.jar
-  bcutil-jdk18on-1.82.jar
+  bcpkix-jdk18on-1.83.jar
+  bcprov-jdk18on-1.83.jar
+  bcutil-jdk18on-1.83.jar
   duct-tape-1.0.8.jar
   java-jwt-4.5.0.jar
   jersey-client-2.46.jar
@@ -475,7 +475,7 @@ MIT
   jersey-container-servlet-core-2.46.jar
   jersey-hk2-2.46.jar
   jnr-x86asm-1.0.2.jar
-  mockito-core-5.20.0.jar
+  mockito-core-5.21.0.jar
   mssql-jdbc-6.2.1.jre7.jar
   reactive-streams-1.0.4.jar
   slf4j-api-2.0.11.jar

--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ subprojects {
     testImplementation('org.junit.jupiter:junit-jupiter')
 
     // We want the same netty version as other neo4j dependencies, are there better ways than to keep this in sync?
-    implementation(platform('io.netty:netty-bom:4.2.4.Final'))
+    implementation(platform('io.netty:netty-bom:4.2.7.Final'))
 
     testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testRuntimeOnly('org.junit.vintage:junit-vintage-engine')


### PR DESCRIPTION
This is the version used in latest Neo4j.

