### PR TITLE
build: bump spotless to 6.24.0 to fix greclipse nested-jar resolution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id('com.gradleup.shadow') version '8.3.6'
   id("maven-publish")
   id("com.github.hierynomus.license-report") version "0.16.1"
-  id("com.diffplug.spotless") version "6.22.0"
+  id("com.diffplug.spotless") version "6.24.0"
 }
 
 ext {
@@ -74,7 +74,7 @@ allprojects {
     }
     groovyGradle {
       target '*.gradle'
-      greclipse().configFile(rootProject.file('greclipse.properties'))
+      greclipse('4.29').configFile(rootProject.file('greclipse.properties'))
     }
   }
 }


### PR DESCRIPTION
This PR fixes the below exception when running `./gradlew build -x test` on my laptop.

```
Missing required bundle org.eclipse.jdt.debug needed by [org.eclipse.jdt.launching]
Recommend setting osgi.configuration.area to a directory, getDataFile will return null
Error in activator of org.eclipse.equinox.registry
java.lang.RuntimeException: java.nio.file.NoSuchFileException: /Users/ushaikh/.m2/repository/dev/equo/p2-data/nested-jars/org.codehaus.groovy_5.0.0.v202306301519-e2306.jar__groovy-5.0.0.jar__suAxSbSt MyIetCe6Arauw--.jar
```