### PR TITLE
Do not generate UUIDs in RandomGraphExportTest.

### DIFF
--- a/core/src/test/java/apoc/test/util/RandomGraph.java
+++ b/core/src/test/java/apoc/test/util/RandomGraph.java
@@ -55,7 +55,10 @@ public class RandomGraph {
                         INT32_VECTOR,
                         INT64_VECTOR,
                         FLOAT,
-                        CHAR -> false;
+                        CHAR,
+                        // TODO: remove UUID and UUID_ARRAY here once they are properly supported in Cypher
+                        UUID,
+                        UUID_ARRAY -> false;
                 default -> true;
             })
             .toList();


### PR DESCRIPTION
UUIDs are not yet supported in Cypher so if the db has those they can be exported but not re-parsed in apoc.cypher.runMany again.
