### PR TITLE
Use grprc-bom as platform dependency

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 
   // These dependencies affect the tests only, they will not be packaged in the resulting .jar
   testImplementation project(':test-utils')
+  testImplementation platform("org.neo4j:arrow-bom:$neo4jVersionEffective")
   testImplementation "com.neo4j:enterprise-it-test-support:$neo4jVersionEffective"
   testImplementation group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
   testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '3.0'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 
   // These dependencies affect the tests only, they will not be packaged in the resulting .jar
   testImplementation project(':test-utils')
-  testImplementation platform("org.neo4j:arrow-bom:$neo4jVersionEffective")
+  testImplementation platform("io.grpc:grpc-bom:1.78.0")
   testImplementation "com.neo4j:enterprise-it-test-support:$neo4jVersionEffective"
   testImplementation group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
   testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '3.0'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -92,6 +92,7 @@ dependencies {
   // These dependencies affect the tests only, they will not be packaged in the resulting .jar
   testImplementation project(":common").sourceSets.test.output
   testImplementation project(':test-utils')
+  testImplementation platform("org.neo4j:arrow-bom:$neo4jVersionEffective")
   testImplementation "com.neo4j:enterprise-it-test-support:$neo4jVersionEffective"
   compileOnly group: 'com.google.guava', name: 'guava', version: guavaVersion
   testImplementation group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -92,7 +92,7 @@ dependencies {
   // These dependencies affect the tests only, they will not be packaged in the resulting .jar
   testImplementation project(":common").sourceSets.test.output
   testImplementation project(':test-utils')
-  testImplementation platform("org.neo4j:arrow-bom:$neo4jVersionEffective")
+  testImplementation platform("io.grpc:grpc-bom:1.78.0")
   testImplementation "com.neo4j:enterprise-it-test-support:$neo4jVersionEffective"
   compileOnly group: 'com.google.guava', name: 'guava', version: guavaVersion
   testImplementation group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'

--- a/it/build.gradle
+++ b/it/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   testImplementation project(':common').sourceSets.test.output
   testImplementation project(':core').sourceSets.test.output
 
+  testImplementation platform("org.neo4j:arrow-bom:$neo4jVersionEffective")
   testImplementation "com.neo4j:enterprise-it-test-support:$neo4jVersionEffective"
   testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.643'
   testImplementation group: 'org.xmlunit', name: 'xmlunit-core', version: '2.11.0'

--- a/it/build.gradle
+++ b/it/build.gradle
@@ -7,7 +7,7 @@ dependencies {
   testImplementation project(':common').sourceSets.test.output
   testImplementation project(':core').sourceSets.test.output
 
-  testImplementation platform("org.neo4j:arrow-bom:$neo4jVersionEffective")
+  testImplementation platform("io.grpc:grpc-bom:1.78.0")
   testImplementation "com.neo4j:enterprise-it-test-support:$neo4jVersionEffective"
   testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.643'
   testImplementation group: 'org.xmlunit', name: 'xmlunit-core', version: '2.11.0'


### PR DESCRIPTION
Changes necessary for updates to ~arrow-bom~ grpc in neo4j.

Note.
The `PercentilesTest` test failure was due to arrow-bom pulling in newer version of `HdrHistogram` which changed the percentile behaviour e.g. rounding up. Instead use `grpc-bom` version which has the expected behaviour.
