### PR TITLE
Updated assertion in MetaCommunityFeaturesTest.schema

### DIFF
--- a/it/src/test/java/apoc/it/core/MetaCommunityFeaturesTest.java
+++ b/it/src/test/java/apoc/it/core/MetaCommunityFeaturesTest.java
@@ -44,7 +44,7 @@ class MetaCommunityFeaturesTest extends AbstractDockerTestBase {
                         "count": 1,
                         "relationships": {
                           "R": {
-                            "count": 0,
+                            "count": 1,
                             "properties": {
                               "r": {
                                 "existence": false,


### PR DESCRIPTION
Assertion should have been updated together with  [SURF 1040: Fix Zero/inaccurate relationships count from apoc.meta.schema
](https://github.com/neo4j/apoc/commit/8275283f7253e4e28cafcacff659039a41f7f66c) but for some reason wasn't.