### PR TITLE
SURF-490 Bump AWS SDK version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ ext {
   testContainersVersion = '2.0.2'
   apacheArrowVersion = '18.3.0'
   guavaVersion = '33.5.0-jre'
+  awsSdkVersion = '2.34.0'
 }
 
 downloadLicenses {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -36,7 +36,7 @@ dependencies {
   // These will be dependencies not packaged with the .jar
   // They need to be provided either through the database or in an extra .jar
   compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
-  compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.643'
+  compileOnly group: 'software.amazon.awssdk', name: 's3', version: awsSdkVersion
   // If updated check if the transitive dependency to javax.servlet.jsp:jsp-api:2.1 has also updated
   // and remove the manual licensing check for it in licenses-3rdparties.gradle
   compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.4.2', withoutServers

--- a/common/src/main/java/apoc/util/SupportedProtocols.java
+++ b/common/src/main/java/apoc/util/SupportedProtocols.java
@@ -22,7 +22,7 @@ public enum SupportedProtocols {
     http(true, null),
     https(true, null),
     ftp(true, null),
-    s3(Util.classExists("com.amazonaws.services.s3.AmazonS3"), "apoc.util.s3.S3UrlStreamHandlerFactory"),
+    s3(Util.classExists("software.amazon.awssdk.services.s3.S3Client"), "apoc.util.s3.S3UrlStreamHandlerFactory"),
     gs(Util.classExists("com.google.cloud.storage.Storage"), "apoc.util.google.cloud.GCStorageURLStreamHandlerFactory"),
     hdfs(Util.classExists("org.apache.hadoop.fs.FileSystem"), "org.apache.hadoop.fs.FsUrlStreamHandlerFactory"),
     file(true, null);

--- a/common/src/main/java/apoc/util/s3/S3Aws.java
+++ b/common/src/main/java/apoc/util/s3/S3Aws.java
@@ -21,68 +21,88 @@ package apoc.util.s3;
 import static apoc.export.util.LimitedSizeInputStream.toLimitedIStream;
 
 import apoc.util.StreamConnection;
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.auth.BasicSessionCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.S3Object;
 import java.io.InputStream;
+import java.net.URI;
 import java.util.Objects;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 public class S3Aws {
 
-    AmazonS3 s3Client;
+    S3Client s3Client;
 
     public S3Aws(S3Params s3Params, String region) {
 
-        AWSCredentialsProvider credentialsProvider =
+        AwsCredentialsProvider credentialsProvider =
                 getCredentialsProvider(s3Params.getAccessKey(), s3Params.getSecretKey(), s3Params.getSessionToken());
 
-        AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard();
-        builder.withCredentials(credentialsProvider)
-                .withClientConfiguration(S3URLConnection.buildClientConfig())
-                .withPathStyleAccessEnabled(true);
+        S3ClientBuilder builder = S3Client.builder();
+        builder.credentialsProvider(credentialsProvider)
+                .overrideConfiguration(S3URLConnection.buildClientOverrideConfig())
+                .forcePathStyle(true)
+                .serviceConfiguration(S3Configuration.builder()
+                        .chunkedEncodingEnabled(false)
+                        .checksumValidationEnabled(false)
+                        .build());
 
         region = Objects.nonNull(region) ? region : s3Params.getRegion();
         String endpoint = s3Params.getEndpoint();
         if (Objects.nonNull(endpoint)) {
-            builder.withEndpointConfiguration(
-                    new AwsClientBuilder.EndpointConfiguration(s3Params.getEndpoint(), region));
+            URI endpointUri;
+            if (!endpoint.startsWith("http://") && !endpoint.startsWith("https://")) {
+                String protocol = S3URLConnection.getConfiguredProtocol();
+                endpointUri = URI.create(protocol + "://" + endpoint);
+            } else {
+                endpointUri = URI.create(endpoint);
+            }
+            builder.endpointOverride(endpointUri);
+            if (region != null) {
+                builder.region(Region.of(region));
+            }
         } else if (Objects.nonNull(region)) {
-            builder.withRegion(region);
+            builder.region(Region.of(region));
         }
 
         s3Client = builder.build();
     }
 
-    public AmazonS3 getClient() {
+    public S3Client getClient() {
         return s3Client;
     }
 
     public StreamConnection getS3AwsInputStream(S3Params s3Params) {
 
-        S3Object s3Object = s3Client.getObject(s3Params.getBucket(), s3Params.getKey());
-        ObjectMetadata metadata = s3Object.getObjectMetadata();
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(s3Params.getBucket())
+                .key(s3Params.getKey())
+                .build();
+        ResponseInputStream<GetObjectResponse> response = s3Client.getObject(getObjectRequest);
+        GetObjectResponse metadata = response.response();
         return new StreamConnection() {
             @Override
             public InputStream getInputStream() {
-                return toLimitedIStream(s3Object.getObjectContent(), getLength());
+                return toLimitedIStream(response, getLength());
             }
 
             @Override
             public String getEncoding() {
-                return metadata.getContentEncoding();
+                return metadata.contentEncoding();
             }
 
             @Override
             public long getLength() {
-                return metadata.getContentLength();
+                return metadata.contentLength();
             }
 
             @Override
@@ -92,18 +112,18 @@ public class S3Aws {
         };
     }
 
-    private static AWSCredentialsProvider getCredentialsProvider(
+    private static AwsCredentialsProvider getCredentialsProvider(
             final String accessKey, final String secretKey, final String sessionToken) {
 
         if (Objects.nonNull(accessKey) && !accessKey.isEmpty() && Objects.nonNull(secretKey) && !secretKey.isEmpty()) {
-            final AWSCredentials credentials;
+            final AwsCredentials credentials;
             if (Objects.isNull(sessionToken) || sessionToken.isEmpty()) {
-                credentials = new BasicAWSCredentials(accessKey, secretKey);
+                credentials = AwsBasicCredentials.create(accessKey, secretKey);
             } else {
-                credentials = new BasicSessionCredentials(accessKey, secretKey, sessionToken);
+                credentials = AwsSessionCredentials.create(accessKey, secretKey, sessionToken);
             }
-            return new AWSStaticCredentialsProvider(credentials);
+            return StaticCredentialsProvider.create(credentials);
         }
-        return new DefaultAWSCredentialsProviderChain();
+        return DefaultCredentialsProvider.create();
     }
 }

--- a/common/src/main/java/apoc/util/s3/S3OutputStream.java
+++ b/common/src/main/java/apoc/util/s3/S3OutputStream.java
@@ -18,22 +18,16 @@
  */
 package apoc.util.s3;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
-import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
-import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
-import com.amazonaws.services.s3.model.PartETag;
-import com.amazonaws.services.s3.model.UploadPartRequest;
-import com.amazonaws.services.s3.model.UploadPartResult;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.InvalidParameterException;
-import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -43,6 +37,15 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nonnull;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 public class S3OutputStream extends OutputStream {
     private volatile boolean isDone = false;
@@ -59,13 +62,13 @@ public class S3OutputStream extends OutputStream {
 
     // Extra constructor to allow user to overwrite maxWaitTimeMinutes.
     S3OutputStream(
-            @Nonnull AmazonS3 s3Client, @Nonnull String bucketName, @Nonnull String keyName, int maxWaitTimeMinutes)
+            @Nonnull S3Client s3Client, @Nonnull String bucketName, @Nonnull String keyName, int maxWaitTimeMinutes)
             throws IOException {
         this(s3Client, bucketName, keyName);
         this.maxWaitTimeMinutes = maxWaitTimeMinutes;
     }
 
-    S3OutputStream(@Nonnull AmazonS3 s3Client, @Nonnull String bucketName, @Nonnull String keyName) throws IOException {
+    S3OutputStream(@Nonnull S3Client s3Client, @Nonnull String bucketName, @Nonnull String keyName) throws IOException {
         if (bucketName.isEmpty() || keyName.isEmpty()) {
             throw new InvalidParameterException("Bucket and/or key pass to S3OutputStream is empty.");
         }
@@ -181,10 +184,10 @@ public class S3OutputStream extends OutputStream {
             synchronized (managerFuture) {
                 managerFuture.get();
             }
-        } catch (InterruptedException | ExecutionException e) {
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
+        } catch (ExecutionException e) {
+            throw new RuntimeException("S3 multipart upload failed", e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -213,11 +216,10 @@ public class S3OutputStream extends OutputStream {
     }
 
     public class S3UploadManager implements Runnable {
-        private final AmazonS3 s3Client;
+        private final S3Client s3Client;
         private final String uploadId;
         private final BlockingQueue<S3UploadData> queue;
-        private final List<PartETag> partETags = new ArrayList<>();
-        private final InitiateMultipartUploadResult initResponse;
+        private final List<CompletedPart> completedParts = new CopyOnWriteArrayList<>();
         private final ExecutorService executorService = Executors.newFixedThreadPool(
                 S3UploadConstants.MAX_THREAD_COUNT,
                 new ThreadFactoryBuilder()
@@ -225,11 +227,15 @@ public class S3OutputStream extends OutputStream {
                         .setDaemon(true)
                         .build());
 
-        S3UploadManager(@Nonnull final AmazonS3 s3Client, @Nonnull final BlockingQueue<S3UploadData> queue) {
+        S3UploadManager(@Nonnull final S3Client s3Client, @Nonnull final BlockingQueue<S3UploadData> queue) {
             this.s3Client = s3Client;
             this.queue = queue;
-            initResponse = s3Client.initiateMultipartUpload(new InitiateMultipartUploadRequest(bucketName, keyName));
-            uploadId = initResponse.getUploadId();
+            CreateMultipartUploadResponse initResponse =
+                    s3Client.createMultipartUpload(CreateMultipartUploadRequest.builder()
+                            .bucket(bucketName)
+                            .key(keyName)
+                            .build());
+            uploadId = initResponse.uploadId();
         }
 
         @Override
@@ -254,8 +260,17 @@ public class S3OutputStream extends OutputStream {
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
-            s3Client.completeMultipartUpload(
-                    new CompleteMultipartUploadRequest(bucketName, keyName, initResponse.getUploadId(), partETags));
+            List<CompletedPart> sortedParts = completedParts.stream()
+                    .sorted(Comparator.comparingInt(CompletedPart::partNumber))
+                    .toList();
+            s3Client.completeMultipartUpload(CompleteMultipartUploadRequest.builder()
+                    .bucket(bucketName)
+                    .key(keyName)
+                    .uploadId(uploadId)
+                    .multipartUpload(CompletedMultipartUpload.builder()
+                            .parts(sortedParts)
+                            .build())
+                    .build());
         }
 
         public class Uploader implements Runnable {
@@ -269,17 +284,20 @@ public class S3OutputStream extends OutputStream {
 
             @Override
             public void run() {
-                // Upload the part and add the part to the tags.
-                final UploadPartRequest uploadPartRequest = new UploadPartRequest()
-                        .withBucketName(bucketName)
-                        .withKey(keyName)
-                        .withUploadId(uploadId)
-                        .withPartNumber(partNumber)
-                        .withInputStream(s3UploadData.getStream())
-                        .withPartSize(s3UploadData.getSize())
-                        .withLastPart(s3UploadData.getIsLast());
-                final UploadPartResult result = s3Client.uploadPart(uploadPartRequest);
-                partETags.add(result.getPartETag());
+                UploadPartRequest uploadPartRequest = UploadPartRequest.builder()
+                        .bucket(bucketName)
+                        .key(keyName)
+                        .uploadId(uploadId)
+                        .partNumber(partNumber)
+                        .contentLength((long) s3UploadData.getSize())
+                        .build();
+                UploadPartResponse result = s3Client.uploadPart(
+                        uploadPartRequest,
+                        RequestBody.fromInputStream(s3UploadData.getStream(), s3UploadData.getSize()));
+                completedParts.add(CompletedPart.builder()
+                        .partNumber(partNumber)
+                        .eTag(result.eTag())
+                        .build());
 
                 // Notify main thread that memory that was given is no longer in use.
                 synchronized (totalMemoryLock) {

--- a/common/src/main/java/apoc/util/s3/S3ParamsExtractor.java
+++ b/common/src/main/java/apoc/util/s3/S3ParamsExtractor.java
@@ -19,11 +19,11 @@
 package apoc.util.s3;
 
 import apoc.util.Util;
-import com.amazonaws.regions.Regions;
 import java.net.URI;
 import java.net.URL;
 import java.util.Map;
 import java.util.Objects;
+import software.amazon.awssdk.regions.Region;
 
 public class S3ParamsExtractor {
 
@@ -101,9 +101,9 @@ public class S3ParamsExtractor {
         if (Objects.nonNull(endpoint)) {
 
             // Look for endpoint contains region
-            for (Regions r : Regions.values()) {
-                if (endpoint.toLowerCase().contains(r.getName().toLowerCase())) {
-                    region = r.getName().toLowerCase();
+            for (Region r : Region.regions()) {
+                if (endpoint.toLowerCase().contains(r.id().toLowerCase())) {
+                    region = r.id().toLowerCase();
                     break;
                 }
             }

--- a/common/src/main/java/apoc/util/s3/S3URLConnection.java
+++ b/common/src/main/java/apoc/util/s3/S3URLConnection.java
@@ -19,12 +19,11 @@
 package apoc.util.s3;
 
 import apoc.util.StreamConnection;
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.Protocol;
-import com.amazonaws.regions.Regions;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Objects;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.regions.Region;
 
 public class S3URLConnection extends URLConnection {
 
@@ -39,28 +38,25 @@ public class S3URLConnection extends URLConnection {
     @Override
     public void connect() {}
 
-    public static ClientConfiguration buildClientConfig() {
+    public static ClientOverrideConfiguration buildClientOverrideConfig() {
         final String userAgent = System.getProperty(PROP_S3_HANDLER_USER_AGENT, null);
-        final String protocol =
-                System.getProperty(PROP_S3_HANDLER_PROTOCOL, "https").toLowerCase();
-        final String signerOverride = System.getProperty(PROP_S3_HANDLER_SIGNER_OVERRIDE, null);
 
-        final ClientConfiguration clientConfig =
-                new ClientConfiguration().withProtocol("https".equals(protocol) ? Protocol.HTTPS : Protocol.HTTP);
+        ClientOverrideConfiguration.Builder builder = ClientOverrideConfiguration.builder();
 
         if (userAgent != null) {
-            clientConfig.setUserAgentPrefix(userAgent);
-        }
-        if (signerOverride != null) {
-            clientConfig.setSignerOverride(signerOverride);
+            builder.putHeader("User-Agent", userAgent);
         }
 
-        return clientConfig;
+        return builder.build();
+    }
+
+    public static String getConfiguredProtocol() {
+        return System.getProperty(PROP_S3_HANDLER_PROTOCOL, "https").toLowerCase();
     }
 
     public static StreamConnection openS3InputStream(URL url) {
         S3Params s3Params = S3ParamsExtractor.extract(url);
-        String region = Objects.nonNull(s3Params.getRegion()) ? s3Params.getRegion() : Regions.US_EAST_1.getName();
+        String region = Objects.nonNull(s3Params.getRegion()) ? s3Params.getRegion() : Region.US_EAST_1.id();
         return new S3Aws(s3Params, region).getS3AwsInputStream(s3Params);
     }
 }

--- a/common/src/main/java/apoc/util/s3/S3UploadUtils.java
+++ b/common/src/main/java/apoc/util/s3/S3UploadUtils.java
@@ -18,10 +18,10 @@
  */
 package apoc.util.s3;
 
-import com.amazonaws.services.s3.AmazonS3;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
+import software.amazon.awssdk.services.s3.S3Client;
 
 public class S3UploadUtils {
 
@@ -30,7 +30,7 @@ public class S3UploadUtils {
     public static OutputStream writeFile(String s3Url) throws IOException {
         S3Params s3Params = S3ParamsExtractor.extract(new URL(s3Url));
         S3Aws s3Aws = new S3Aws(s3Params, s3Params.getRegion());
-        AmazonS3 s3 = s3Aws.getClient();
+        S3Client s3 = s3Aws.getClient();
         return new S3OutputStream(s3, s3Params.getBucket(), s3Params.getKey());
     }
 }

--- a/it/build.gradle
+++ b/it/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
   testImplementation platform("io.grpc:grpc-bom:1.78.0")
   testImplementation "com.neo4j:enterprise-it-test-support:$neo4jVersionEffective"
-  testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.643'
+  testImplementation group: 'software.amazon.awssdk', name: 's3', version: awsSdkVersion
   testImplementation group: 'org.xmlunit', name: 'xmlunit-core', version: '2.11.0'
   testImplementation("net.javacrumbs.json-unit:json-unit-assertj:5.1.0")
 

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -50,7 +50,7 @@ dependencies {
   implementation group: 'org.neo4j', name: 'neo4j-io', version: neo4jVersionEffective, classifier: "tests"
   implementation group: 'org.gradle', name: 'gradle-tooling-api', version: '7.3'
   implementation group: 'org.jetbrains', name: 'annotations', version: "17.0.0"
-  implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.643'
+  implementation group: 'software.amazon.awssdk', name: 's3', version: awsSdkVersion
   implementation('tools.jackson.dataformat:jackson-dataformat-csv:3.0.3')
 }
 

--- a/test-utils/src/main/java/apoc/util/s3/S3BaseTest.java
+++ b/test-utils/src/main/java/apoc/util/s3/S3BaseTest.java
@@ -28,14 +28,12 @@ public abstract class S3BaseTest {
     public static void baseBeforeClass() {
         s3Container = new S3Container();
 
-        // In test environment we skip the MD5 validation that can cause issues
-        System.setProperty("com.amazonaws.services.s3.disableGetObjectMD5Validation", "true");
+        // Used by S3ParamsExtractor to prepend http:// to endpoints for local testing
         System.setProperty("com.amazonaws.sdk.disableCertChecking", "true");
     }
 
     @AfterAll
     public static void tearDown() {
-        System.clearProperty("com.amazonaws.services.s3.disableGetObjectMD5Validation");
         System.clearProperty("com.amazonaws.sdk.disableCertChecking");
 
         s3Container.close();

--- a/test-utils/src/main/java/apoc/util/s3/S3Container.java
+++ b/test-utils/src/main/java/apoc/util/s3/S3Container.java
@@ -21,62 +21,75 @@ package apoc.util.s3;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 
 import apoc.util.Util;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import java.io.File;
+import java.net.URI;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 public class S3Container implements AutoCloseable {
     private static final String S3_BUCKET_NAME = "test-bucket";
     private final LocalStackContainer localstack;
-    private final AmazonS3 s3;
+    private final S3Client s3;
 
     public S3Container() {
         localstack = new LocalStackContainer(DockerImageName.parse("localstack/localstack:1.2.0")).withServices(S3);
         localstack.addExposedPorts(4566);
         localstack.start();
 
-        s3 = AmazonS3ClientBuilder.standard()
-                .withEndpointConfiguration(getEndpointConfiguration())
-                .withCredentials(getCredentialsProvider())
+        s3 = S3Client.builder()
+                .endpointOverride(localstack.getEndpoint())
+                .region(Region.of(localstack.getRegion()))
+                .credentialsProvider(getCredentialsProvider())
+                .forcePathStyle(true)
                 .build();
-        s3.createBucket(S3_BUCKET_NAME);
+        s3.createBucket(CreateBucketRequest.builder().bucket(S3_BUCKET_NAME).build());
     }
 
     public void close() {
         Util.close(localstack);
     }
 
-    public AwsClientBuilder.EndpointConfiguration getEndpointConfiguration() {
-        return new AwsClientBuilder.EndpointConfiguration(
-                localstack.getEndpoint().toString(), localstack.getRegion());
+    public URI getEndpoint() {
+        return localstack.getEndpoint();
     }
 
-    public AWSCredentialsProvider getCredentialsProvider() {
-        return new AWSStaticCredentialsProvider(
-                new BasicAWSCredentials(localstack.getAccessKey(), localstack.getSecretKey()));
+    public String getRegion() {
+        return localstack.getRegion();
+    }
+
+    public StaticCredentialsProvider getCredentialsProvider() {
+        return StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey()));
     }
 
     public String getUrl(String key) {
+        AwsCredentials credentials = getCredentialsProvider().resolveCredentials();
         return String.format(
                 "s3://%s.%s/%s/%s?accessKey=%s&secretKey=%s",
-                getEndpointConfiguration().getSigningRegion(),
-                getEndpointConfiguration().getServiceEndpoint().replace("http://", ""),
+                getRegion(),
+                getEndpoint().toString().replace("http://", ""),
                 S3_BUCKET_NAME,
                 key,
-                getCredentialsProvider().getCredentials().getAWSAccessKeyId(),
-                getCredentialsProvider().getCredentials().getAWSSecretKey());
+                credentials.accessKeyId(),
+                credentials.secretAccessKey());
     }
 
     @SuppressWarnings("unused") // used from extended
     public String putFile(String fileName) {
         final File file = new File(fileName);
-        s3.putObject(S3_BUCKET_NAME, file.getName(), file);
+        s3.putObject(
+                PutObjectRequest.builder()
+                        .bucket(S3_BUCKET_NAME)
+                        .key(file.getName())
+                        .build(),
+                file.toPath());
         return getUrl(file.getName());
     }
 }

--- a/test-utils/src/main/java/apoc/util/s3/S3TestUtil.java
+++ b/test-utils/src/main/java/apoc/util/s3/S3TestUtil.java
@@ -20,16 +20,18 @@ package apoc.util.s3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.services.s3.model.S3ObjectInputStream;
-import com.amazonaws.util.IOUtils;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import org.neo4j.test.assertion.Assert;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
 /**
  * Utility class for testing Amazon S3 related functionality.
@@ -41,22 +43,25 @@ public class S3TestUtil {
      * @param s3Url String containing url to S3 bucket.
      * @return the s3 string object
      */
-    public static String readS3FileToString(String s3Url) throws AmazonClientException {
+    public static String readS3FileToString(String s3Url) throws SdkException {
         try {
-            S3Object s3object = getS3Object(s3Url);
-            S3ObjectInputStream inputStream = s3object.getObjectContent();
-            return IOUtils.toString(inputStream);
+            ResponseInputStream<GetObjectResponse> response = getS3Object(s3Url);
+            return new String(response.readAllBytes(), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static S3Object getS3Object(String s3Url) throws MalformedURLException, AmazonClientException {
+    public static ResponseInputStream<GetObjectResponse> getS3Object(String s3Url)
+            throws MalformedURLException, SdkException {
         S3Params s3Params = S3ParamsExtractor.extract(new URL(s3Url));
         S3Aws s3Aws = new S3Aws(s3Params, s3Params.getRegion());
-        AmazonS3 s3Client = s3Aws.getClient();
+        S3Client s3Client = s3Aws.getClient();
 
-        return s3Client.getObject(s3Params.getBucket(), s3Params.getKey());
+        return s3Client.getObject(GetObjectRequest.builder()
+                .bucket(s3Params.getBucket())
+                .key(s3Params.getKey())
+                .build());
     }
 
     public static void assertStringFileEquals(String expected, String s3Url) {
@@ -72,11 +77,8 @@ public class S3TestUtil {
                     try {
                         runnable.run();
                         return true;
-                    } catch (AmazonClientException e) {
-                        if (e.getMessage().contains("The specified key does not exist")) {
-                            return false;
-                        }
-                        throw e;
+                    } catch (NoSuchKeyException e) {
+                        return false;
                     }
                 },
                 v -> v,


### PR DESCRIPTION
https://linear.app/neo4j/issue/SURF-490/the-aws-sdk-for-java-1x-has-entered-maintenance-mode-as-of-july-31

Fixes # SURF-490

One sentence summary of the change.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Migrated to software.amazon.awssdk:s3:2.34.0 (SDK v2) across 13 files.
