### PR TITLE
Patch semgrep supply chain vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,18 @@ subprojects {
     implementation(platform('io.netty:netty-bom:4.2.9.Final'))
 
     testRuntimeOnly('org.junit.platform:junit-platform-launcher')
+
+    constraints {
+      implementation('com.nimbusds:nimbus-jose-jwt:9.37.4') {
+        because 'CVE-2025-53864'
+      }
+      implementation('org.apache.avro:avro:1.11.5') {
+        because 'CVE-2025-33042'
+      }
+      implementation('com.google.guava:guava:33.5.0-jre') {
+        because 'CVE-2020-8908, CVE-2023-2976'
+      }
+    }
   }
 
   java {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -71,6 +71,9 @@ dependencies {
     exclude group: 'org.slf4j', module: 'slf4j-nop'
     exclude group: 'ch.qos.logback', module: 'logback-classic'
     exclude group: 'org.ow2.asm', module: 'asm'
+    exclude group: 'io.airlift', module: 'aircompressor' // CVE-2025-67721 - no fix available, unreachable
+    exclude group: 'commons-lang', module: 'commons-lang' // CVE-2025-48924 - no fix for v2, use commons-lang3
+    exclude group: 'org.jsonschema2pojo', module: 'jsonschema2pojo-core' // CVE-2025-3588 - no fix available
   }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -105,6 +105,7 @@ dependencies {
   configurations.all {
     exclude group: 'org.slf4j', module: 'slf4j-nop'
     exclude group: 'ch.qos.logback', module: 'logback-classic'
+    exclude group: 'io.airlift', module: 'aircompressor' // CVE-2025-67721 - no fix available, unreachable
   }
 }
 

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -44,6 +44,10 @@ dependencies {
   testImplementation 'org.mockito:mockito-core:5.21.0'
 }
 
+configurations.configureEach {
+  exclude group: 'io.airlift', module: 'aircompressor' // CVE-2025-67721 - no fix available, unreachable
+}
+
 publishing {
   repositories {
     maven {

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -54,6 +54,11 @@ dependencies {
   implementation('tools.jackson.dataformat:jackson-dataformat-csv:3.0.3')
 }
 
+configurations.configureEach {
+  exclude group: 'io.airlift', module: 'aircompressor' // CVE-2025-67721 - no fix available, unreachable
+  exclude group: 'commons-lang', module: 'commons-lang' // CVE-2025-48924 - no fix for v2, use commons-lang3
+  exclude group: 'org.jsonschema2pojo', module: 'jsonschema2pojo-core' // CVE-2025-3588 - no fix available
+}
 
 publishing {
   repositories {


### PR DESCRIPTION
## Summary
- Add dependency constraints to force safe versions of transitive dependencies:
  - `com.nimbusds:nimbus-jose-jwt` 9.37.2 → 9.37.4 (CVE-2025-53864)
  - `org.apache.avro:avro` 1.11.4 → 1.11.5 (CVE-2025-33042)
  - `com.google.guava:guava` → 33.5.0-jre (CVE-2020-8908, CVE-2023-2976)
- Exclude unfixable transitive dependencies (no upstream patch available):
  - `io.airlift:aircompressor` 2.0.2 (CVE-2025-67721 -- HIGH but Unreachable, no fix on Maven)
  - `commons-lang:commons-lang` 2.6 (CVE-2025-48924 -- no fix for v2 artifact)
  - `org.jsonschema2pojo:jsonschema2pojo-core` 1.0.2 (CVE-2025-3588 -- no fix available)
- All vulnerable dependencies are transitive, pulled in by Apache Hadoop/Parquet

