### PR TITLE
Fix apoc.load.csv by checking for EOF instead of null bytes

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -100,6 +100,7 @@ dependencies {
   testImplementation group: 'org.mock-server', name: 'mockserver-netty', version: '5.15.0', {
     exclude group: 'org.slf4j', module: 'slf4j-api'
   }
+  testImplementation group: 'org.neo4j', name: 'neo4j-graph-algo', version: neo4jVersionEffective
   testImplementation 'org.assertj:assertj-core:3.27.6'
   testImplementation 'net.javacrumbs.json-unit:json-unit-assertj:5.1.0'
 

--- a/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
+++ b/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
@@ -336,7 +336,7 @@ public class CsvEntityLoader {
     private static String readFirstLine(CountingReader reader) throws IOException {
         String line = "";
         int i;
-        while ((i = reader.read()) != 0) {
+        while ((i = reader.read()) != -1) {
             char c = (char) i;
             if (c == '\n') break;
             line += c;

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -37,8 +37,10 @@ import apoc.csv.CsvTestUtil;
 import apoc.util.CompressionAlgo;
 import apoc.util.TestUtil;
 import com.neo4j.test.extension.EnterpriseDbmsExtension;
+import com.sun.net.httpserver.HttpServer;
 import java.io.File;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -53,6 +55,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
@@ -74,6 +77,9 @@ import org.neo4j.values.storable.Values;
 class ImportCsvTest {
     public static final String BASE_URL_FILES = "src/test/resources/csv-inputs";
     private static final ZoneId DEFAULT_TIMEZONE = ZoneId.of("Asia/Tokyo");
+
+    private HttpServer localServer;
+    private int localServerPort;
 
     @Inject
     GraphDatabaseService db;
@@ -327,6 +333,33 @@ class ImportCsvTest {
 
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
+
+        localServer = HttpServer.create(new InetSocketAddress(0), 0);
+        localServer.createContext("/waf-challenge.csv", exchange -> {
+            exchange.getResponseHeaders().set("Content-Length", "0");
+            exchange.sendResponseHeaders(202, -1);
+            exchange.getResponseBody().close();
+        });
+        localServer.start();
+        localServerPort = localServer.getAddress().getPort();
+    }
+
+    @AfterAll
+    void tearDown() {
+        if (localServer != null) {
+            localServer.stop(0);
+        }
+    }
+
+    @Test
+    void testImportCsvWithWafChallenge() {
+        // AWS WAF returns 202 with content-length: 0 for bot challenges aka "Are you human?"
+        String url = "http://localhost:" + localServerPort + "/waf-challenge.csv";
+        TestUtil.testCall(
+                db,
+                "CALL apoc.import.csv([{fileName: $url, labels: ['Test']}], [], {})",
+                Map.of("url", url),
+                r -> assertEquals(0L, r.get("nodes")));
     }
 
     @Test

--- a/core/src/test/java/apoc/trigger/TriggerTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerTest.java
@@ -120,7 +120,7 @@ class TriggerTest {
         db.executeTransactionally("CREATE (:Counter {count:0})");
         db.executeTransactionally("CREATE (f:Foo)");
         final String triggerQuery = "MATCH (c:Counter) SET c.count = c.count + size($deletedNodes)";
-        db.executeTransactionally("CALL apoc.trigger.add('count-removals', $query, {})", map("$query", triggerQuery));
+        db.executeTransactionally("CALL apoc.trigger.add('count-removals', $query, {})", map("query", triggerQuery));
 
         // Wait for trigger
         TriggerTestUtil.awaitTriggerDiscovered(db, "count-removals", triggerQuery);

--- a/it/build.gradle
+++ b/it/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   testImplementation project(':core').sourceSets.test.output
 
   testImplementation platform("io.grpc:grpc-bom:1.78.0")
+  testImplementation group: 'org.neo4j', name: 'neo4j-graph-algo', version: neo4jVersionEffective
   testImplementation "com.neo4j:enterprise-it-test-support:$neo4jVersionEffective"
   testImplementation group: 'software.amazon.awssdk', name: 's3', version: awsSdkVersion
   testImplementation group: 'org.xmlunit', name: 'xmlunit-core', version: '2.11.0'

--- a/it/src/test/java/apoc/it/core/RBACOnLoadTest.java
+++ b/it/src/test/java/apoc/it/core/RBACOnLoadTest.java
@@ -230,7 +230,7 @@ class RBACOnLoadTest {
 
     @Test
     void testBoostedPrivilegesOverridesLoadPrivileges() throws IOException {
-        String url = "https://neo4j.com/docs/cypher-refcard/3.3/csv/artists.csv";
+        String url = "https://data.neo4j.com/bands/artists.csv";
         addRBACOnLoad(url, "testUserWithBoostedPrivileges");
 
         testCall(


### PR DESCRIPTION
The csv file we were calling in the IT tests was a url that got a bot check added to it, the bot check returns different info than other failing cases, and it got stuck in a while loop looking for a null value instead of EoF.