### PR TITLE
SURF-1191: Fix flaky Util test and clean up withBackOffRetries function

### DIFF
--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -1339,32 +1339,30 @@ public class Util {
     }
 
     public static <T> T withBackOffRetries(Supplier<T> func, long initialTimeout, long upperTimeout, Log log) {
-        T result = null;
         var startTime = System.currentTimeMillis();
         var timeout = initialTimeout;
-        var lastTry = startTime - timeout;
 
         while (true) {
-            var timeStamp = System.currentTimeMillis();
-            if (timeStamp - lastTry >= timeout) {
-                try {
-                    result = func.get();
-                    break;
-                } catch (Exception e) {
-                    if (timeout >= upperTimeout) {
-                        Long totalTime = (System.currentTimeMillis() - startTime) / 1000;
-                        if (log.isDebugEnabled()) {
-                            log.debug(String.format(
-                                    "Got %s: %s after %s seconds.", e.getClass(), e.getMessage(), totalTime));
-                        }
-                        throw e;
+            try {
+                return func.get();
+            } catch (Exception e) {
+                if (timeout >= upperTimeout) {
+                    Long totalTime = (System.currentTimeMillis() - startTime) / 1000;
+                    if (log.isDebugEnabled()) {
+                        log.debug(
+                                String.format("Got %s: %s after %s seconds.", e.getClass(), e.getMessage(), totalTime));
                     }
+                    throw e;
                 }
-                lastTry = timeStamp;
                 timeout *= 2;
+                try {
+                    Thread.sleep(timeout);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw e;
+                }
             }
         }
-        return result;
     }
 
     public static String getCypherVersionString(ProcedureCallContext procedureCallContext) {

--- a/core/src/test/java/apoc/util/UtilTest.java
+++ b/core/src/test/java/apoc/util/UtilTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.neo4j.test.extension.EnterpriseDbmsExtension;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -197,37 +198,37 @@ class UtilTest {
 
     @Test
     void testWithBackOffRetriesWithSuccess() {
+        AtomicInteger counter = new AtomicInteger();
         long start = System.currentTimeMillis();
-        int result = Util.withBackOffRetries(this::testFunction, 100, 2000, NullLog.getInstance());
+        int result = Util.withBackOffRetries(() -> testFunction(counter), 100, 2000, NullLog.getInstance());
         long time = System.currentTimeMillis() - start;
 
         assertEquals(4, result);
 
         // The method should be run directly, after 200ms, after 400ms and after 800 ms when it will succeed
-        // So the total time should be roughly 1400 ms
-        assertTrue(time > 1300 && time < 1500, "Expected time to be in the interval 1300 ms - 1500 ms but was " + time);
+        // So the total time should be roughly 1400 ms. Allow generous slack for CI scheduling jitter.
+        assertTrue(time > 1200 && time < 1900, "Expected time to be in the interval 1200 ms - 1900 ms but was " + time);
     }
 
     @Test
     void testWithBackOffRetriesWithError() {
+        AtomicInteger counter = new AtomicInteger();
         long start = System.currentTimeMillis();
         assertThrows(
                 RuntimeException.class,
-                () -> Util.withBackOffRetries(this::testFunction, 100, 300, NullLog.getInstance()));
+                () -> Util.withBackOffRetries(() -> testFunction(counter), 100, 300, NullLog.getInstance()));
 
         // The method should be run directly, after 200ms and after 400ms when it will fail
-        // So the total time should be roughly 600 ms
+        // So the total time should be roughly 600 ms. Allow generous slack for CI scheduling jitter.
         long time = System.currentTimeMillis() - start;
-        assertTrue(time > 550);
-        assertTrue(time < 650);
+        assertTrue(time > 500 && time < 900, "Expected time to be in the interval 500 ms - 900 ms but was " + time);
     }
 
-    private static int i = 0;
-
-    private int testFunction() {
-        if (++i % 4 != 0) {
+    private int testFunction(AtomicInteger counter) {
+        int value = counter.incrementAndGet();
+        if (value % 4 != 0) {
             throw new RuntimeException("Unexpected i");
         }
-        return i;
+        return value;
     }
 }


### PR DESCRIPTION
Attempts to fix a flaky test related to withBackOffRetries as well as cleans up how the function works