### PR TITLE
Fix Cypher Initializer for clusters

### DIFF
--- a/core/src/main/java/apoc/cypher/CypherInitializer.java
+++ b/core/src/main/java/apoc/cypher/CypherInitializer.java
@@ -115,8 +115,6 @@ public class CypherInitializer implements AvailabilityListener {
                                 counter++;
                                 try (InternalTransaction tx = db.beginTransaction(
                                         KernelTransaction.Type.EXPLICIT, LoginContext.AUTH_DISABLED)) {
-                                    // Only try to add constraint if the db is writable (i.e. we are on the cluster
-                                    // leader)
                                     if (tx.securityContext().mode().allowsSchemaWrites()) {
                                         var constraintName = "triggerConstraint";
                                         var maybeConstraint = StreamSupport.stream(
@@ -127,12 +125,22 @@ public class CypherInitializer implements AvailabilityListener {
                                                 .filter(x -> x.getName().equals(constraintName))
                                                 .toList();
                                         if (maybeConstraint.isEmpty()) {
-                                            tx.schema()
-                                                    .constraintFor(SystemLabels.ApocTriggerMeta)
-                                                    .withName(constraintName)
-                                                    .assertPropertyIsUnique(SystemPropertyKeys.database.name())
-                                                    .create();
-                                            tx.commit();
+                                            try {
+                                                tx.schema()
+                                                        .constraintFor(SystemLabels.ApocTriggerMeta)
+                                                        .withName(constraintName)
+                                                        .assertPropertyIsUnique(SystemPropertyKeys.database.name())
+                                                        .create();
+                                                tx.commit();
+                                            } catch (Exception e) {
+                                                if (!e.getMessage()
+                                                        .contains(
+                                                                "No write operations are allowed directly on this database. Writes must pass through the leader. The role of this server is: FOLLOWER")) {
+                                                    throw e;
+                                                }
+                                                // else swallow error, it seems clusters can show they allow writes even
+                                                // when they don't
+                                            }
                                         }
                                         constraintCreated = true;
                                     }

--- a/it/src/test/java/apoc/it/core/AbstractDockerTestBase.java
+++ b/it/src/test/java/apoc/it/core/AbstractDockerTestBase.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package apoc.it.core;
 
 import static apoc.util.TestContainerUtil.createNeo4jContainer;

--- a/it/src/test/java/apoc/it/core/CypherInitializerClusterTest.java
+++ b/it/src/test/java/apoc/it/core/CypherInitializerClusterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package apoc.it.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import apoc.util.Neo4jContainerExtension;
+import apoc.util.TestContainerUtil;
+import apoc.util.TestcontainersCausalCluster;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CypherInitializerClusterTest {
+
+    private static TestcontainersCausalCluster cluster;
+    private static List<Neo4jContainerExtension> clusterMembers;
+
+    @BeforeClass
+    public static void setupCluster() {
+        cluster = TestContainerUtil.createEnterpriseCluster(
+                List.of(TestContainerUtil.ApocPackage.CORE),
+                3,
+                0,
+                Collections.emptyMap(),
+                Map.of("NEO4J_dbms_routing_enabled", "true"));
+
+        clusterMembers = cluster.getClusterMembers();
+        assertEquals(3, clusterMembers.size());
+    }
+
+    @AfterClass
+    public static void bringDownCluster() {
+        if (cluster != null) {
+            cluster.close();
+        }
+    }
+
+    @Test
+    public void triggerConstraintDoesntErrorOnFollowers() {
+        for (Neo4jContainerExtension member : clusterMembers) {
+            assertFalse(
+                    "Cluster member logged a follower write error during CypherInitializer startup",
+                    member.getLogs().contains("No write operations are allowed directly on this database"));
+        }
+    }
+}


### PR DESCRIPTION
Clusters seems to still make it through the is writeable check, as this failing is not actually a problem I just ignore those errors and let it continue. (Also when regenerating license headers this other one popped up, we already have a card for why the CI is passing without checking that)