### PR TITLE
Fix flakiness of testExportDataGraphML

### DIFF
--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -678,11 +678,15 @@ class ExportGraphMLTest {
         File output = new File(directory, "data.graphml");
         TestUtil.testCall(
                 db,
-                "MATCH (person:Person) \n" + "WHERE person.name STARTS WITH \"F\"\n"
-                        + "WITH collect(person) as people\n"
-                        + "CALL apoc.export.graphml.data(people, [], $file, {})\n"
-                        + "YIELD file, source, format, nodes, relationships, properties, time, rows, batchSize, batches, done, data\n"
-                        + "RETURN *",
+                """
+                        WITH COLLECT {
+                            MATCH (person:Person)
+                            WHERE person.name STARTS WITH "F"
+                            RETURN person ORDER BY person.name
+                        } AS people
+                        CALL apoc.export.graphml.data(people, [], $file, {})
+                        YIELD file, source, format, nodes, relationships, properties, time, rows, batchSize, batches, done, data
+                        RETURN *""",
                 map("file", output.getAbsolutePath()),
                 (r) -> assertEquals(2L, r.get("nodes")));
         assertXMLEquals(output, EXPECTED_DATA);


### PR DESCRIPTION
Looks like the error was due to the ordering, so added an ORDER BY using COLLECT, but as it was so rarely flaky, it is hard to confirm, but that is the woes of APOC :) 

Linear: Fixes SURF-632