### PR TITLE
Fix deprecation tag warning

### DIFF
--- a/core/src/main/java/apoc/convert/Json.java
+++ b/core/src/main/java/apoc/convert/Json.java
@@ -225,6 +225,7 @@ public class Json {
         }
     }
 
+    @Deprecated
     @Procedure(value = "apoc.convert.toTree", deprecatedBy = "apoc.paths.toJsonTree")
     @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
     @Description(


### PR DESCRIPTION
On db load the procedure compiler will output a warning if a deprecatedBy exists without a deprecation tag.