### PR TITLE
SURF-766 Add additionalLabels and additionalProperties config to `apoc.create.virtual.fromNode`

### DIFF
--- a/core/src/main/java/apoc/create/Create.java
+++ b/core/src/main/java/apoc/create/Create.java
@@ -411,15 +411,61 @@ public class Create {
     }
 
     @UserFunction("apoc.create.virtual.fromNode")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
     @Description(
             "Returns a virtual `NODE` from the given existing `NODE`. The virtual `NODE` only contains the requested properties.")
-    public Node virtualFromNodeFunction(
+    public Node virtualFromNodeFunctionCypher5(
             @Name(value = "node", description = "The node to generate a virtual node from.") Node node,
             @Name(value = "propertyNames", description = "The properties to copy to the virtual node.")
                     List<String> propertyNames,
             @Name(value = "config", defaultValue = "{}", description = "{ wrapNodeIds = false :: BOOLEAN }")
                     Map<String, Object> config) {
         return new VirtualNode(node, propertyNames, Util.toBoolean(config.get("wrapNodeIds")));
+    }
+
+    @UserFunction("apoc.create.virtual.fromNode")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
+    @Description(
+            "Returns a virtual `NODE` from the given existing `NODE`. The virtual `NODE` only contains the requested properties.")
+    public Node virtualFromNodeFunction(
+            @Name(value = "node", description = "The node to generate a virtual node from.") Node node,
+            @Name(value = "propertyNames", description = "The properties to copy to the virtual node.")
+                    List<String> propertyNames,
+            @Name(
+                            value = "config",
+                            defaultValue = "{}",
+                            description =
+                                    "{ wrapNodeIds = false :: BOOLEAN, additionalLabels = [] :: LIST<STRING>, additionalProperties = {} :: MAP }")
+                    Map<String, Object> config) {
+        VirtualNode virtualNode = new VirtualNode(node, propertyNames, Util.toBoolean(config.get("wrapNodeIds")));
+
+        Object labelsValue = config.get("additionalLabels");
+        if (labelsValue != null) {
+            if (!(labelsValue instanceof List<?> labels)) {
+                throw new IllegalArgumentException("additionalLabels must be a LIST<STRING>, but was: "
+                        + labelsValue.getClass().getSimpleName());
+            }
+            for (Object l : labels) {
+                if (l instanceof String labelName) {
+                    virtualNode.addLabel(Label.label(labelName));
+                }
+            }
+        }
+
+        Object propsValue = config.get("additionalProperties");
+        if (propsValue != null) {
+            if (!(propsValue instanceof Map<?, ?> props)) {
+                throw new IllegalArgumentException("additionalProperties must be a MAP, but was: "
+                        + propsValue.getClass().getSimpleName());
+            }
+            props.forEach((key, value) -> {
+                if (key instanceof String propertyName) {
+                    virtualNode.setProperty(propertyName, value);
+                }
+            });
+        }
+
+        return virtualNode;
     }
 
     @Procedure("apoc.create.vNodes")

--- a/core/src/test/java/apoc/create/CreateTest.java
+++ b/core/src/test/java/apoc/create/CreateTest.java
@@ -485,6 +485,106 @@ class CreateTest {
     }
 
     @Test
+    void testVirtualFromNodeWithAdditionalLabels() {
+        testCall(
+                db,
+                """
+                        CYPHER 25
+                        CREATE (n:Person{name:'Vincent', born: 1974} )
+                        RETURN apoc.create.virtual.fromNode(n, ['name'], { additionalLabels: ['Suspect', 'Highlighted'] }) AS node
+                        """,
+                (row) -> {
+                    Node node = (Node) row.get("node");
+
+                    assertTrue(node.hasLabel(label("Person")));
+                    assertTrue(node.hasLabel(label("Suspect")));
+                    assertTrue(node.hasLabel(label("Highlighted")));
+                    assertEquals("Vincent", node.getProperty("name"));
+                    assertNull(node.getProperty("born"));
+                });
+    }
+
+    @Test
+    void testVirtualFromNodeWithAdditionalProperties() {
+        testCall(
+                db,
+                """
+                        CYPHER 25
+                        CREATE (n:Person{name:'Vincent', born: 1974} )
+                        RETURN apoc.create.virtual.fromNode(n, ['name'], { additionalProperties: { flagged: true, score: 42 } }) AS node
+                        """,
+                (row) -> {
+                    Node node = (Node) row.get("node");
+
+                    assertTrue(node.hasLabel(label("Person")));
+                    assertEquals("Vincent", node.getProperty("name"));
+                    assertEquals(true, node.getProperty("flagged"));
+                    assertEquals(42L, node.getProperty("score"));
+                    assertNull(node.getProperty("born"));
+                });
+    }
+
+    @Test
+    void testVirtualFromNodeWithAdditionalLabelsAndProperties() {
+        testCall(
+                db,
+                """
+                        CYPHER 25
+                        CREATE (n:Person{name:'Vincent', born: 1974} )
+                        RETURN apoc.create.virtual.fromNode(n, ['name'], {
+                            wrapNodeIds: true,
+                            additionalLabels: ['Fraud'],
+                            additionalProperties: { risk: 'high' }
+                        }) AS node
+                        """,
+                (row) -> {
+                    Node node = (Node) row.get("node");
+
+                    assertTrue(node.hasLabel(label("Person")));
+                    assertTrue(node.hasLabel(label("Fraud")));
+                    assertTrue(node.getId() >= 0);
+                    assertEquals("Vincent", node.getProperty("name"));
+                    assertEquals("high", node.getProperty("risk"));
+                    assertNull(node.getProperty("born"));
+                });
+    }
+
+    @Test
+    void testVirtualFromNodeWithEmptyAdditionalLabelsAndProperties() {
+        testCall(
+                db,
+                """
+                        CYPHER 25
+                        CREATE (n:Person{name:'Vincent', born: 1974} )
+                        RETURN apoc.create.virtual.fromNode(n, ['name'], { additionalLabels: [], additionalProperties: {} }) AS node
+                        """,
+                (row) -> {
+                    Node node = (Node) row.get("node");
+
+                    assertTrue(node.hasLabel(label("Person")));
+                    assertEquals(1, Iterables.count(node.getLabels()));
+                    assertEquals("Vincent", node.getProperty("name"));
+                    assertNull(node.getProperty("born"));
+                });
+    }
+
+    @Test
+    void testVirtualFromNodeAdditionalPropertyOverwritesCopied() {
+        testCall(
+                db,
+                """
+                        CYPHER 25
+                        CREATE (n:Person{name:'Vincent', born: 1974} )
+                        RETURN apoc.create.virtual.fromNode(n, ['name'], { additionalProperties: { name: 'Override' } }) AS node
+                        """,
+                (row) -> {
+                    Node node = (Node) row.get("node");
+
+                    assertEquals("Override", node.getProperty("name"));
+                });
+    }
+
+    @Test
     void testVirtualFromNodeShouldNotEditOriginalOne() {
         db.executeTransactionally("CREATE (n:Person {name:'toUpdate'})");
 
@@ -707,6 +807,28 @@ class CreateTest {
         assertEquals("TEST_2", secondRel.getType().name());
         assertEquals(Map.of("aa", "bb"), secondRel.getAllProperties());
         assertFalse(rels.hasNext());
+    }
+
+    @Test
+    void testVirtualFromNodeWithInvalidAdditionalLabelsType() {
+        assertionsError(
+                "additionalLabels must be a LIST<STRING>, but was: String",
+                """
+                        CYPHER 25
+                        CREATE (n:Person{name:'Vincent'})
+                        RETURN apoc.create.virtual.fromNode(n, ['name'], { additionalLabels: 'notAList' }) AS node
+                        """);
+    }
+
+    @Test
+    void testVirtualFromNodeWithInvalidAdditionalPropertiesType() {
+        assertionsError(
+                "additionalProperties must be a MAP, but was: String",
+                """
+                        CYPHER 25
+                        CREATE (n:Person{name:'Vincent'})
+                        RETURN apoc.create.virtual.fromNode(n, ['name'], { additionalProperties: 'notAMap' }) AS node
+                        """);
     }
 
     @Test

--- a/core/src/test/resources/functions/common/functions.json
+++ b/core/src/test/resources/functions/common/functions.json
@@ -1338,38 +1338,6 @@
   {
     "isDeprecated": false,
     "aggregating": false,
-    "signature": "apoc.create.virtual.fromNode(node :: NODE, propertyNames :: LIST<STRING>, config = {} :: MAP) :: NODE",
-    "name": "apoc.create.virtual.fromNode",
-    "description": "Returns a virtual `NODE` from the given existing `NODE`. The virtual `NODE` only contains the requested properties.",
-    "returnDescription": "NODE",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "node",
-        "description": "The node to generate a virtual node from.",
-        "isDeprecated": false,
-        "type": "NODE"
-      },
-      {
-        "name": "propertyNames",
-        "description": "The properties to copy to the virtual node.",
-        "isDeprecated": false,
-        "type": "LIST<STRING>"
-      },
-      {
-        "name": "config",
-        "description": "{ wrapNodeIds = false :: BOOLEAN }",
-        "isDeprecated": false,
-        "default": "DefaultParameterValue{value={}, type=MAP}",
-        "type": "MAP"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
     "signature": "apoc.cypher.runFirstColumnMany(statement :: STRING, params :: MAP) :: LIST<ANY>",
     "name": "apoc.cypher.runFirstColumnMany",
     "description": "Runs the given statement with the given parameters and returns the first column collected into a `LIST<ANY>`.",

--- a/core/src/test/resources/functions/cypher25/functions.json
+++ b/core/src/test/resources/functions/cypher25/functions.json
@@ -612,6 +612,38 @@
     ]
   },
   {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.create.virtual.fromNode(node :: NODE, propertyNames :: LIST<STRING>, config = {} :: MAP) :: NODE",
+    "name": "apoc.create.virtual.fromNode",
+    "description": "Returns a virtual `NODE` from the given existing `NODE`. The virtual `NODE` only contains the requested properties.",
+    "returnDescription": "NODE",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "node",
+        "description": "The node to generate a virtual node from.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "propertyNames",
+        "description": "The properties to copy to the virtual node.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "config",
+        "description": "{ wrapNodeIds = false :: BOOLEAN, additionalLabels = [] :: LIST<STRING>, additionalProperties = {} :: MAP }",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
     "isDeprecated": true,
     "aggregating": false,
     "signature": "apoc.date.convertFormat(temporal :: STRING, currentFormat :: STRING, convertTo = yyyy-MM-dd :: STRING) :: STRING",

--- a/core/src/test/resources/functions/cypher5/functions.json
+++ b/core/src/test/resources/functions/cypher5/functions.json
@@ -626,6 +626,38 @@
   {
     "isDeprecated": false,
     "aggregating": false,
+    "signature": "apoc.create.virtual.fromNode(node :: NODE, propertyNames :: LIST<STRING>, config = {} :: MAP) :: NODE",
+    "name": "apoc.create.virtual.fromNode",
+    "description": "Returns a virtual `NODE` from the given existing `NODE`. The virtual `NODE` only contains the requested properties.",
+    "returnDescription": "NODE",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "node",
+        "description": "The node to generate a virtual node from.",
+        "isDeprecated": false,
+        "type": "NODE"
+      },
+      {
+        "name": "propertyNames",
+        "description": "The properties to copy to the virtual node.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "config",
+        "description": "{ wrapNodeIds = false :: BOOLEAN }",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value={}, type=MAP}",
+        "type": "MAP"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
     "signature": "apoc.date.convertFormat(temporal :: STRING, currentFormat :: STRING, convertTo = yyyy-MM-dd :: STRING) :: STRING",
     "name": "apoc.date.convertFormat",
     "description": "Converts a `STRING` of one type of date format into a `STRING` of another type of date format.",


### PR DESCRIPTION

Extend the config map of apoc.create.virtual.fromNode to support additionalLabels (LIST<STRING>) and additionalProperties (MAP), allowing users to annotate virtual nodes with extra labels and properties at creation time without requiring write mode.

https://linear.app/neo4j/issue/SURF-766/apoc-add-a-virtual-label-to-a-result-node-to-highlight-eg-potential


