### PR TITLE
Fix termination guard in csv loader

### DIFF
--- a/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
+++ b/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
@@ -25,6 +25,7 @@ import apoc.load.CSVResult;
 import apoc.load.Mapping;
 import apoc.load.util.Results;
 import apoc.util.FileUtils;
+import apoc.util.Util;
 import com.opencsv.CSVReader;
 import com.opencsv.CSVReaderBuilder;
 import com.opencsv.RFC4180ParserBuilder;
@@ -38,6 +39,7 @@ import org.neo4j.graphdb.*;
 import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.graphdb.security.URLAccessValidationError;
 import org.neo4j.logging.Log;
+import org.neo4j.procedure.TerminationGuard;
 
 public class CsvEntityLoader {
 
@@ -45,16 +47,23 @@ public class CsvEntityLoader {
     private final ProgressReporter reporter;
     private final Log log;
     private final URLAccessChecker urlAccessChecker;
+    private final TerminationGuard terminationGuard;
 
     /**
      * @param clc configuration object
      * @param reporter
      */
-    public CsvEntityLoader(CsvLoaderConfig clc, ProgressReporter reporter, Log log, URLAccessChecker urlAccessChecker) {
+    public CsvEntityLoader(
+            CsvLoaderConfig clc,
+            ProgressReporter reporter,
+            Log log,
+            URLAccessChecker urlAccessChecker,
+            TerminationGuard terminationGuard) {
         this.clc = clc;
         this.reporter = reporter;
         this.log = log;
         this.urlAccessChecker = urlAccessChecker;
+        this.terminationGuard = terminationGuard;
     }
 
     /**
@@ -112,7 +121,9 @@ public class CsvEntityLoader {
             AtomicInteger lineNo = new AtomicInteger();
             BatchTransaction btx = new BatchTransaction(db, clc.getBatchSize(), reporter);
             try {
-                csv.forEach(line -> {
+                final Iterator<String[]> lineIterator = csv.iterator();
+                while (lineIterator.hasNext() && !Util.transactionIsTerminated(terminationGuard)) {
+                    final String[] line = lineIterator.next();
                     lineNo.getAndIncrement();
 
                     final EnumSet<Results> results = EnumSet.of(Results.map);
@@ -133,7 +144,7 @@ public class CsvEntityLoader {
                     // we either fail the loading process or skip it depending on the 'ignore duplicate nodes' setting
                     if (idField.isPresent() && idspaceIdMapping.containsKey(nodeCsvId)) {
                         if (clc.getIgnoreDuplicateNodes()) {
-                            return;
+                            continue;
                         } else {
                             throw new IllegalStateException("Duplicate node with id " + nodeCsvId + " found on line "
                                     + lineNo + "\n" + Arrays.toString(line));
@@ -179,7 +190,7 @@ public class CsvEntityLoader {
                     }
                     btx.increment();
                     reporter.update(1, 0, props++);
-                });
+                }
                 btx.doCommit();
             } catch (RuntimeException e) {
                 btx.rollback();
@@ -244,7 +255,9 @@ public class CsvEntityLoader {
                 AtomicInteger lineNo = new AtomicInteger();
                 BatchTransaction btx = new BatchTransaction(db, clc.getBatchSize(), reporter);
                 try {
-                    csv.forEach(line -> {
+                    final Iterator<String[]> lineIterator = csv.iterator();
+                    while (lineIterator.hasNext() && !Util.transactionIsTerminated(terminationGuard)) {
+                        final String[] line = lineIterator.next();
                         lineNo.getAndIncrement();
 
                         final EnumSet<Results> results = EnumSet.of(Results.map);
@@ -296,7 +309,7 @@ public class CsvEntityLoader {
                         }
                         btx.increment();
                         reporter.update(0, 1, props);
-                    });
+                    }
                     btx.doCommit();
                 } catch (RuntimeException e) {
                     btx.rollback();

--- a/core/src/main/java/apoc/export/csv/ImportCsv.java
+++ b/core/src/main/java/apoc/export/csv/ImportCsv.java
@@ -44,6 +44,9 @@ public class ImportCsv {
     @Context
     public URLAccessChecker urlAccessChecker;
 
+    @Context
+    public TerminationGuard terminationGuard;
+
     @Procedure(name = "apoc.import.csv", mode = Mode.SCHEMA)
     @Description("Imports `NODE` and `RELATIONSHIP` values with the given labels and types from the provided CSV file.")
     public Stream<ImportProgressInfo> importCsv(
@@ -86,7 +89,7 @@ public class ImportCsv {
             final CsvLoaderConfig clc = CsvLoaderConfig.from(config);
             final ProgressReporter reporter =
                     new ProgressReporter(null, null, new ImportProgressInfo(file, source, "csv"));
-            final CsvEntityLoader loader = new CsvEntityLoader(clc, reporter, log, urlAccessChecker);
+            final CsvEntityLoader loader = new CsvEntityLoader(clc, reporter, log, urlAccessChecker, terminationGuard);
 
             final Map<String, Map<String, String>> idMapping = new HashMap<>();
             for (Map<String, Object> node : nodes) {


### PR DESCRIPTION
The test was flaky depending on when the termination was called and what part was hit, I could reproduce by running the test 20 times in a row before, and after this change that repetition no longer found it :)