### PR TITLE
Fix apoc to work with long degrees

### DIFF
--- a/core/src/main/java/apoc/nodes/NodesRestricted.java
+++ b/core/src/main/java/apoc/nodes/NodesRestricted.java
@@ -132,7 +132,7 @@ public class NodesRestricted {
                 int typeId = tokenRead.relationshipType(pair.getLeft().name());
                 Direction direction = pair.getRight();
 
-                int count =
+                long count =
                         switch (direction) {
                             case INCOMING -> org.neo4j.internal.kernel.api.helpers.Nodes.countIncoming(
                                     nodeCursor, typeId);

--- a/core/src/main/java/apoc/stats/DegreeDistribution.java
+++ b/core/src/main/java/apoc/stats/DegreeDistribution.java
@@ -60,7 +60,7 @@ public class DegreeDistribution {
         private transient AtomicHistogram histogram;
 
         public void computeDegree(NodeCursor nodeCursor) {
-            int degree = DegreeUtil.degree(nodeCursor, type, direction);
+            long degree = DegreeUtil.degree(nodeCursor, type, direction);
             record(degree);
         }
 

--- a/core/src/main/java/apoc/stats/DegreeUtil.java
+++ b/core/src/main/java/apoc/stats/DegreeUtil.java
@@ -26,7 +26,7 @@ import org.neo4j.internal.kernel.api.helpers.Nodes;
 
 public class DegreeUtil {
 
-    public static int degree(NodeCursor nodeCursor, int relType, Direction direction) {
+    public static long degree(NodeCursor nodeCursor, int relType, Direction direction) {
 
         switch (direction) {
             case INCOMING:


### PR DESCRIPTION
Related to KRNL-147

Fixes apoc to work with long degrees.

Locally tested with [corresponding neo4j PR](https://github.com/neo-technology/neo4j/pull/30874): `./gradlew shadow` works. I haven't tested more than that.