### PR TITLE
Add IOException throws declaration to CountingInputStream constructor…

### DIFF
--- a/common/src/main/java/apoc/export/util/CountingInputStream.java
+++ b/common/src/main/java/apoc/export/util/CountingInputStream.java
@@ -35,12 +35,12 @@ public class CountingInputStream extends FilterInputStream implements SizeCounte
     private final long total;
     private long count = 0;
 
-    public CountingInputStream(InputStream stream, long total) {
+    public CountingInputStream(InputStream stream, long total) throws IOException {
         super(toBufferedStream(stream, total));
         this.total = total;
     }
 
-    private static BufferedInputStream toBufferedStream(InputStream stream, long total) {
+    private static BufferedInputStream toBufferedStream(InputStream stream, long total) throws IOException {
         final BOMInputStream bomInputStream = new BOMInputStream(stream);
 
         InputStream sizeInputStream = toLimitedIStream(bomInputStream, total);


### PR DESCRIPTION
Cherry picks (#926) since we 5.26 has also bumped the dependency of apache commons configuration2.
