### PR TITLE
Close cursor-backed resources to prevent leaks at commit 

### DIFF
--- a/common/src/main/java/apoc/export/cypher/formatter/CypherFormatterUtils.java
+++ b/common/src/main/java/apoc/export/cypher/formatter/CypherFormatterUtils.java
@@ -32,6 +32,7 @@ import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.values.storable.DurationValue;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
@@ -163,12 +164,11 @@ public class CypherFormatterUtils {
      * Returns true if there exists no other relationship with the same start node, end node and type
      */
     public static boolean isUniqueRelationship(Relationship rel) {
-        return StreamSupport.stream(
-                        rel.getStartNode()
-                                .getRelationships(Direction.OUTGOING, rel.getType())
-                                .spliterator(),
-                        false)
-                .noneMatch(r -> !r.equals(rel) && r.getEndNode().equals(rel.getEndNode()));
+        try (ResourceIterable<Relationship> rels =
+                rel.getStartNode().getRelationships(Direction.OUTGOING, rel.getType())) {
+            return StreamSupport.stream(rels.spliterator(), false)
+                    .noneMatch(r -> !r.equals(rel) && r.getEndNode().equals(rel.getEndNode()));
+        }
     }
 
     // ---- properties ----

--- a/common/src/main/java/apoc/export/util/MetaInformation.java
+++ b/common/src/main/java/apoc/export/util/MetaInformation.java
@@ -39,6 +39,7 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.ResultTransformer;
 
 /**
@@ -53,8 +54,10 @@ public class MetaInformation {
             SubGraph graph, GraphDatabaseService db, ExportConfig config) {
         if (!config.isSampling()) {
             Map<String, Class> propTypes = new LinkedHashMap<>();
-            for (Node node : graph.getNodes()) {
-                updateKeyTypes(propTypes, node);
+            try (ResourceIterable<Node> nodes = graph.getNodes()) {
+                for (Node node : nodes) {
+                    updateKeyTypes(propTypes, node);
+                }
             }
             return propTypes;
         }
@@ -71,8 +74,10 @@ public class MetaInformation {
             SubGraph graph, GraphDatabaseService db, ExportConfig config) {
         if (!config.isSampling()) {
             Map<String, Class> propTypes = new LinkedHashMap<>();
-            for (Relationship relationship : graph.getRelationships()) {
-                updateKeyTypes(propTypes, relationship);
+            try (ResourceIterable<Relationship> relationships = graph.getRelationships()) {
+                for (Relationship relationship : relationships) {
+                    updateKeyTypes(propTypes, relationship);
+                }
             }
             return propTypes;
         }

--- a/common/src/main/java/apoc/graph/document/builder/DocumentToGraph.java
+++ b/common/src/main/java/apoc/graph/document/builder/DocumentToGraph.java
@@ -35,6 +35,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.ResourceIterable;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 
 public class DocumentToGraph {
@@ -377,12 +379,14 @@ public class DocumentToGraph {
         }
 
         public Node getOrCreateRealNode(Label[] labels, Map<String, Object> idValues) {
-            return Stream.of(labels)
-                    .map(label -> tx.findNodes(label, idValues))
-                    .filter(it -> it.hasNext())
-                    .map(it -> it.next())
-                    .findFirst()
-                    .orElseGet(() -> tx.createNode(labels));
+            for (Label label : labels) {
+                try (ResourceIterator<Node> it = tx.findNodes(label, idValues)) {
+                    if (it.hasNext()) {
+                        return it.next();
+                    }
+                }
+            }
+            return tx.createNode(labels);
         }
 
         public Node getOrCreateVirtualNode(
@@ -399,13 +403,15 @@ public class DocumentToGraph {
                             Map<String, Object> ids = filterNodeIdProperties(n, idValues);
                             return idValues.equals(ids);
                         }
-                        return StreamSupport.stream(n.getRelationships().spliterator(), false)
-                                .anyMatch(r -> {
-                                    Node otherNode = r.getOtherNode(n);
-                                    Map<String, Object> ids = filterNodeIdProperties(otherNode, idValues);
-                                    return Stream.of(labels).anyMatch(label -> otherNode.hasLabel(label))
-                                            && idValues.equals(ids);
-                                });
+                        try (ResourceIterable<Relationship> rels = n.getRelationships()) {
+                            return StreamSupport.stream(rels.spliterator(), false)
+                                    .anyMatch(r -> {
+                                        Node otherNode = r.getOtherNode(n);
+                                        Map<String, Object> ids = filterNodeIdProperties(otherNode, idValues);
+                                        return Stream.of(labels).anyMatch(label -> otherNode.hasLabel(label))
+                                                && idValues.equals(ids);
+                                    });
+                        }
                     })
                     .findFirst()
                     .orElseGet(() -> new VirtualNode(labels, Collections.emptyMap()));

--- a/common/src/main/java/apoc/graph/document/builder/RelationshipBuilder.java
+++ b/common/src/main/java/apoc/graph/document/builder/RelationshipBuilder.java
@@ -28,6 +28,7 @@ import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterable;
 
 public class RelationshipBuilder {
 
@@ -53,9 +54,10 @@ public class RelationshipBuilder {
     }
 
     private List<Relationship> getRelationshipsForRealNodes(Node parent, Node child, RelationshipType type) {
-        Iterable<Relationship> relationships = child.getRelationships(Direction.INCOMING, type);
-        return StreamSupport.stream(relationships.spliterator(), false)
-                .filter(rel -> rel.getOtherNode(child).equals(parent))
-                .collect(Collectors.toList());
+        try (ResourceIterable<Relationship> relationships = child.getRelationships(Direction.INCOMING, type)) {
+            return StreamSupport.stream(relationships.spliterator(), false)
+                    .filter(rel -> rel.getOtherNode(child).equals(parent))
+                    .collect(Collectors.toList());
+        }
     }
 }

--- a/common/src/main/java/apoc/meta/Tables4LabelsProfile.java
+++ b/common/src/main/java/apoc/meta/Tables4LabelsProfile.java
@@ -219,23 +219,25 @@ public class Tables4LabelsProfile {
             int out = n.getDegree(type, Direction.OUTGOING);
             if (out == 0) continue;
 
-            for (Relationship r : n.getRelationships(Direction.OUTGOING, type)) {
-                Iterable relStartNode = r.getStartNode().getLabels();
-                Iterable relEndNode = r.getEndNode().getLabels();
+            try (ResourceIterable<Relationship> rels = n.getRelationships(Direction.OUTGOING, type)) {
+                for (Relationship r : rels) {
+                    Iterable relStartNode = r.getStartNode().getLabels();
+                    Iterable relEndNode = r.getEndNode().getLabels();
 
-                String relIdentifier = labelJoin(relStartNode) + "###" + labelJoin(relEndNode) + "###" + typeName;
+                    String relIdentifier = labelJoin(relStartNode) + "###" + labelJoin(relEndNode) + "###" + typeName;
 
-                PropertyContainerProfile localRelProfile = getRelProfile(relIdentifier);
-                long seenSoFar = sawRel(relIdentifier);
-                boolean isNode = false;
+                    PropertyContainerProfile localRelProfile = getRelProfile(relIdentifier);
+                    long seenSoFar = sawRel(relIdentifier);
+                    boolean isNode = false;
 
-                if (seenSoFar > config.getMaxRels()) {
-                    // We've seen more than the maximum sample size for this rel, so
-                    // we don't need to keep looking.
-                    continue;
+                    if (seenSoFar > config.getMaxRels()) {
+                        // We've seen more than the maximum sample size for this rel, so
+                        // we don't need to keep looking.
+                        continue;
+                    }
+
+                    localRelProfile.observe(r, isNode);
                 }
-
-                localRelProfile.observe(r, isNode);
             }
         }
     }

--- a/common/src/main/java/apoc/result/VirtualGraph.java
+++ b/common/src/main/java/apoc/result/VirtualGraph.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.procedure.Description;
 
 /**
@@ -43,16 +44,24 @@ public class VirtualGraph {
                 "name",
                 name,
                 "nodes",
-                nodes instanceof Set
-                        ? nodes
-                        : StreamSupport.stream(nodes.spliterator(), false).collect(Collectors.toSet()),
+                toGraphCollection(nodes),
                 "relationships",
-                relationships instanceof Set
-                        ? relationships
-                        : StreamSupport.stream(relationships.spliterator(), false)
-                                .collect(Collectors.toSet()),
+                toGraphCollection(relationships),
                 "properties",
                 properties);
+    }
+
+    private static <T> Object toGraphCollection(Iterable<T> iterable) {
+        if (iterable instanceof Set) {
+            return iterable;
+        }
+        if (iterable instanceof ResourceIterable) {
+            try (ResourceIterable<T> resourceIterable = (ResourceIterable<T>) iterable) {
+                return StreamSupport.stream(resourceIterable.spliterator(), false)
+                        .collect(Collectors.toSet());
+            }
+        }
+        return StreamSupport.stream(iterable.spliterator(), false).collect(Collectors.toSet());
     }
 
     public Collection<Node> nodes() {

--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -990,17 +990,20 @@ public class Util {
 
     public static Node mergeNode(
             Transaction tx, Label primaryLabel, Label addtionalLabel, Pair<String, Object>... pairs) {
-        Node node = Iterators.singleOrNull(tx.findNodes(primaryLabel, pairs[0].getLeft(), pairs[0].getRight()).stream()
-                .filter(n -> addtionalLabel == null || n.hasLabel(addtionalLabel))
-                .filter(n -> {
-                    for (int i = 1; i < pairs.length; i++) {
-                        if (!Objects.deepEquals(pairs[i].getRight(), n.getProperty(pairs[i].getLeft(), null))) {
-                            return false;
+        Node node;
+        try (ResourceIterator<Node> nodes = tx.findNodes(primaryLabel, pairs[0].getLeft(), pairs[0].getRight())) {
+            node = Iterators.singleOrNull(nodes.stream()
+                    .filter(n -> addtionalLabel == null || n.hasLabel(addtionalLabel))
+                    .filter(n -> {
+                        for (int i = 1; i < pairs.length; i++) {
+                            if (!Objects.deepEquals(pairs[i].getRight(), n.getProperty(pairs[i].getLeft(), null))) {
+                                return false;
+                            }
                         }
-                    }
-                    return true;
-                })
-                .iterator());
+                        return true;
+                    })
+                    .iterator());
+        }
         if (node == null) {
             Label[] labels =
                     addtionalLabel == null ? new Label[] {primaryLabel} : new Label[] {primaryLabel, addtionalLabel};

--- a/common/src/main/java/apoc/util/kernel/MultiThreadedGlobalGraphOperations.java
+++ b/common/src/main/java/apoc/util/kernel/MultiThreadedGlobalGraphOperations.java
@@ -117,24 +117,39 @@ public class MultiThreadedGlobalGraphOperations {
             try (InternalTransaction tx =
                     db.beginTransaction(KernelTransaction.Type.EXPLICIT, LoginContext.AUTH_DISABLED)) {
                 KernelTransaction ktx = tx.kernelTransaction();
-                ktx.acquireStatement();
-                ExecutionContext executionContext = ktx.createExecutionContext();
-                try (NodeCursor cursor = cursorAllocator.apply(ktx)) {
-                    while (scan.reservePartition(cursor, executionContext)) {
-                        // Branch out so that all available threads will get saturated
-                        executorService.submit(new BatchJob(
-                                scan, batchSize, db, consumer, result, cursorAllocator, executorService, processing));
-                        executorService.submit(new BatchJob(
-                                scan, batchSize, db, consumer, result, cursorAllocator, executorService, processing));
-                        while (processAndReport(cursor)) {
-                            // just continue processing...
+                try (var statement = ktx.acquireStatement()) {
+                    ExecutionContext executionContext = ktx.createExecutionContext();
+                    try (NodeCursor cursor = cursorAllocator.apply(ktx)) {
+                        while (scan.reservePartition(cursor, executionContext)) {
+                            // Branch out so that all available threads will get saturated
+                            executorService.submit(new BatchJob(
+                                    scan,
+                                    batchSize,
+                                    db,
+                                    consumer,
+                                    result,
+                                    cursorAllocator,
+                                    executorService,
+                                    processing));
+                            executorService.submit(new BatchJob(
+                                    scan,
+                                    batchSize,
+                                    db,
+                                    consumer,
+                                    result,
+                                    cursorAllocator,
+                                    executorService,
+                                    processing));
+                            while (processAndReport(cursor)) {
+                                // just continue processing...
+                            }
                         }
                     }
+                    tx.commit();
+                    executionContext.complete();
+                    executionContext.close();
+                    return null;
                 }
-                tx.commit();
-                executionContext.complete();
-                executionContext.close();
-                return null;
             } finally {
                 result.batches.incrementAndGet();
                 processing.decrementAndGet();

--- a/common/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
+++ b/common/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
@@ -169,16 +169,18 @@ public class CypherResultSubGraph implements SubGraph {
     private void addRelationshipsBetweenNodes() {
         Set<Node> newNodes = new HashSet<>();
         for (Node node : nodes.values()) {
-            for (Relationship relationship : node.getRelationships()) {
-                if (!relationships.containsKey(relationship.getElementId())) {
-                    continue;
-                }
+            try (ResourceIterable<Relationship> rels = node.getRelationships()) {
+                for (Relationship relationship : rels) {
+                    if (!relationships.containsKey(relationship.getElementId())) {
+                        continue;
+                    }
 
-                final Node other = relationship.getOtherNode(node);
-                if (nodes.containsKey(other.getElementId()) || newNodes.contains(other)) {
-                    continue;
+                    final Node other = relationship.getOtherNode(node);
+                    if (nodes.containsKey(other.getElementId()) || newNodes.contains(other)) {
+                        continue;
+                    }
+                    newNodes.add(other);
                 }
-                newNodes.add(other);
             }
         }
         for (Node node : newNodes) {

--- a/common/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
+++ b/common/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
@@ -30,6 +30,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.ResourceIterable;
+import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
@@ -107,18 +108,18 @@ public class DatabaseSubGraph implements SubGraph {
         String startNode = cypherNode(start);
         String endNode = cypherNode(end);
         String relationship = String.format("[r:%s]", quote(type.name()));
-        return transaction
-                .execute(String.format("MATCH %s-%s->%s RETURN count(r) AS count", startNode, relationship, endNode))
-                .<Long>columnAs("count")
-                .next();
+        try (Result result = transaction.execute(
+                String.format("MATCH %s-%s->%s RETURN count(r) AS count", startNode, relationship, endNode))) {
+            return result.<Long>columnAs("count").next();
+        }
     }
 
     @Override
     public long countsForNode(Label label) {
-        return transaction
-                .execute(String.format("MATCH (n:%s) RETURN count(n) AS count", quote(label.name())))
-                .<Long>columnAs("count")
-                .next();
+        try (Result result =
+                transaction.execute(String.format("MATCH (n:%s) RETURN count(n) AS count", quote(label.name())))) {
+            return result.<Long>columnAs("count").next();
+        }
     }
 
     @Override

--- a/core/src/main/java/apoc/atomic/Atomic.java
+++ b/core/src/main/java/apoc/atomic/Atomic.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.neo4j.exceptions.Neo4jException;
 import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.NotFoundException;
+import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.kernel.api.procs.ProcedureCallContext;
 import org.neo4j.procedure.*;
@@ -288,7 +289,10 @@ public class Atomic {
                     String statement = "WITH $container AS n WITH n SET n." + Util.sanitize(property, true) + "="
                             + operation + ";";
                     Map<String, Object> properties = MapUtil.map("container", entity);
-                    return context.tx.execute(Util.prefixQuery(procedureCallContext, statement), properties);
+                    try (Result result =
+                            context.tx.execute(Util.prefixQuery(procedureCallContext, statement), properties)) {
+                        return result.resultAsString();
+                    }
                 },
                 retryAttempts);
 

--- a/core/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/core/src/main/java/apoc/export/csv/CsvFormat.java
@@ -58,6 +58,7 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
@@ -202,12 +203,16 @@ public class CsvFormat {
 
     private void writeAllBulkImport(
             InternalTransaction threadBoundTx, SubGraph graph, Reporter reporter, ExportFileManager writer) {
-        Map<Iterable<Label>, List<Node>> objectNodes = StreamSupport.stream(
-                        graph.getNodes().spliterator(), false)
-                .collect(Collectors.groupingBy(Node::getLabels));
-        Map<RelationshipType, List<Relationship>> objectRels = StreamSupport.stream(
-                        graph.getRelationships().spliterator(), false)
-                .collect(Collectors.groupingBy(Relationship::getType));
+        Map<Iterable<Label>, List<Node>> objectNodes;
+        try (ResourceIterable<Node> nodes = graph.getNodes()) {
+            objectNodes =
+                    StreamSupport.stream(nodes.spliterator(), false).collect(Collectors.groupingBy(Node::getLabels));
+        }
+        Map<RelationshipType, List<Relationship>> objectRels;
+        try (ResourceIterable<Relationship> rels = graph.getRelationships()) {
+            objectRels = StreamSupport.stream(rels.spliterator(), false)
+                    .collect(Collectors.groupingBy(Relationship::getType));
+        }
         writeNodesBulkImport(threadBoundTx, reporter, writer, objectNodes);
         writeRelsBulkImport(threadBoundTx, reporter, writer, objectRels);
     }
@@ -358,15 +363,17 @@ public class CsvFormat {
             boolean keepNulls) {
         String[] row = new String[cols];
         int nodes = 0;
-        for (Node node : graph.getNodes()) {
-            row[0] = String.valueOf(getNodeId(threadBoundTx, node.getElementId()));
-            row[1] = getLabelsString(node);
-            collectProps(nodePropTypes, node, reporter, row, 2, keepNulls);
-            out.writeNext(row, applyQuotesToAll);
-            nodes++;
-            if (batchSize == -1 || nodes % batchSize == 0) {
-                reporter.update(nodes, 0, 0);
-                nodes = 0;
+        try (ResourceIterable<Node> nodeIterable = graph.getNodes()) {
+            for (Node node : nodeIterable) {
+                row[0] = String.valueOf(getNodeId(threadBoundTx, node.getElementId()));
+                row[1] = getLabelsString(node);
+                collectProps(nodePropTypes, node, reporter, row, 2, keepNulls);
+                out.writeNext(row, applyQuotesToAll);
+                nodes++;
+                if (batchSize == -1 || nodes % batchSize == 0) {
+                    reporter.update(nodes, 0, 0);
+                    nodes = 0;
+                }
             }
         }
         if (nodes > 0) {
@@ -401,18 +408,20 @@ public class CsvFormat {
             boolean keepNull) {
         String[] row = new String[cols];
         int rels = 0;
-        for (Relationship rel : graph.getRelationships()) {
-            row[offset] =
-                    String.valueOf(getNodeId(threadBoundTx, rel.getStartNode().getElementId()));
-            row[offset + 1] =
-                    String.valueOf(getNodeId(threadBoundTx, rel.getEndNode().getElementId()));
-            row[offset + 2] = rel.getType().name();
-            collectProps(relPropNames, rel, reporter, row, 3 + offset, keepNull);
-            out.writeNext(row, applyQuotesToAll);
-            rels++;
-            if (batchSize == -1 || rels % batchSize == 0) {
-                reporter.update(0, rels, 0);
-                rels = 0;
+        try (ResourceIterable<Relationship> relIterable = graph.getRelationships()) {
+            for (Relationship rel : relIterable) {
+                row[offset] = String.valueOf(
+                        getNodeId(threadBoundTx, rel.getStartNode().getElementId()));
+                row[offset + 1] =
+                        String.valueOf(getNodeId(threadBoundTx, rel.getEndNode().getElementId()));
+                row[offset + 2] = rel.getType().name();
+                collectProps(relPropNames, rel, reporter, row, 3 + offset, keepNull);
+                out.writeNext(row, applyQuotesToAll);
+                rels++;
+                if (batchSize == -1 || rels % batchSize == 0) {
+                    reporter.update(0, rels, 0);
+                    rels = 0;
+                }
             }
         }
         if (rels > 0) {

--- a/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
+++ b/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
@@ -107,9 +107,10 @@ public class MultiStatementCypherSubGraphExporter {
                 artificialUniqueNodes += countArtificialUniqueNodes(graph.getNodes());
                 // In this code path an artificial relationship property is added for each relationship
                 if (exportConfig.isMultipleRelationshipsWithType()) {
-                    artificialUniqueRels += StreamSupport.stream(
-                                    graph.getRelationships().spliterator(), false)
-                            .count();
+                    try (ResourceIterable<Relationship> rels = graph.getRelationships()) {
+                        artificialUniqueRels +=
+                                StreamSupport.stream(rels.spliterator(), false).count();
+                    }
                 }
                 exportSchema(schemaWriter, config);
                 reporter.update(0, 0, 0);
@@ -162,10 +163,12 @@ public class MultiStatementCypherSubGraphExporter {
 
     private long appendNodes(PrintWriter out, int batchSize, Reporter reporter) {
         long count = 0;
-        for (Node node : graph.getNodes()) {
-            if (count > 0 && count % batchSize == 0) restart(out);
-            count++;
-            appendNode(out, node, reporter);
+        try (ResourceIterable<Node> nodes = graph.getNodes()) {
+            for (Node node : nodes) {
+                if (count > 0 && count % batchSize == 0) restart(out);
+                count++;
+                appendNode(out, node, reporter);
+            }
         }
         return count;
     }
@@ -207,10 +210,12 @@ public class MultiStatementCypherSubGraphExporter {
 
     private long appendRelationships(PrintWriter out, int batchSize, Reporter reporter) {
         long count = 0;
-        for (Relationship rel : graph.getRelationships()) {
-            if (count > 0 && count % batchSize == 0) restart(out);
-            count++;
-            appendRelationship(out, rel, reporter);
+        try (ResourceIterable<Relationship> rels = graph.getRelationships()) {
+            for (Relationship rel : rels) {
+                if (count > 0 && count % batchSize == 0) restart(out);
+                count++;
+                appendRelationship(out, rel, reporter);
+            }
         }
         return count;
     }
@@ -437,8 +442,10 @@ public class MultiStatementCypherSubGraphExporter {
 
     public long countArtificialUniqueNodes(ResourceIterable<Node> n) {
         long artificialUniques = 0;
-        for (Node node : n) {
-            artificialUniques = getArtificialUniqueNodes(node, artificialUniques);
+        try (n) {
+            for (Node node : n) {
+                artificialUniques = getArtificialUniqueNodes(node, artificialUniques);
+            }
         }
         return artificialUniques;
     }

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLWriter.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLWriter.java
@@ -33,6 +33,7 @@ import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.ResourceIterable;
 
 /**
  * @author mh
@@ -46,13 +47,17 @@ public class XmlGraphMLWriter {
         writeHeader(xmlWriter);
         writeKey(xmlWriter, graph, config);
         writeGraph(xmlWriter);
-        for (Node node : graph.getNodes()) {
-            int props = writeNode(xmlWriter, node, config);
-            reporter.update(1, 0, props);
+        try (ResourceIterable<Node> nodes = graph.getNodes()) {
+            for (Node node : nodes) {
+                int props = writeNode(xmlWriter, node, config);
+                reporter.update(1, 0, props);
+            }
         }
-        for (Relationship rel : graph.getRelationships()) {
-            int props = writeRelationship(xmlWriter, rel, config);
-            reporter.update(0, 1, props);
+        try (ResourceIterable<Relationship> rels = graph.getRelationships()) {
+            for (Relationship rel : rels) {
+                int props = writeRelationship(xmlWriter, rel, config);
+                reporter.update(0, 1, props);
+            }
         }
         writeFooter(xmlWriter);
         reporter.done();
@@ -60,15 +65,17 @@ public class XmlGraphMLWriter {
 
     private void writeKey(XMLStreamWriter writer, SubGraph ops, ExportConfig config) throws Exception {
         Map<String, Class> keyTypes = new HashMap<>();
-        for (Node node : ops.getNodes()) {
-            if (node.getLabels().iterator().hasNext()) {
-                if (config.getFormat() == ExportFormat.TINKERPOP) {
-                    keyTypes.put("labelV", String.class);
-                } else {
-                    keyTypes.put("labels", String.class);
+        try (ResourceIterable<Node> nodes = ops.getNodes()) {
+            for (Node node : nodes) {
+                if (node.getLabels().iterator().hasNext()) {
+                    if (config.getFormat() == ExportFormat.TINKERPOP) {
+                        keyTypes.put("labelV", String.class);
+                    } else {
+                        keyTypes.put("labels", String.class);
+                    }
                 }
+                updateKeyTypes(keyTypes, node);
             }
-            updateKeyTypes(keyTypes, node);
         }
         boolean useTypes = config.useTypes();
         ExportFormat format = config.getFormat();
@@ -77,13 +84,15 @@ public class XmlGraphMLWriter {
         }
         writeKey(writer, keyTypes, "node", useTypes);
         keyTypes.clear();
-        for (Relationship rel : ops.getRelationships()) {
-            if (config.getFormat() == ExportFormat.TINKERPOP) {
-                keyTypes.put("labelE", String.class);
-            } else {
-                keyTypes.put("label", String.class);
+        try (ResourceIterable<Relationship> rels = ops.getRelationships()) {
+            for (Relationship rel : rels) {
+                if (config.getFormat() == ExportFormat.TINKERPOP) {
+                    keyTypes.put("labelE", String.class);
+                } else {
+                    keyTypes.put("label", String.class);
+                }
+                updateKeyTypes(keyTypes, rel);
             }
-            updateKeyTypes(keyTypes, rel);
         }
         if (format == ExportFormat.GEPHI) {
             keyTypes.put("TYPE", String.class);

--- a/core/src/main/java/apoc/export/json/JsonFormat.java
+++ b/core/src/main/java/apoc/export/json/JsonFormat.java
@@ -190,8 +190,22 @@ public class JsonFormat {
 
     private void writeNodes(Iterable<Node> nodes, Reporter reporter, JsonGenerator jsonGenerator, ExportConfig config)
             throws IOException {
-        for (Node node : nodes) {
-            writeNode(reporter, jsonGenerator, node, config);
+        try {
+            for (Node node : nodes) {
+                writeNode(reporter, jsonGenerator, node, config);
+            }
+        } finally {
+            closeIfResource(nodes);
+        }
+    }
+
+    private static void closeIfResource(Object o) {
+        if (o instanceof AutoCloseable ac) {
+            try {
+                ac.close();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 
@@ -217,8 +231,12 @@ public class JsonFormat {
     private void writeRels(
             Iterable<Relationship> rels, Reporter reporter, JsonGenerator jsonGenerator, ExportConfig config)
             throws IOException {
-        for (Relationship rel : rels) {
-            writeRel(reporter, jsonGenerator, rel, config);
+        try {
+            for (Relationship rel : rels) {
+                writeRel(reporter, jsonGenerator, rel, config);
+            }
+        } finally {
+            closeIfResource(rels);
         }
     }
 

--- a/core/src/main/java/apoc/graph/Graphs.java
+++ b/core/src/main/java/apoc/graph/Graphs.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.kernel.api.procs.ProcedureCallContext;
 import org.neo4j.procedure.*;
@@ -134,19 +135,18 @@ public class Graphs {
         Set<Node> nodes = new HashSet<>(1000);
         Set<Relationship> rels = new HashSet<>(1000);
         Map<String, Object> props = new HashMap<>(properties);
-        tx
-                .execute(
-                        Util.prefixQueryWithCheck(
-                                procedureCallContext, CypherUtils.withParamMapping(statement, params.keySet())),
-                        params)
-                .stream()
-                .forEach(row -> {
-                    row.forEach((k, v) -> {
-                        if (!extract(v, nodes, rels)) {
-                            props.put(k, v);
-                        }
-                    });
+        try (Result result = tx.execute(
+                Util.prefixQueryWithCheck(
+                        procedureCallContext, CypherUtils.withParamMapping(statement, params.keySet())),
+                params)) {
+            result.stream().forEach(row -> {
+                row.forEach((k, v) -> {
+                    if (!extract(v, nodes, rels)) {
+                        props.put(k, v);
+                    }
                 });
+            });
+        }
         return Stream.of(new VirtualGraph(name, nodes, rels, props));
     }
 

--- a/core/src/main/java/apoc/hashing/Fingerprinting.java
+++ b/core/src/main/java/apoc/hashing/Fingerprinting.java
@@ -36,6 +36,7 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
@@ -174,14 +175,17 @@ public class Fingerprinting {
                 FingerprintingConfig.FingerprintStrategy.EAGER.toString()));
         return withMessageDigest(config, messageDigest -> {
             // step 1: load all nodes, calc their hash and map them to id
-            Map<Long, String> idToNodeHash = tx.getAllNodes().stream()
-                    .collect(Collectors.toMap(
-                            Node::getId,
-                            node -> fingerprint(node, config),
-                            (aLong, aLong2) -> {
-                                throw new RuntimeException();
-                            },
-                            () -> new TreeMap<>()));
+            Map<Long, String> idToNodeHash;
+            try (ResourceIterable<Node> allNodes = tx.getAllNodes()) {
+                idToNodeHash = allNodes.stream()
+                        .collect(Collectors.toMap(
+                                Node::getId,
+                                node -> fingerprint(node, config),
+                                (aLong, aLong2) -> {
+                                    throw new RuntimeException();
+                                },
+                                () -> new TreeMap<>()));
+            }
 
             // step 2: build inverse map
             final Map<String, List<Long>> nodeHashToId = idToNodeHash.entrySet().stream()
@@ -194,14 +198,16 @@ public class Fingerprinting {
             nodeHashToId.forEach((hash, ids) -> ids.forEach(id -> {
                 messageDigest.update(hash.getBytes());
                 Node node = tx.getNodeById(id);
-                List<EndNodeRelationshipHashTuple> endNodeRelationshipHashTuples = StreamSupport.stream(
-                                node.getRelationships(Direction.OUTGOING).spliterator(), false)
-                        .map(relationship -> {
-                            String endNodeHash = idToNodeHash.get(relationship.getEndNodeId());
-                            String relationshipHash = fingerprint(relationship, excludedPropertyKeys);
-                            return new EndNodeRelationshipHashTuple(endNodeHash, relationshipHash);
-                        })
-                        .collect(Collectors.toList());
+                List<EndNodeRelationshipHashTuple> endNodeRelationshipHashTuples;
+                try (ResourceIterable<Relationship> nodeRels = node.getRelationships(Direction.OUTGOING)) {
+                    endNodeRelationshipHashTuples = StreamSupport.stream(nodeRels.spliterator(), false)
+                            .map(relationship -> {
+                                String endNodeHash = idToNodeHash.get(relationship.getEndNodeId());
+                                String relationshipHash = fingerprint(relationship, excludedPropertyKeys);
+                                return new EndNodeRelationshipHashTuple(endNodeHash, relationshipHash);
+                            })
+                            .collect(Collectors.toList());
+                }
 
                 endNodeRelationshipHashTuples.stream().sorted().forEach(endNodeRelationshipHashTuple -> {
                     messageDigest.update(

--- a/core/src/main/java/apoc/help/Help.java
+++ b/core/src/main/java/apoc/help/Help.java
@@ -23,6 +23,7 @@ import static apoc.util.Util.map;
 import apoc.util.Util;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.kernel.api.procs.ProcedureCallContext;
 import org.neo4j.kernel.api.QueryLanguage;
@@ -68,16 +69,20 @@ public class Help {
                 "SHOW FUNCTIONS yield name, description, signature, isDeprecated " + filter
                         + "RETURN 'function' as type, name, description, signature, isDeprecated ");
         Map<String, Object> params = map("name", name, "desc", searchText ? name : null);
-        Stream<Map<String, Object>> proceduresResults = tx.execute(proceduresQuery, params).stream();
-        Stream<Map<String, Object>> functionsResults = tx.execute(functionsQuery, params).stream();
+        // Keep the Result handles so both are closed when the returned stream is closed; otherwise a
+        // downstream LIMIT satisfied from the first stream would leave the second Result's cursor open.
+        Result proceduresResults = tx.execute(proceduresQuery, params);
+        Result functionsResults = tx.execute(functionsQuery, params);
 
-        return Stream.of(proceduresResults, functionsResults)
+        return Stream.of(proceduresResults.stream(), functionsResults.stream())
                 .flatMap(results -> results.map(row -> new HelpResult(
                         row,
                         existsInCore(
                                 (String) row.get("name"),
                                 procedureCallContext.calledwithQueryLanguage().equals(QueryLanguage.CYPHER_5),
-                                row.get("type").equals("function")))));
+                                row.get("type").equals("function")))))
+                .onClose(proceduresResults::close)
+                .onClose(functionsResults::close);
     }
 
     private boolean existsInCore(String name, boolean version5, boolean function) {

--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -43,6 +43,7 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
@@ -409,13 +410,15 @@ public class Meta {
         relMeta.elementType(Types.of(node).name());
         relMeta.inc().rel(out, in);
         relNodeMeta.inc().rel(out, in);
-        for (Relationship rel : node.getRelationships(Direction.OUTGOING, type)) {
-            Node endNode = rel.getEndNode();
-            List<String> labels = toStrings(endNode.getLabels());
-            relMeta.other(labels);
-            relNodeMeta.other(labels);
-            addProperties(typeMeta, type.name(), relConstraints, indexes, rel, node);
-            relNodeMeta.elementType(Types.RELATIONSHIP.name());
+        try (ResourceIterable<Relationship> rels = node.getRelationships(Direction.OUTGOING, type)) {
+            for (Relationship rel : rels) {
+                Node endNode = rel.getEndNode();
+                List<String> labels = toStrings(endNode.getLabels());
+                relMeta.other(labels);
+                relNodeMeta.other(labels);
+                addProperties(typeMeta, type.name(), relConstraints, indexes, rel, node);
+                relNodeMeta.elementType(Types.RELATIONSHIP.name());
+            }
         }
     }
 
@@ -486,11 +489,13 @@ public class Meta {
                 Node node = nodes.next();
                 if (count % skipCount == 0) {
                     long maxRels = metaConfig.getMaxRels();
-                    for (Relationship rel : node.getRelationships(direction, relationshipType)) {
-                        Node otherNode = direction == Direction.OUTGOING ? rel.getEndNode() : rel.getStartNode();
-                        // We have found the rel, we are confident the relationship exists.
-                        if (otherNode.hasLabel(labelToLabel)) return true;
-                        if (maxRels != -1 && maxRels-- == 0) break;
+                    try (ResourceIterable<Relationship> rels = node.getRelationships(direction, relationshipType)) {
+                        for (Relationship rel : rels) {
+                            Node otherNode = direction == Direction.OUTGOING ? rel.getEndNode() : rel.getStartNode();
+                            // We have found the rel, we are confident the relationship exists.
+                            if (otherNode.hasLabel(labelToLabel)) return true;
+                            if (maxRels != -1 && maxRels-- == 0) break;
+                        }
                     }
                 }
                 count++;

--- a/core/src/main/java/apoc/meta/MetaRestricted.java
+++ b/core/src/main/java/apoc/meta/MetaRestricted.java
@@ -938,13 +938,15 @@ public class MetaRestricted {
         relMeta.elementType(Types.of(node).name());
         relMeta.inc().rel(out, in);
         relNodeMeta.inc().rel(out, in);
-        for (Relationship rel : node.getRelationships(Direction.OUTGOING, type)) {
-            Node endNode = rel.getEndNode();
-            List<String> labels = toStrings(endNode.getLabels());
-            relMeta.other(labels);
-            relNodeMeta.other(labels);
-            addProperties(typeMeta, type.name(), relConstraints, indexes, rel, node);
-            relNodeMeta.elementType(Types.RELATIONSHIP.name());
+        try (ResourceIterable<Relationship> rels = node.getRelationships(Direction.OUTGOING, type)) {
+            for (Relationship rel : rels) {
+                Node endNode = rel.getEndNode();
+                List<String> labels = toStrings(endNode.getLabels());
+                relMeta.other(labels);
+                relNodeMeta.other(labels);
+                addProperties(typeMeta, type.name(), relConstraints, indexes, rel, node);
+                relNodeMeta.elementType(Types.RELATIONSHIP.name());
+            }
         }
     }
 

--- a/core/src/main/java/apoc/neighbors/Neighbors.java
+++ b/core/src/main/java/apoc/neighbors/Neighbors.java
@@ -22,6 +22,7 @@ import static apoc.path.RelationshipTypeAndDirections.parse;
 import static apoc.util.Util.getNodeElementId;
 import static apoc.util.Util.getNodeId;
 
+import apoc.util.collection.Iterables;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -40,17 +41,17 @@ public class Neighbors {
     @Context
     public Transaction tx;
 
-    private Iterable<Relationship> getRelationshipsByTypeAndDirection(
+    private ResourceIterable<Relationship> getRelationshipsByTypeAndDirection(
             Node node, Pair<RelationshipType, Direction> typesAndDirection) {
         // as policy if both elements in the pair are null we return an empty result
         if (typesAndDirection.getLeft() == null) {
             return typesAndDirection.getRight() == null
-                    ? Collections.emptyList()
+                    ? Iterables.asResourceIterable(Collections.<Relationship>emptyList())
                     : node.getRelationships(typesAndDirection.getRight());
         }
         if (typesAndDirection.getRight() == null) {
             return typesAndDirection.getLeft() == null
-                    ? Collections.emptyList()
+                    ? Iterables.asResourceIterable(Collections.<Relationship>emptyList())
                     : node.getRelationships(typesAndDirection.getLeft());
         }
         return node.getRelationships(typesAndDirection.getRight(), typesAndDirection.getLeft());
@@ -90,9 +91,11 @@ public class Neighbors {
 
         // First Hop
         for (Pair<RelationshipType, Direction> pair : typesAndDirections) {
-            for (Relationship r : getRelationshipsByTypeAndDirection(node, pair)) {
-                nextB.addLong(
-                        getNodeId((InternalTransaction) tx, r.getOtherNode(node).getElementId()));
+            try (ResourceIterable<Relationship> rels = getRelationshipsByTypeAndDirection(node, pair)) {
+                for (Relationship r : rels) {
+                    nextB.addLong(getNodeId(
+                            (InternalTransaction) tx, r.getOtherNode(node).getElementId()));
+                }
             }
         }
 
@@ -106,9 +109,12 @@ public class Neighbors {
                 nodeElementId = getNodeElementId((InternalTransaction) tx, iterator.next());
                 node = tx.getNodeByElementId(nodeElementId);
                 for (Pair<RelationshipType, Direction> pair : typesAndDirections) {
-                    for (Relationship r : getRelationshipsByTypeAndDirection(node, pair)) {
-                        nextA.add(getNodeId(
-                                (InternalTransaction) tx, r.getOtherNode(node).getElementId()));
+                    try (ResourceIterable<Relationship> rels = getRelationshipsByTypeAndDirection(node, pair)) {
+                        for (Relationship r : rels) {
+                            nextA.add(getNodeId(
+                                    (InternalTransaction) tx,
+                                    r.getOtherNode(node).getElementId()));
+                        }
                     }
                 }
             }
@@ -124,10 +130,12 @@ public class Neighbors {
                     nodeElementId = getNodeElementId((InternalTransaction) tx, iterator.next());
                     node = tx.getNodeByElementId(nodeElementId);
                     for (Pair<RelationshipType, Direction> pair : typesAndDirections) {
-                        for (Relationship r : getRelationshipsByTypeAndDirection(node, pair)) {
-                            nextB.add(getNodeId(
-                                    (InternalTransaction) tx,
-                                    r.getOtherNode(node).getElementId()));
+                        try (ResourceIterable<Relationship> rels = getRelationshipsByTypeAndDirection(node, pair)) {
+                            for (Relationship r : rels) {
+                                nextB.add(getNodeId(
+                                        (InternalTransaction) tx,
+                                        r.getOtherNode(node).getElementId()));
+                            }
                         }
                     }
                 }
@@ -178,9 +186,11 @@ public class Neighbors {
         List<Pair<RelationshipType, Direction>> typesAndDirections = parse(types);
         // First Hop
         for (Pair<RelationshipType, Direction> pair : typesAndDirections) {
-            for (Relationship r : getRelationshipsByTypeAndDirection(node, pair)) {
-                nextB.add(
-                        getNodeId((InternalTransaction) tx, r.getOtherNode(node).getElementId()));
+            try (ResourceIterable<Relationship> rels = getRelationshipsByTypeAndDirection(node, pair)) {
+                for (Relationship r : rels) {
+                    nextB.add(getNodeId(
+                            (InternalTransaction) tx, r.getOtherNode(node).getElementId()));
+                }
             }
         }
 
@@ -194,9 +204,12 @@ public class Neighbors {
                 nodeElementId = getNodeElementId((InternalTransaction) tx, iterator.next());
                 node = tx.getNodeByElementId(nodeElementId);
                 for (Pair<RelationshipType, Direction> pair : typesAndDirections) {
-                    for (Relationship r : getRelationshipsByTypeAndDirection(node, pair)) {
-                        nextA.add(getNodeId(
-                                (InternalTransaction) tx, r.getOtherNode(node).getElementId()));
+                    try (ResourceIterable<Relationship> rels = getRelationshipsByTypeAndDirection(node, pair)) {
+                        for (Relationship r : rels) {
+                            nextA.add(getNodeId(
+                                    (InternalTransaction) tx,
+                                    r.getOtherNode(node).getElementId()));
+                        }
                     }
                 }
             }
@@ -212,10 +225,12 @@ public class Neighbors {
                     nodeElementId = getNodeElementId((InternalTransaction) tx, iterator.next());
                     node = tx.getNodeByElementId(nodeElementId);
                     for (Pair<RelationshipType, Direction> pair : typesAndDirections) {
-                        for (Relationship r : getRelationshipsByTypeAndDirection(node, pair)) {
-                            nextB.add(getNodeId(
-                                    (InternalTransaction) tx,
-                                    r.getOtherNode(node).getElementId()));
+                        try (ResourceIterable<Relationship> rels = getRelationshipsByTypeAndDirection(node, pair)) {
+                            for (Relationship r : rels) {
+                                nextB.add(getNodeId(
+                                        (InternalTransaction) tx,
+                                        r.getOtherNode(node).getElementId()));
+                            }
                         }
                     }
                 }
@@ -270,9 +285,11 @@ public class Neighbors {
         List<Pair<RelationshipType, Direction>> typesAndDirections = parse(types);
         // First Hop
         for (Pair<RelationshipType, Direction> pair : typesAndDirections) {
-            for (Relationship r : getRelationshipsByTypeAndDirection(node, pair)) {
-                seen[0].add(
-                        getNodeId((InternalTransaction) tx, r.getOtherNode(node).getElementId()));
+            try (ResourceIterable<Relationship> rels = getRelationshipsByTypeAndDirection(node, pair)) {
+                for (Relationship r : rels) {
+                    seen[0].add(getNodeId(
+                            (InternalTransaction) tx, r.getOtherNode(node).getElementId()));
+                }
             }
         }
 
@@ -282,9 +299,12 @@ public class Neighbors {
                 nodeElementId = getNodeElementId((InternalTransaction) tx, iterator.next());
                 node = tx.getNodeByElementId(nodeElementId);
                 for (Pair<RelationshipType, Direction> pair : typesAndDirections) {
-                    for (Relationship r : getRelationshipsByTypeAndDirection(node, pair)) {
-                        seen[i].add(getNodeId(
-                                (InternalTransaction) tx, r.getOtherNode(node).getElementId()));
+                    try (ResourceIterable<Relationship> rels = getRelationshipsByTypeAndDirection(node, pair)) {
+                        for (Relationship r : rels) {
+                            seen[i].add(getNodeId(
+                                    (InternalTransaction) tx,
+                                    r.getOtherNode(node).getElementId()));
+                        }
                     }
                 }
             }
@@ -333,9 +353,11 @@ public class Neighbors {
         List<Pair<RelationshipType, Direction>> typesAndDirections = parse(types);
         // First Hop
         for (Pair<RelationshipType, Direction> pair : typesAndDirections) {
-            for (Relationship r : getRelationshipsByTypeAndDirection(node, pair)) {
-                seen[0].add(
-                        getNodeId((InternalTransaction) tx, r.getOtherNode(node).getElementId()));
+            try (ResourceIterable<Relationship> rels = getRelationshipsByTypeAndDirection(node, pair)) {
+                for (Relationship r : rels) {
+                    seen[0].add(getNodeId(
+                            (InternalTransaction) tx, r.getOtherNode(node).getElementId()));
+                }
             }
         }
 
@@ -345,9 +367,12 @@ public class Neighbors {
                 nodeElementId = getNodeElementId((InternalTransaction) tx, iterator.next());
                 node = tx.getNodeByElementId(nodeElementId);
                 for (Pair<RelationshipType, Direction> pair : typesAndDirections) {
-                    for (Relationship r : getRelationshipsByTypeAndDirection(node, pair)) {
-                        seen[i].add(getNodeId(
-                                (InternalTransaction) tx, r.getOtherNode(node).getElementId()));
+                    try (ResourceIterable<Relationship> rels = getRelationshipsByTypeAndDirection(node, pair)) {
+                        for (Relationship r : rels) {
+                            seen[i].add(getNodeId(
+                                    (InternalTransaction) tx,
+                                    r.getOtherNode(node).getElementId()));
+                        }
                     }
                 }
             }
@@ -394,9 +419,11 @@ public class Neighbors {
         List<Pair<RelationshipType, Direction>> typesAndDirections = parse(types);
         // First Hop
         for (Pair<RelationshipType, Direction> pair : typesAndDirections) {
-            for (Relationship r : getRelationshipsByTypeAndDirection(node, pair)) {
-                seen[0].add(
-                        getNodeId((InternalTransaction) tx, r.getOtherNode(node).getElementId()));
+            try (ResourceIterable<Relationship> rels = getRelationshipsByTypeAndDirection(node, pair)) {
+                for (Relationship r : rels) {
+                    seen[0].add(getNodeId(
+                            (InternalTransaction) tx, r.getOtherNode(node).getElementId()));
+                }
             }
         }
 
@@ -406,9 +433,12 @@ public class Neighbors {
                 nodeElementId = getNodeElementId((InternalTransaction) tx, iterator.next());
                 node = tx.getNodeByElementId(nodeElementId);
                 for (Pair<RelationshipType, Direction> pair : typesAndDirections) {
-                    for (Relationship r : getRelationshipsByTypeAndDirection(node, pair)) {
-                        seen[i].add(getNodeId(
-                                (InternalTransaction) tx, r.getOtherNode(node).getElementId()));
+                    try (ResourceIterable<Relationship> rels = getRelationshipsByTypeAndDirection(node, pair)) {
+                        for (Relationship r : rels) {
+                            seen[i].add(getNodeId(
+                                    (InternalTransaction) tx,
+                                    r.getOtherNode(node).getElementId()));
+                        }
                     }
                 }
             }
@@ -457,9 +487,11 @@ public class Neighbors {
         List<Pair<RelationshipType, Direction>> typesAndDirections = parse(types);
         // First Hop
         for (Pair<RelationshipType, Direction> pair : typesAndDirections) {
-            for (Relationship r : getRelationshipsByTypeAndDirection(node, pair)) {
-                seen[0].add(
-                        getNodeId((InternalTransaction) tx, r.getOtherNode(node).getElementId()));
+            try (ResourceIterable<Relationship> rels = getRelationshipsByTypeAndDirection(node, pair)) {
+                for (Relationship r : rels) {
+                    seen[0].add(getNodeId(
+                            (InternalTransaction) tx, r.getOtherNode(node).getElementId()));
+                }
             }
         }
 
@@ -469,9 +501,12 @@ public class Neighbors {
                 nodeElementId = getNodeElementId((InternalTransaction) tx, iterator.next());
                 node = tx.getNodeByElementId(nodeElementId);
                 for (Pair<RelationshipType, Direction> pair : typesAndDirections) {
-                    for (Relationship r : getRelationshipsByTypeAndDirection(node, pair)) {
-                        seen[i].add(getNodeId(
-                                (InternalTransaction) tx, r.getOtherNode(node).getElementId()));
+                    try (ResourceIterable<Relationship> rels = getRelationshipsByTypeAndDirection(node, pair)) {
+                        for (Relationship r : rels) {
+                            seen[i].add(getNodeId(
+                                    (InternalTransaction) tx,
+                                    r.getOtherNode(node).getElementId()));
+                        }
                     }
                 }
             }

--- a/core/src/main/java/apoc/nodes/Grouping.java
+++ b/core/src/main/java/apoc/nodes/Grouping.java
@@ -241,27 +241,29 @@ public class Grouping {
                                 node = Util.rebind(txInThread, node);
                                 NodeKey startKey = entry.getKey();
                                 VirtualNode v1 = virtualNodes.get(startKey);
-                                for (Relationship rel : node.getRelationships(Direction.OUTGOING)) {
-                                    if (includeRels != null
-                                            && !includeRels.contains(
-                                                    rel.getType().name())) continue;
-                                    Node endNode = rel.getEndNode();
-                                    for (NodeKey endKey : keysFor(endNode, labels, keys)) {
-                                        VirtualNode v2 = virtualNodes.get(endKey);
-                                        if (v2 == null) continue;
-                                        if (!selfRels && startKey.equals(endKey)) continue;
-                                        virtualRels.compute(new RelKey(startKey, endKey, rel), (rk, vRel) -> {
-                                            if (vRel == null) vRel = v1.createRelationshipTo(v2, rel.getType());
-                                            if (!relAggNames.isEmpty()) {
-                                                aggregate(
-                                                        vRel,
-                                                        relAggNames,
-                                                        relAggKeys.length > 0
-                                                                ? rel.getProperties(relAggKeys)
-                                                                : Collections.emptyMap());
-                                            }
-                                            return vRel;
-                                        });
+                                try (ResourceIterable<Relationship> rels = node.getRelationships(Direction.OUTGOING)) {
+                                    for (Relationship rel : rels) {
+                                        if (includeRels != null
+                                                && !includeRels.contains(
+                                                        rel.getType().name())) continue;
+                                        Node endNode = rel.getEndNode();
+                                        for (NodeKey endKey : keysFor(endNode, labels, keys)) {
+                                            VirtualNode v2 = virtualNodes.get(endKey);
+                                            if (v2 == null) continue;
+                                            if (!selfRels && startKey.equals(endKey)) continue;
+                                            virtualRels.compute(new RelKey(startKey, endKey, rel), (rk, vRel) -> {
+                                                if (vRel == null) vRel = v1.createRelationshipTo(v2, rel.getType());
+                                                if (!relAggNames.isEmpty()) {
+                                                    aggregate(
+                                                            vRel,
+                                                            relAggNames,
+                                                            relAggKeys.length > 0
+                                                                    ? rel.getProperties(relAggKeys)
+                                                                    : Collections.emptyMap());
+                                                }
+                                                return vRel;
+                                            });
+                                        }
                                     }
                                 }
                             }

--- a/core/src/main/java/apoc/path/PathExplorer.java
+++ b/core/src/main/java/apoc/path/PathExplorer.java
@@ -403,8 +403,12 @@ public class PathExplorer {
         Stream<Path> optionalStream;
         Iterator<Path> itr = stream.iterator();
         if (itr.hasNext()) {
-            optionalStream = StreamSupport.stream(Spliterators.spliteratorUnknownSize(itr, 0), false);
+            // Preserve the source stream's onClose (which closes the underlying Traverser cursor); the
+            // re-wrapped stream would otherwise drop it and leak the traversal cursor under a LIMIT.
+            optionalStream = StreamSupport.stream(Spliterators.spliteratorUnknownSize(itr, 0), false)
+                    .onClose(stream::close);
         } else {
+            stream.close();
             List<Path> listOfNull = new ArrayList<>();
             listOfNull.add(null);
             optionalStream = listOfNull.stream();

--- a/core/src/main/java/apoc/refactor/util/RefactorUtil.java
+++ b/core/src/main/java/apoc/refactor/util/RefactorUtil.java
@@ -32,23 +32,25 @@ public class RefactorUtil {
     public static void mergeRelationshipsWithSameTypeAndDirection(
             Node node, RefactorConfig config, Direction dir, List<String> excludeRelIds) {
         for (RelationshipType type : node.getRelationshipTypes()) {
-            StreamSupport.stream(node.getRelationships(dir, type).spliterator(), false)
-                    .filter(rel -> !excludeRelIds.contains(rel.getElementId()))
-                    .collect(Collectors.groupingBy(rel -> Pair.of(rel.getStartNode(), rel.getEndNode())))
-                    .values()
-                    .stream()
-                    .filter(list -> !list.isEmpty())
-                    .forEach(list -> {
-                        Relationship first = list.get(0);
-                        if (isSelfRel(first) && !config.isCreatingNewSelfRel()) {
-                            list.forEach(Relationship::delete);
-                        } else {
-                            for (int i = 1; i < list.size(); i++) {
-                                Relationship relationship = list.get(i);
-                                mergeRels(relationship, first, true, config);
+            try (ResourceIterable<Relationship> relationships = node.getRelationships(dir, type)) {
+                StreamSupport.stream(relationships.spliterator(), false)
+                        .filter(rel -> !excludeRelIds.contains(rel.getElementId()))
+                        .collect(Collectors.groupingBy(rel -> Pair.of(rel.getStartNode(), rel.getEndNode())))
+                        .values()
+                        .stream()
+                        .filter(list -> !list.isEmpty())
+                        .forEach(list -> {
+                            Relationship first = list.get(0);
+                            if (isSelfRel(first) && !config.isCreatingNewSelfRel()) {
+                                list.forEach(Relationship::delete);
+                            } else {
+                                for (int i = 1; i < list.size(); i++) {
+                                    Relationship relationship = list.get(i);
+                                    mergeRels(relationship, first, true, config);
+                                }
                             }
-                        }
-                    });
+                        });
+            }
         }
     }
 

--- a/core/src/main/java/apoc/trigger/TriggerHandler.java
+++ b/core/src/main/java/apoc/trigger/TriggerHandler.java
@@ -361,10 +361,11 @@ public class TriggerHandler extends LifecycleAdapter implements TransactionEvent
 
         return Util.withBackOffRetries(
                 () -> {
-                    Transaction tx = apocConfig.getSystemDb().beginTx();
-                    T result = action.apply(tx);
-                    tx.commit();
-                    return result;
+                    try (Transaction tx = apocConfig.getSystemDb().beginTx()) {
+                        T result = action.apply(tx);
+                        tx.commit();
+                        return result;
+                    }
                 },
                 timeout,
                 upperTimeout,

--- a/core/src/main/java/apoc/warmup/Warmup.java
+++ b/core/src/main/java/apoc/warmup/Warmup.java
@@ -121,13 +121,14 @@ public class Warmup {
                     long start = System.currentTimeMillis();
                     try {
                         if (pagedFile.fileSize() > 0) {
-                            PageCursor cursor = pagedFile.io(
-                                    0L, PagedFile.PF_READ_AHEAD | PagedFile.PF_SHARED_READ_LOCK, ktx.cursorContext());
-                            while (cursor.next()) {
-                                cursor.getByte();
-                                pages++;
-                                if (pages % 1000 == 0 && Util.transactionIsTerminated(guard)) {
-                                    break;
+                            try (PageCursor cursor = pagedFile.io(
+                                    0L, PagedFile.PF_READ_AHEAD | PagedFile.PF_SHARED_READ_LOCK, ktx.cursorContext())) {
+                                while (cursor.next()) {
+                                    cursor.getByte();
+                                    pages++;
+                                    if (pages % 1000 == 0 && Util.transactionIsTerminated(guard)) {
+                                        break;
+                                    }
                                 }
                             }
                         }

--- a/core/src/test/java/apoc/algo/CoverTest.java
+++ b/core/src/test/java/apoc/algo/CoverTest.java
@@ -147,6 +147,25 @@ class CoverTest {
     }
 
     @Test
+    void testCoverDoesNotLeakCursorsUnderLimit() {
+        // A hub node with many outgoing relationships: a Cypher LIMIT short-circuits apoc.algo.cover's lazy
+        // stream while a relationship cursor is mid-iteration. Before the fix this leaked the cursor and the
+        // commit failed with "Not all allocated cursors were returned".
+        db.executeTransactionally("CREATE (h:Hub) FOREACH (i IN range(1, 20) | CREATE (h)-[:X]->(:Leaf))");
+        TestUtil.testResult(
+                db,
+                """
+                MATCH (n)
+                WITH collect(n) AS nodes
+                CALL apoc.algo.cover(nodes)
+                YIELD rel
+                RETURN rel
+                LIMIT 1
+                """,
+                result -> assertEquals(1L, result.stream().count()));
+    }
+
+    @Test
     void testCoverSubset() {
         // chain of 3; passing only the first two nodes should return only the relationship between them
         db.executeTransactionally("CREATE (:Sub {id: 1})-[:X]->(:Sub {id: 2})-[:X]->(:Sub {id: 3})");

--- a/core/src/test/java/apoc/graph/GraphsTest.java
+++ b/core/src/test/java/apoc/graph/GraphsTest.java
@@ -219,6 +219,29 @@ class GraphsTest {
     }
 
     @Test
+    void testFromDocumentDoesNotLeakCursorsWhenNodesAlreadyExist() throws Exception {
+        Map<String, Object> artistGenesisMap = Util.map("type", "artist", "name", "Genesis", "id", 1L);
+        Map<String, Object> albumGenesisMap =
+                Util.map("type", "album", "producer", "Jonathan King", "id", 1L, "title", "From Genesis to Revelation");
+        Map<String, Object> doc = new HashMap<>() {
+            {
+                putAll(artistGenesisMap);
+                put("albums", List.of(albumGenesisMap));
+            }
+        };
+        Map<String, Object> params =
+                Util.map("json", JsonUtil.OBJECT_MAPPER.writeValueAsString(doc), "config", Util.map("write", true));
+
+        db.executeTransactionally("CALL apoc.graph.fromDocument($json, $config) yield graph RETURN graph", params);
+        TestUtil.testResult(
+                db,
+                "CALL apoc.graph.fromDocument($json, $config) yield graph RETURN graph",
+                params,
+                result -> assertTrue(result.hasNext()));
+        db.executeTransactionally("MATCH p = (a:Artist)-[r:ALBUMS]->(b:Album) detach delete p");
+    }
+
+    @Test
     void testFromDocumentWithCustomRelName() throws Exception {
         Map<String, Object> artistGenesisMap = map("type", "artist", "name", "Genesis", "id", 1L);
         Map<String, Object> albumGenesisMap =


### PR DESCRIPTION
Wrap relationship/node iterables and query Results in try-with-resources
(and keep onClose on procedure-returned streams) so kernel cursors are
released on early exit or exception. Adds regression tests.