### PR TITLE
SURF-647 Filter optional Arrow signatures in StartupTest

### DIFF
--- a/it/src/test/java/apoc/it/core/StartupTest.java
+++ b/it/src/test/java/apoc/it/core/StartupTest.java
@@ -192,8 +192,12 @@ class StartupTest {
                                 "CYPHER 5 CALL apoc.help('') YIELD core, type, name WHERE core = true and type = 'procedure' RETURN name")
                         .list(record -> record.get("name").asString());
 
-                assertEquals(sorted(ApocSignatures.PROCEDURES_CYPHER_5), procedureNames);
-                assertEquals(sorted(ApocSignatures.FUNCTIONS_CYPHER_5), functionNames);
+                assertEquals(
+                        filterOptionalSignatures(sorted(ApocSignatures.PROCEDURES_CYPHER_5)),
+                        filterOptionalSignatures(procedureNames));
+                assertEquals(
+                        filterOptionalSignatures(sorted(ApocSignatures.FUNCTIONS_CYPHER_5)),
+                        filterOptionalSignatures(functionNames));
             }
 
             neo4jContainer.close();
@@ -287,5 +291,14 @@ class StartupTest {
 
     private List<String> sorted(List<String> signatures) {
         return signatures.stream().sorted().collect(Collectors.toList());
+    }
+
+    /**
+     * Filters out procedures/functions that depend on optional (compileOnly) runtime dependencies
+     * such as Apache Arrow, which may or may not be available in the Neo4j container at runtime.
+     * By filtering both expected and actual lists, the comparison is stable regardless of the environment.
+     */
+    private List<String> filterOptionalSignatures(List<String> signatures) {
+        return signatures.stream().filter(name -> !name.contains(".arrow")).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## Summary
- Filter Apache Arrow-related procedure/function signatures from both the expected (`ApocSignatures`) and actual (container-loaded) lists in `StartupTest.compare_with_sources_cypher5`
- Arrow is a `compileOnly` dependency, not bundled in the APOC shadow jar. Its availability at runtime depends on the Neo4j container image, making the test flaky when the CI Neo4j image changes
- By filtering both sides, the comparison is stable regardless of whether the runtime environment includes Arrow libraries


https://linear.app/neo4j/issue/SURF-647/test-failure-apocitcorestartuptest-compare-with-sources

