### PR TITLE
Deprecate apoc.text.indexOf, apoc.text.join and apoc.text.regexReplace in favour of Cypher.

### DIFF
--- a/core/src/main/java/apoc/text/Strings.java
+++ b/core/src/main/java/apoc/text/Strings.java
@@ -76,6 +76,21 @@ public class Strings {
 
     @UserFunction("apoc.text.indexOf")
     @Description("Returns the first occurrence of the lookup `STRING` in the given `STRING`, or -1 if not found.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    public Long indexOfCypher5(
+            final @Name(value = "text", description = "The string to search for the lookup string in.") String text,
+            final @Name(value = "lookup", description = "The lookup string to search for in the given string.") String
+                            lookup,
+            final @Name(value = "from", defaultValue = "0", description = "The index at which to start the search.")
+                    long from,
+            @Name(value = "to", defaultValue = "-1", description = "The index at which to stop the search.") long to) {
+        return indexOf(text, lookup, from, to);
+    }
+
+    @UserFunction(name = "apoc.text.indexOf", deprecatedBy = "Cypher's `string.indexOf` function.")
+    @Description("Returns the first occurrence of the lookup `STRING` in the given `STRING`, or -1 if not found.")
+    @Deprecated
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     public Long indexOf(
             final @Name(value = "text", description = "The string to search for the lookup string in.") String text,
             final @Name(value = "lookup", description = "The lookup string to search for in the given string.") String
@@ -116,6 +131,22 @@ public class Strings {
 
     @UserFunction("apoc.text.replace")
     @Description("Finds and replaces all matches found by the given regular expression with the given replacement.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    public String replaceCypher5(
+            final @Name(value = "text", description = "The string to be modified.") String text,
+            final @Name(
+                            value = "regex",
+                            description = "The regular expression pattern to replace in the original string.") String
+                            regex,
+            final @Name(value = "replacement", description = "The value to be inserted in the original string.") String
+                            replacement) {
+        return regreplace(text, regex, replacement);
+    }
+
+    @UserFunction(name = "apoc.text.replace", deprecatedBy = "Cypher's `string.regexReplace` function.")
+    @Description("Finds and replaces all matches found by the given regular expression with the given replacement.")
+    @Deprecated
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     public String replace(
             final @Name(value = "text", description = "The string to be modified.") String text,
             final @Name(
@@ -260,6 +291,25 @@ public class Strings {
 
     @UserFunction("apoc.text.join")
     @Description("Joins the given `STRING` values using the given delimiter.")
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_5})
+    public String joinCypher5(
+            final @Name(
+                            value = "texts",
+                            description = "The list of strings to be concatenated using the given delimiter.") List<
+                                    String>
+                            texts,
+            final @Name(value = "delimiter", description = "The given delimiter to join the given strings with.") String
+                            delimiter) {
+        if (texts == null || delimiter == null) {
+            return null;
+        }
+        return String.join(delimiter, texts);
+    }
+
+    @UserFunction(name = "apoc.text.join", deprecatedBy = "Cypher's `string.join` function.")
+    @Description("Joins the given `STRING` values using the given delimiter.")
+    @Deprecated
+    @QueryLanguageScope(scope = {QueryLanguage.CYPHER_25})
     public String join(
             final @Name(
                             value = "texts",

--- a/core/src/test/resources/functions/common/functions.json
+++ b/core/src/test/resources/functions/common/functions.json
@@ -3880,45 +3880,6 @@
   {
     "isDeprecated": false,
     "aggregating": false,
-    "signature": "apoc.text.indexOf(text :: STRING, lookup :: STRING, from = 0 :: INTEGER, to = -1 :: INTEGER) :: INTEGER",
-    "name": "apoc.text.indexOf",
-    "description": "Returns the first occurrence of the lookup `STRING` in the given `STRING`, or -1 if not found.",
-    "returnDescription": "INTEGER",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "text",
-        "description": "The string to search for the lookup string in.",
-        "isDeprecated": false,
-        "type": "STRING"
-      },
-      {
-        "name": "lookup",
-        "description": "The lookup string to search for in the given string.",
-        "isDeprecated": false,
-        "type": "STRING"
-      },
-      {
-        "name": "from",
-        "description": "The index at which to start the search.",
-        "isDeprecated": false,
-        "default": "DefaultParameterValue{value=0, type=INTEGER}",
-        "type": "INTEGER"
-      },
-      {
-        "name": "to",
-        "description": "The index at which to stop the search.",
-        "isDeprecated": false,
-        "default": "DefaultParameterValue{value=-1, type=INTEGER}",
-        "type": "INTEGER"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
     "signature": "apoc.text.indexesOf(text :: STRING, lookup :: STRING, from = 0 :: INTEGER, to = -1 :: INTEGER) :: LIST<ANY>",
     "name": "apoc.text.indexesOf",
     "description": "Returns all occurrences of the lookup `STRING` in the given `STRING`, or an empty list if not found.",
@@ -3975,31 +3936,6 @@
       {
         "name": "text2",
         "description": "The second string to be compared against the first.",
-        "isDeprecated": false,
-        "type": "STRING"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.text.join(texts :: LIST<STRING>, delimiter :: STRING) :: STRING",
-    "name": "apoc.text.join",
-    "description": "Joins the given `STRING` values using the given delimiter.",
-    "returnDescription": "STRING",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "texts",
-        "description": "The list of strings to be concatenated using the given delimiter.",
-        "isDeprecated": false,
-        "type": "LIST<STRING>"
-      },
-      {
-        "name": "delimiter",
-        "description": "The given delimiter to join the given strings with.",
         "isDeprecated": false,
         "type": "STRING"
       }
@@ -4179,37 +4115,6 @@
         "description": "The number of times to repeat the given string.",
         "isDeprecated": false,
         "type": "INTEGER"
-      }
-    ]
-  },
-  {
-    "isDeprecated": false,
-    "aggregating": false,
-    "signature": "apoc.text.replace(text :: STRING, regex :: STRING, replacement :: STRING) :: STRING",
-    "name": "apoc.text.replace",
-    "description": "Finds and replaces all matches found by the given regular expression with the given replacement.",
-    "returnDescription": "STRING",
-    "deprecatedBy": null,
-    "category": "",
-    "isBuiltIn": false,
-    "argumentDescription": [
-      {
-        "name": "text",
-        "description": "The string to be modified.",
-        "isDeprecated": false,
-        "type": "STRING"
-      },
-      {
-        "name": "regex",
-        "description": "The regular expression pattern to replace in the original string.",
-        "isDeprecated": false,
-        "type": "STRING"
-      },
-      {
-        "name": "replacement",
-        "description": "The value to be inserted in the original string.",
-        "isDeprecated": false,
-        "type": "STRING"
       }
     ]
   },

--- a/core/src/test/resources/functions/cypher25/functions.json
+++ b/core/src/test/resources/functions/cypher25/functions.json
@@ -1204,5 +1204,100 @@
         "type": "STRING"
       }
     ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.text.indexOf(text :: STRING, lookup :: STRING, from = 0 :: INTEGER, to = -1 :: INTEGER) :: INTEGER",
+    "name": "apoc.text.indexOf",
+    "description": "Returns the first occurrence of the lookup `STRING` in the given `STRING`, or -1 if not found.",
+    "returnDescription": "INTEGER",
+    "deprecatedBy": "Cypher's `string.indexOf` function.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "text",
+        "description": "The string to search for the lookup string in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "lookup",
+        "description": "The lookup string to search for in the given string.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "from",
+        "description": "The index at which to start the search.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=0, type=INTEGER}",
+        "type": "INTEGER"
+      },
+      {
+        "name": "to",
+        "description": "The index at which to stop the search.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=-1, type=INTEGER}",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.text.join(texts :: LIST<STRING>, delimiter :: STRING) :: STRING",
+    "name": "apoc.text.join",
+    "description": "Joins the given `STRING` values using the given delimiter.",
+    "returnDescription": "STRING",
+    "deprecatedBy": "Cypher's `string.join` function.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "texts",
+        "description": "The list of strings to be concatenated using the given delimiter.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "delimiter",
+        "description": "The given delimiter to join the given strings with.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": true,
+    "aggregating": false,
+    "signature": "apoc.text.replace(text :: STRING, regex :: STRING, replacement :: STRING) :: STRING",
+    "name": "apoc.text.replace",
+    "description": "Finds and replaces all matches found by the given regular expression with the given replacement.",
+    "returnDescription": "STRING",
+    "deprecatedBy": "Cypher's `string.regexReplace` function.",
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "text",
+        "description": "The string to be modified.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "regex",
+        "description": "The regular expression pattern to replace in the original string.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "replacement",
+        "description": "The value to be inserted in the original string.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
   }
 ]

--- a/core/src/test/resources/functions/cypher5/functions.json
+++ b/core/src/test/resources/functions/cypher5/functions.json
@@ -1242,6 +1242,101 @@
     ]
   },
   {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.text.indexOf(text :: STRING, lookup :: STRING, from = 0 :: INTEGER, to = -1 :: INTEGER) :: INTEGER",
+    "name": "apoc.text.indexOf",
+    "description": "Returns the first occurrence of the lookup `STRING` in the given `STRING`, or -1 if not found.",
+    "returnDescription": "INTEGER",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "text",
+        "description": "The string to search for the lookup string in.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "lookup",
+        "description": "The lookup string to search for in the given string.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "from",
+        "description": "The index at which to start the search.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=0, type=INTEGER}",
+        "type": "INTEGER"
+      },
+      {
+        "name": "to",
+        "description": "The index at which to stop the search.",
+        "isDeprecated": false,
+        "default": "DefaultParameterValue{value=-1, type=INTEGER}",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.text.join(texts :: LIST<STRING>, delimiter :: STRING) :: STRING",
+    "name": "apoc.text.join",
+    "description": "Joins the given `STRING` values using the given delimiter.",
+    "returnDescription": "STRING",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "texts",
+        "description": "The list of strings to be concatenated using the given delimiter.",
+        "isDeprecated": false,
+        "type": "LIST<STRING>"
+      },
+      {
+        "name": "delimiter",
+        "description": "The given delimiter to join the given strings with.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
+    "isDeprecated": false,
+    "aggregating": false,
+    "signature": "apoc.text.replace(text :: STRING, regex :: STRING, replacement :: STRING) :: STRING",
+    "name": "apoc.text.replace",
+    "description": "Finds and replaces all matches found by the given regular expression with the given replacement.",
+    "returnDescription": "STRING",
+    "deprecatedBy": null,
+    "category": "",
+    "isBuiltIn": false,
+    "argumentDescription": [
+      {
+        "name": "text",
+        "description": "The string to be modified.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "regex",
+        "description": "The regular expression pattern to replace in the original string.",
+        "isDeprecated": false,
+        "type": "STRING"
+      },
+      {
+        "name": "replacement",
+        "description": "The value to be inserted in the original string.",
+        "isDeprecated": false,
+        "type": "STRING"
+      }
+    ]
+  },
+  {
     "isDeprecated": true,
     "aggregating": false,
     "signature": "apoc.text.levenshteinDistance(text1 :: STRING, text2 :: STRING) :: INTEGER",


### PR DESCRIPTION
Cypher has new functions: string.join, string.indexOf and string.regexReplace 🎉 

docs: https://github.com/neo4j/docs-apoc/pull/515