### PR TITLE
SURF-789: Add SHA commits to GA

### DIFF
--- a/.github/actions/gradle-command-on-pr/action.yaml
+++ b/.github/actions/gradle-command-on-pr/action.yaml
@@ -53,7 +53,7 @@ runs:
 
     - name: Add reaction on pushed changes
       if: ${{ success() && steps.git-check.outputs.modified == 'true' }}
-      uses: peter-evans/create-or-update-comment@v2
+      uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d # v2
       with:
         token: ${{ inputs.SERVICE_ACCOUNT_PAT }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -62,7 +62,7 @@ runs:
 
     - name: Add reaction when no update is needed
       if: ${{ success() && steps.git-check.outputs.modified == 'false' }}
-      uses: peter-evans/create-or-update-comment@v2
+      uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d # v2
       with:
         token: ${{ inputs.SERVICE_ACCOUNT_PAT }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -79,7 +79,7 @@ runs:
       env:
         GRADLE_COMMAND: ${{ inputs.gradle-command }}
       if: ${{ !success() }}
-      uses: peter-evans/create-or-update-comment@v2
+      uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d # v2
       with:
         token: ${{ inputs.SERVICE_ACCOUNT_PAT }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -91,7 +91,7 @@ runs:
 
     - name: Report failure to original comment with a reaction
       if: ${{ !success() }}
-      uses: peter-evans/create-or-update-comment@v2
+      uses: peter-evans/create-or-update-comment@67dcc547d311b736a8e6c5c236542148a47adc3d # v2
       with:
         token: ${{ inputs.SERVICE_ACCOUNT_PAT }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/ChatOps.yml
+++ b/.github/workflows/ChatOps.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@v3
+        uses: peter-evans/slash-command-dispatch@f996d7b7aae9059759ac55e978cff76d91853301 #v3
         with:
           issue-type: pull-request
           reaction-token: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ subprojects {
     testImplementation('org.junit.jupiter:junit-jupiter')
 
     // We want the same netty version as other neo4j dependencies, are there better ways than to keep this in sync?
-    implementation(platform('io.netty:netty-bom:4.2.9.Final'))
+    implementation(platform('io.netty:netty-bom:4.2.12.Final'))
 
     testRuntimeOnly('org.junit.platform:junit-platform-launcher')
 


### PR DESCRIPTION
I didn't update the versions even if there are new releases, as I figured "don't touch what ain't broke" :) Just updated them to the SHA as security requested.

Fixes: SURF-789