### PR TITLE
SURF-646 Replace Guava Sets.intersection() with plain Java in MetaRestricted

### DIFF
--- a/core/src/main/java/apoc/meta/MetaRestricted.java
+++ b/core/src/main/java/apoc/meta/MetaRestricted.java
@@ -32,7 +32,6 @@ import apoc.util.CollectionUtils;
 import apoc.util.MapUtil;
 import apoc.util.Util;
 import apoc.util.collection.Iterables;
-import com.google.common.collect.Sets;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -488,7 +487,8 @@ public class MetaRestricted {
 
         Map<String, Object> relationships = collectRelationshipsMetaData(metaStats, metaData);
         Map<String, Object> nodes = collectNodesMetaData(metaStats, metaData, relationships);
-        final Collection<String> commonKeys = Sets.intersection(nodes.keySet(), relationships.keySet());
+        final Set<String> commonKeys = new HashSet<>(nodes.keySet());
+        commonKeys.retainAll(relationships.keySet());
         if (!commonKeys.isEmpty()) {
             relationships = relationships.entrySet().stream()
                     .map(e -> {


### PR DESCRIPTION
## Summary
- Replace `com.google.common.collect.Sets.intersection()` with plain Java `HashSet.retainAll()` in `MetaRestricted.java`
- Guava is a `compileOnly` dependency, not bundled in the APOC plugin jar. At runtime it relies on Neo4j providing Guava on its classpath. Newer Neo4j versions may no longer bundle Guava, causing `ClassNotFoundException` for `com.google.common.collect.Sets` when calling `apoc.meta.schema()`
- This eliminates the fragile runtime dependency on Neo4j's internal classpath


https://linear.app/neo4j/issue/SURF-646/test-failure-apocitcoremetacommunityfeaturestestschema
