### PR TITLE
refactor: add explicit declaration for neo4j-graph-algo dependency

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -36,6 +36,7 @@ dependencies {
   // These will be dependencies not packaged with the .jar
   // They need to be provided either through the database or in an extra .jar
   compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
+  compileOnly group: 'org.neo4j', name: 'neo4j-graph-algo', version: neo4jVersionEffective
   compileOnly group: 'software.amazon.awssdk', name: 's3', version: awsSdkVersion
   // If updated check if the transitive dependency to javax.servlet.jsp:jsp-api:2.1 has also updated
   // and remove the manual licensing check for it in licenses-3rdparties.gradle


### PR DESCRIPTION
Needed to ensure PR on `neo-technology` passes.

Add explicit dependency declaration instead of using transitively. 

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - add explicit declaration for `neo4j-graph-algo` dependency.
 
