### PR TITLE
Only try to create constraint in CypherInitializer on leader

### DIFF
--- a/core/src/main/java/apoc/cypher/CypherInitializer.java
+++ b/core/src/main/java/apoc/cypher/CypherInitializer.java
@@ -39,10 +39,12 @@ import org.neo4j.configuration.Config;
 import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.event.DatabaseEventContext;
 import org.neo4j.graphdb.event.DatabaseEventListener;
+import org.neo4j.internal.kernel.api.security.LoginContext;
+import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.availability.AvailabilityListener;
+import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.monitoring.DatabaseEventListeners;
 import org.neo4j.logging.Log;
@@ -105,22 +107,35 @@ public class CypherInitializer implements AvailabilityListener {
 
                             // Create a uniqueness constraint on system db to avoid race conditions when installing
                             // triggers
-                            try (Transaction tx = db.beginTx()) {
-                                var constraintName = "triggerConstraint";
-                                var maybeConstraint = StreamSupport.stream(
-                                                tx.schema()
-                                                        .getConstraints(SystemLabels.ApocTriggerMeta)
-                                                        .spliterator(),
-                                                false)
-                                        .filter(x -> x.getName().equals(constraintName))
-                                        .toList();
-                                if (maybeConstraint.isEmpty()) {
-                                    tx.schema()
-                                            .constraintFor(SystemLabels.ApocTriggerMeta)
-                                            .withName(constraintName)
-                                            .assertPropertyIsUnique(SystemPropertyKeys.database.name())
-                                            .create();
-                                    tx.commit();
+                            // Retry 3 times on each cluster member to decrease the likelihood of there being no leader
+                            int counter = 0;
+                            boolean constraintCreated = false;
+
+                            while (counter < 3 && !constraintCreated) {
+                                counter++;
+                                try (InternalTransaction tx = db.beginTransaction(
+                                        KernelTransaction.Type.EXPLICIT, LoginContext.AUTH_DISABLED)) {
+                                    // Only try to add constraint if the db is writable (i.e. we are on the cluster
+                                    // leader)
+                                    if (tx.securityContext().mode().allowsSchemaWrites()) {
+                                        var constraintName = "triggerConstraint";
+                                        var maybeConstraint = StreamSupport.stream(
+                                                        tx.schema()
+                                                                .getConstraints(SystemLabels.ApocTriggerMeta)
+                                                                .spliterator(),
+                                                        false)
+                                                .filter(x -> x.getName().equals(constraintName))
+                                                .toList();
+                                        if (maybeConstraint.isEmpty()) {
+                                            tx.schema()
+                                                    .constraintFor(SystemLabels.ApocTriggerMeta)
+                                                    .withName(constraintName)
+                                                    .assertPropertyIsUnique(SystemPropertyKeys.database.name())
+                                                    .create();
+                                            tx.commit();
+                                        }
+                                        constraintCreated = true;
+                                    }
                                 }
                             }
 

--- a/core/src/test/java/apoc/cypher/CypherInitializerTest.java
+++ b/core/src/test/java/apoc/cypher/CypherInitializerTest.java
@@ -24,6 +24,7 @@ import static org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAM
 import static org.neo4j.configuration.GraphDatabaseSettings.SYSTEM_DATABASE_NAME;
 
 import apoc.ApocExtensionFactory;
+import apoc.SystemLabels;
 import apoc.test.EnvSettingRule;
 import apoc.test.annotations.Env;
 import apoc.test.annotations.EnvSetting;
@@ -31,12 +32,14 @@ import apoc.util.TestUtil;
 import apoc.util.Utils;
 import apoc.util.collection.Iterators;
 import java.util.Collections;
+import java.util.stream.StreamSupport;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.availability.AvailabilityListener;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.rule.DbmsRule;
@@ -98,6 +101,22 @@ public class CypherInitializerTest {
     }
 
     @Test
+    @Env
+    public void noInitializerHasSystemConstraint() {
+        GraphDatabaseService systemDb = dbmsRule.getManagementService().database(SYSTEM_DATABASE_NAME);
+        try (Transaction tx = systemDb.beginTx()) {
+            var triggerConstraints = StreamSupport.stream(
+                            tx.schema()
+                                    .getConstraints(SystemLabels.ApocTriggerMeta)
+                                    .spliterator(),
+                            false)
+                    .filter(x -> x.getName().equals("triggerConstraint"))
+                    .toList();
+            assertEquals(1, triggerConstraints.size());
+        }
+    }
+
+    @Test
     @Env({@EnvSetting(key = APOC_CONFIG_INITIALIZER + "." + DEFAULT_DATABASE_NAME, value = "")})
     public void emptyInitializerWorks() {
         expectNodeCount(0);
@@ -107,6 +126,22 @@ public class CypherInitializerTest {
     @Env({@EnvSetting(key = APOC_CONFIG_INITIALIZER + "." + DEFAULT_DATABASE_NAME, value = "create()")})
     public void singleInitializerWorks() {
         expectNodeCount(1);
+    }
+
+    @Test
+    @Env({@EnvSetting(key = APOC_CONFIG_INITIALIZER + "." + DEFAULT_DATABASE_NAME, value = "create()")})
+    public void singleInitializerHasSystemConstraint() {
+        GraphDatabaseService systemDb = dbmsRule.getManagementService().database(SYSTEM_DATABASE_NAME);
+        try (Transaction tx = systemDb.beginTx()) {
+            var triggerConstraints = StreamSupport.stream(
+                            tx.schema()
+                                    .getConstraints(SystemLabels.ApocTriggerMeta)
+                                    .spliterator(),
+                            false)
+                    .filter(x -> x.getName().equals("triggerConstraint"))
+                    .toList();
+            assertEquals(1, triggerConstraints.size());
+        }
     }
 
     @Test


### PR DESCRIPTION
Manual backport of https://github.com/neo4j/apoc/pull/890

I skipped to backport the restart test from that PR, because in 5.26 the initializer tests are on community which do not allow start and stop database.
