### PR TITLE
SURF-1348: Trigger duplicate metadate nodes bug

### DIFF
--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -35,7 +35,7 @@ Apache-2.0
   checksums-spi-2.34.0.jar
   commons-cli-1.9.0.jar
   commons-codec-1.19.0.jar
-  commons-codec-1.22.0.jar
+  commons-codec-1.22.1.jar
   commons-collections4-4.4.jar
   commons-compress-1.28.0.jar
   commons-configuration2-2.15.1.jar
@@ -68,10 +68,10 @@ Apache-2.0
   guava-33.5.0-jre.jar
   guice-4.2.3.jar
   guice-servlet-4.2.3.jar
-  hadoop-annotations-3.4.2.jar
-  hadoop-auth-3.4.2.jar
-  hadoop-common-3.4.2-tests.jar
-  hadoop-common-3.4.2.jar
+  hadoop-annotations-3.5.0.jar
+  hadoop-auth-3.5.0.jar
+  hadoop-common-3.5.0-tests.jar
+  hadoop-common-3.5.0.jar
   hadoop-hdfs-3.4.2-tests.jar
   hadoop-hdfs-3.4.2.jar
   hadoop-hdfs-client-3.4.2.jar
@@ -84,8 +84,8 @@ Apache-2.0
   hadoop-mapreduce-client-shuffle-3.4.2.jar
   hadoop-minicluster-3.4.2.jar
   hadoop-registry-3.4.2.jar
-  hadoop-shaded-guava-1.4.0.jar
-  hadoop-shaded-protobuf_3_25-1.4.0.jar
+  hadoop-shaded-guava-1.5.0.jar
+  hadoop-shaded-protobuf_3_25-1.5.0.jar
   hadoop-yarn-api-3.4.2.jar
   hadoop-yarn-client-3.4.2.jar
   hadoop-yarn-common-3.4.2.jar
@@ -124,7 +124,6 @@ Apache-2.0
   javax-websocket-client-impl-9.4.57.v20241219.jar
   javax-websocket-server-impl-9.4.57.v20241219.jar
   javax.inject-1.jar
-  jcip-annotations-1.0-1.jar
   jctools-core-4.0.6.jar
   jettison-1.5.4.jar
   jetty-alpn-java-server-12.1.11.jar
@@ -167,77 +166,77 @@ Apache-2.0
   log4j-core-2.26.1.jar
   log4j-jul-2.26.1.jar
   log4j-layout-template-json-2.26.1.jar
-  lucene-analysis-common-10.5.0.jar
-  lucene-backward-codecs-10.5.0.jar
-  lucene-core-10.5.0.jar
-  lucene-queryparser-10.5.0.jar
+  lucene-analysis-common-10.5.1.jar
+  lucene-backward-codecs-10.5.1.jar
+  lucene-core-10.5.1.jar
+  lucene-queryparser-10.5.1.jar
   magnolia_3-1.3.0.jar
   metrics-core-3.2.4.jar
   metrics-spi-2.34.0.jar
-  netty-all-4.2.14.Final.jar
-  netty-buffer-4.2.16.Final.jar
-  netty-codec-4.2.14.Final.jar
-  netty-codec-base-4.2.16.Final.jar
-  netty-codec-classes-quic-4.2.14.Final.jar
-  netty-codec-compression-4.2.16.Final.jar
-  netty-codec-dns-4.2.14.Final.jar
-  netty-codec-haproxy-4.2.16.Final.jar
-  netty-codec-http-4.2.16.Final.jar
-  netty-codec-http2-4.2.14.Final.jar
-  netty-codec-http3-4.2.14.Final.jar
-  netty-codec-marshalling-4.2.14.Final.jar
-  netty-codec-memcache-4.2.14.Final.jar
-  netty-codec-mqtt-4.2.14.Final.jar
-  netty-codec-native-quic-4.2.14.Final-linux-aarch_64.jar
-  netty-codec-native-quic-4.2.14.Final-linux-x86_64.jar
-  netty-codec-native-quic-4.2.14.Final-osx-aarch_64.jar
-  netty-codec-native-quic-4.2.14.Final-osx-x86_64.jar
-  netty-codec-native-quic-4.2.14.Final-windows-x86_64.jar
-  netty-codec-protobuf-4.2.14.Final.jar
-  netty-codec-redis-4.2.14.Final.jar
-  netty-codec-smtp-4.2.14.Final.jar
-  netty-codec-socks-4.2.14.Final.jar
-  netty-codec-stomp-4.2.14.Final.jar
-  netty-codec-xml-4.2.14.Final.jar
-  netty-common-4.2.16.Final.jar
-  netty-handler-4.2.16.Final.jar
-  netty-handler-proxy-4.2.14.Final.jar
-  netty-handler-ssl-ocsp-4.2.14.Final.jar
+  netty-all-4.2.16.Final.jar
+  netty-buffer-4.2.17.Final.jar
+  netty-codec-4.2.16.Final.jar
+  netty-codec-base-4.2.17.Final.jar
+  netty-codec-classes-quic-4.2.16.Final.jar
+  netty-codec-compression-4.2.17.Final.jar
+  netty-codec-dns-4.2.16.Final.jar
+  netty-codec-haproxy-4.2.17.Final.jar
+  netty-codec-http-4.2.17.Final.jar
+  netty-codec-http2-4.2.16.Final.jar
+  netty-codec-http3-4.2.16.Final.jar
+  netty-codec-marshalling-4.2.16.Final.jar
+  netty-codec-memcache-4.2.16.Final.jar
+  netty-codec-mqtt-4.2.16.Final.jar
+  netty-codec-native-quic-4.2.16.Final-linux-aarch_64.jar
+  netty-codec-native-quic-4.2.16.Final-linux-x86_64.jar
+  netty-codec-native-quic-4.2.16.Final-osx-aarch_64.jar
+  netty-codec-native-quic-4.2.16.Final-osx-x86_64.jar
+  netty-codec-native-quic-4.2.16.Final-windows-x86_64.jar
+  netty-codec-protobuf-4.2.16.Final.jar
+  netty-codec-redis-4.2.16.Final.jar
+  netty-codec-smtp-4.2.16.Final.jar
+  netty-codec-socks-4.2.16.Final.jar
+  netty-codec-stomp-4.2.16.Final.jar
+  netty-codec-xml-4.2.16.Final.jar
+  netty-common-4.2.17.Final.jar
+  netty-handler-4.2.17.Final.jar
+  netty-handler-proxy-4.2.16.Final.jar
+  netty-handler-ssl-ocsp-4.2.16.Final.jar
   netty-nio-client-2.34.0.jar
-  netty-resolver-4.2.16.Final.jar
-  netty-resolver-dns-4.2.14.Final.jar
-  netty-resolver-dns-classes-macos-4.2.14.Final.jar
-  netty-resolver-dns-native-macos-4.2.14.Final-osx-aarch_64.jar
-  netty-resolver-dns-native-macos-4.2.14.Final-osx-x86_64.jar
-  netty-tcnative-classes-2.0.77.Final.jar
-  netty-transport-4.2.16.Final.jar
-  netty-transport-classes-epoll-4.2.16.Final.jar
-  netty-transport-classes-io_uring-4.2.14.Final.jar
-  netty-transport-classes-kqueue-4.2.16.Final.jar
-  netty-transport-native-epoll-4.2.16.Final-linux-aarch_64.jar
-  netty-transport-native-epoll-4.2.16.Final-linux-riscv64.jar
-  netty-transport-native-epoll-4.2.16.Final-linux-x86_64.jar
-  netty-transport-native-epoll-4.2.16.Final.jar
-  netty-transport-native-io_uring-4.2.14.Final-linux-aarch_64.jar
-  netty-transport-native-io_uring-4.2.14.Final-linux-riscv64.jar
-  netty-transport-native-io_uring-4.2.14.Final-linux-x86_64.jar
-  netty-transport-native-kqueue-4.2.16.Final-osx-aarch_64.jar
-  netty-transport-native-kqueue-4.2.16.Final-osx-x86_64.jar
-  netty-transport-native-unix-common-4.2.16.Final.jar
-  netty-transport-rxtx-4.2.14.Final.jar
-  netty-transport-sctp-4.2.14.Final.jar
-  netty-transport-udt-4.2.14.Final.jar
-  nimbus-jose-jwt-9.37.4.jar
+  netty-resolver-4.2.17.Final.jar
+  netty-resolver-dns-4.2.16.Final.jar
+  netty-resolver-dns-classes-macos-4.2.16.Final.jar
+  netty-resolver-dns-native-macos-4.2.16.Final-osx-aarch_64.jar
+  netty-resolver-dns-native-macos-4.2.16.Final-osx-x86_64.jar
+  netty-tcnative-classes-2.0.78.Final.jar
+  netty-transport-4.2.17.Final.jar
+  netty-transport-classes-epoll-4.2.17.Final.jar
+  netty-transport-classes-io_uring-4.2.16.Final.jar
+  netty-transport-classes-kqueue-4.2.17.Final.jar
+  netty-transport-native-epoll-4.2.17.Final-linux-aarch_64.jar
+  netty-transport-native-epoll-4.2.17.Final-linux-riscv64.jar
+  netty-transport-native-epoll-4.2.17.Final-linux-x86_64.jar
+  netty-transport-native-epoll-4.2.17.Final.jar
+  netty-transport-native-io_uring-4.2.16.Final-linux-aarch_64.jar
+  netty-transport-native-io_uring-4.2.16.Final-linux-riscv64.jar
+  netty-transport-native-io_uring-4.2.16.Final-linux-x86_64.jar
+  netty-transport-native-kqueue-4.2.17.Final-osx-aarch_64.jar
+  netty-transport-native-kqueue-4.2.17.Final-osx-x86_64.jar
+  netty-transport-native-unix-common-4.2.17.Final.jar
+  netty-transport-rxtx-4.2.16.Final.jar
+  netty-transport-sctp-4.2.16.Final.jar
+  netty-transport-udt-4.2.16.Final.jar
+  nimbus-jose-jwt-10.4.jar
   objenesis-3.3.jar
   opencsv-5.12.0.jar
   opentest4j-1.3.0.jar
-  parquet-column-1.17.1.jar
-  parquet-common-1.17.1.jar
-  parquet-encoding-1.17.1.jar
+  parquet-column-1.18.0.jar
+  parquet-common-1.18.0.jar
+  parquet-encoding-1.18.0.jar
   parquet-floor-2.1.jar
-  parquet-format-structures-1.17.1.jar
-  parquet-hadoop-1.17.1.jar
-  parquet-jackson-1.17.1.jar
+  parquet-format-structures-1.18.0.jar
+  parquet-hadoop-1.18.0.jar
+  parquet-jackson-1.18.0.jar
   picocli-4.7.7.jar
   profiles-2.34.0.jar
   protocol-core-2.34.0.jar
@@ -260,7 +259,7 @@ Apache-2.0
   shiro-crypto-hash-3.0.0.jar
   shiro-event-3.0.0.jar
   shiro-lang-3.0.0.jar
-  snappy-java-1.1.10.7.jar
+  snappy-java-1.1.10.8.jar
   third-party-jackson-core-2.34.0.jar
   utils-2.34.0.jar
   utils-lite-2.34.0.jar
@@ -481,7 +480,7 @@ BSD-2-Clause
   jline-3.9.0.jar
   jsch-0.1.55.jar
   stax2-api-4.2.1.jar
-  zstd-jni-1.5.7-11.jar
+  zstd-jni-1.5.7-13.jar
 ------------------------------------------------------------------------------
 
 Copyright <year> <copyright holder>
@@ -642,7 +641,6 @@ Common Development and Distribution License Version 1.1
   jersey-json-1.22.0.jar
   jersey-server-1.19.4.jar
   jersey-servlet-1.19.4.jar
-  jsp-api-2.1.jar
   jsr311-api-1.1.1.jar
 ------------------------------------------------------------------------------
 
@@ -1754,16 +1752,21 @@ Eclipse Distribution License - v 1.0
   FastInfoset-1.2.16.jar
   eclipse-collections-11.1.0.jar
   eclipse-collections-api-11.1.0.jar
+  istack-commons-runtime-3.0.12.jar
   istack-commons-runtime-3.0.8.jar
+  jakarta.activation-1.2.2.jar
   jakarta.activation-api-1.2.2.jar
   jakarta.xml.bind-api-2.3.2.jar
+  jakarta.xml.bind-api-2.3.3.jar
   jaxb-runtime-2.3.2.jar
+  jaxb-runtime-2.3.9.jar
   jersey-client-2.46.jar
   jersey-container-servlet-2.46.jar
   jersey-container-servlet-core-2.46.jar
   jersey-hk2-2.46.jar
   stax-ex-1.8.1.jar
   txw2-2.3.2.jar
+  txw2-2.3.9.jar
 ------------------------------------------------------------------------------
 
 Eclipse Distribution License - v 1.0
@@ -2008,11 +2011,13 @@ in any resulting litigation.
 
 ------------------------------------------------------------------------------
 Eclipse Public License - v 2.0
+  aopalliance-repackaged-2.6.1.jar
   hk2-api-2.6.1.jar
   hk2-locator-2.6.1.jar
   hk2-utils-2.6.1.jar
   jakarta.annotation-api-1.3.5.jar
   jakarta.inject-2.6.1.jar
+  jakarta.servlet.jsp-api-2.3.6.jar
   jakarta.ws.rs-api-2.1.6.jar
   jersey-client-2.46.jar
   jersey-common-2.46.jar
@@ -2020,14 +2025,14 @@ Eclipse Public License - v 2.0
   jersey-container-servlet-core-2.46.jar
   jersey-hk2-2.46.jar
   jersey-server-2.46.jar
-  junit-jupiter-6.1.1.jar
-  junit-jupiter-api-6.1.1.jar
-  junit-jupiter-engine-6.1.1.jar
-  junit-jupiter-params-6.1.1.jar
-  junit-platform-commons-6.1.1.jar
-  junit-platform-engine-6.1.1.jar
-  junit-platform-launcher-6.1.1.jar
-  junit-platform-testkit-6.1.1.jar
+  junit-jupiter-6.1.3.jar
+  junit-jupiter-api-6.1.3.jar
+  junit-jupiter-engine-6.1.3.jar
+  junit-jupiter-params-6.1.3.jar
+  junit-platform-commons-6.1.3.jar
+  junit-platform-engine-6.1.3.jar
+  junit-platform-launcher-6.1.3.jar
+  junit-platform-testkit-6.1.3.jar
   osgi-resource-locator-1.0.3.jar
 ------------------------------------------------------------------------------
 
@@ -2707,11 +2712,11 @@ and/or involve the use of third party software.
 
 ------------------------------------------------------------------------------
 MIT
-  bcpkix-jdk18on-1.84.jar
-  bcprov-jdk18on-1.84.jar
-  bcutil-jdk18on-1.84.jar
+  bcpkix-jdk18on-1.85.jar
+  bcprov-jdk18on-1.85.jar
+  bcutil-jdk18on-1.85.jar
   duct-tape-1.0.8.jar
-  java-jwt-4.5.2.jar
+  java-jwt-4.6.0.jar
   jersey-client-2.46.jar
   jersey-container-servlet-2.46.jar
   jersey-container-servlet-core-2.46.jar

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -65,7 +65,7 @@ Apache-2.0
   checksums-spi-2.34.0.jar
   commons-cli-1.9.0.jar
   commons-codec-1.19.0.jar
-  commons-codec-1.22.0.jar
+  commons-codec-1.22.1.jar
   commons-collections4-4.4.jar
   commons-compress-1.28.0.jar
   commons-configuration2-2.15.1.jar
@@ -98,10 +98,10 @@ Apache-2.0
   guava-33.5.0-jre.jar
   guice-4.2.3.jar
   guice-servlet-4.2.3.jar
-  hadoop-annotations-3.4.2.jar
-  hadoop-auth-3.4.2.jar
-  hadoop-common-3.4.2-tests.jar
-  hadoop-common-3.4.2.jar
+  hadoop-annotations-3.5.0.jar
+  hadoop-auth-3.5.0.jar
+  hadoop-common-3.5.0-tests.jar
+  hadoop-common-3.5.0.jar
   hadoop-hdfs-3.4.2-tests.jar
   hadoop-hdfs-3.4.2.jar
   hadoop-hdfs-client-3.4.2.jar
@@ -114,8 +114,8 @@ Apache-2.0
   hadoop-mapreduce-client-shuffle-3.4.2.jar
   hadoop-minicluster-3.4.2.jar
   hadoop-registry-3.4.2.jar
-  hadoop-shaded-guava-1.4.0.jar
-  hadoop-shaded-protobuf_3_25-1.4.0.jar
+  hadoop-shaded-guava-1.5.0.jar
+  hadoop-shaded-protobuf_3_25-1.5.0.jar
   hadoop-yarn-api-3.4.2.jar
   hadoop-yarn-client-3.4.2.jar
   hadoop-yarn-common-3.4.2.jar
@@ -154,7 +154,6 @@ Apache-2.0
   javax-websocket-client-impl-9.4.57.v20241219.jar
   javax-websocket-server-impl-9.4.57.v20241219.jar
   javax.inject-1.jar
-  jcip-annotations-1.0-1.jar
   jctools-core-4.0.6.jar
   jettison-1.5.4.jar
   jetty-alpn-java-server-12.1.11.jar
@@ -197,77 +196,77 @@ Apache-2.0
   log4j-core-2.26.1.jar
   log4j-jul-2.26.1.jar
   log4j-layout-template-json-2.26.1.jar
-  lucene-analysis-common-10.5.0.jar
-  lucene-backward-codecs-10.5.0.jar
-  lucene-core-10.5.0.jar
-  lucene-queryparser-10.5.0.jar
+  lucene-analysis-common-10.5.1.jar
+  lucene-backward-codecs-10.5.1.jar
+  lucene-core-10.5.1.jar
+  lucene-queryparser-10.5.1.jar
   magnolia_3-1.3.0.jar
   metrics-core-3.2.4.jar
   metrics-spi-2.34.0.jar
-  netty-all-4.2.14.Final.jar
-  netty-buffer-4.2.16.Final.jar
-  netty-codec-4.2.14.Final.jar
-  netty-codec-base-4.2.16.Final.jar
-  netty-codec-classes-quic-4.2.14.Final.jar
-  netty-codec-compression-4.2.16.Final.jar
-  netty-codec-dns-4.2.14.Final.jar
-  netty-codec-haproxy-4.2.16.Final.jar
-  netty-codec-http-4.2.16.Final.jar
-  netty-codec-http2-4.2.14.Final.jar
-  netty-codec-http3-4.2.14.Final.jar
-  netty-codec-marshalling-4.2.14.Final.jar
-  netty-codec-memcache-4.2.14.Final.jar
-  netty-codec-mqtt-4.2.14.Final.jar
-  netty-codec-native-quic-4.2.14.Final-linux-aarch_64.jar
-  netty-codec-native-quic-4.2.14.Final-linux-x86_64.jar
-  netty-codec-native-quic-4.2.14.Final-osx-aarch_64.jar
-  netty-codec-native-quic-4.2.14.Final-osx-x86_64.jar
-  netty-codec-native-quic-4.2.14.Final-windows-x86_64.jar
-  netty-codec-protobuf-4.2.14.Final.jar
-  netty-codec-redis-4.2.14.Final.jar
-  netty-codec-smtp-4.2.14.Final.jar
-  netty-codec-socks-4.2.14.Final.jar
-  netty-codec-stomp-4.2.14.Final.jar
-  netty-codec-xml-4.2.14.Final.jar
-  netty-common-4.2.16.Final.jar
-  netty-handler-4.2.16.Final.jar
-  netty-handler-proxy-4.2.14.Final.jar
-  netty-handler-ssl-ocsp-4.2.14.Final.jar
+  netty-all-4.2.16.Final.jar
+  netty-buffer-4.2.17.Final.jar
+  netty-codec-4.2.16.Final.jar
+  netty-codec-base-4.2.17.Final.jar
+  netty-codec-classes-quic-4.2.16.Final.jar
+  netty-codec-compression-4.2.17.Final.jar
+  netty-codec-dns-4.2.16.Final.jar
+  netty-codec-haproxy-4.2.17.Final.jar
+  netty-codec-http-4.2.17.Final.jar
+  netty-codec-http2-4.2.16.Final.jar
+  netty-codec-http3-4.2.16.Final.jar
+  netty-codec-marshalling-4.2.16.Final.jar
+  netty-codec-memcache-4.2.16.Final.jar
+  netty-codec-mqtt-4.2.16.Final.jar
+  netty-codec-native-quic-4.2.16.Final-linux-aarch_64.jar
+  netty-codec-native-quic-4.2.16.Final-linux-x86_64.jar
+  netty-codec-native-quic-4.2.16.Final-osx-aarch_64.jar
+  netty-codec-native-quic-4.2.16.Final-osx-x86_64.jar
+  netty-codec-native-quic-4.2.16.Final-windows-x86_64.jar
+  netty-codec-protobuf-4.2.16.Final.jar
+  netty-codec-redis-4.2.16.Final.jar
+  netty-codec-smtp-4.2.16.Final.jar
+  netty-codec-socks-4.2.16.Final.jar
+  netty-codec-stomp-4.2.16.Final.jar
+  netty-codec-xml-4.2.16.Final.jar
+  netty-common-4.2.17.Final.jar
+  netty-handler-4.2.17.Final.jar
+  netty-handler-proxy-4.2.16.Final.jar
+  netty-handler-ssl-ocsp-4.2.16.Final.jar
   netty-nio-client-2.34.0.jar
-  netty-resolver-4.2.16.Final.jar
-  netty-resolver-dns-4.2.14.Final.jar
-  netty-resolver-dns-classes-macos-4.2.14.Final.jar
-  netty-resolver-dns-native-macos-4.2.14.Final-osx-aarch_64.jar
-  netty-resolver-dns-native-macos-4.2.14.Final-osx-x86_64.jar
-  netty-tcnative-classes-2.0.77.Final.jar
-  netty-transport-4.2.16.Final.jar
-  netty-transport-classes-epoll-4.2.16.Final.jar
-  netty-transport-classes-io_uring-4.2.14.Final.jar
-  netty-transport-classes-kqueue-4.2.16.Final.jar
-  netty-transport-native-epoll-4.2.16.Final-linux-aarch_64.jar
-  netty-transport-native-epoll-4.2.16.Final-linux-riscv64.jar
-  netty-transport-native-epoll-4.2.16.Final-linux-x86_64.jar
-  netty-transport-native-epoll-4.2.16.Final.jar
-  netty-transport-native-io_uring-4.2.14.Final-linux-aarch_64.jar
-  netty-transport-native-io_uring-4.2.14.Final-linux-riscv64.jar
-  netty-transport-native-io_uring-4.2.14.Final-linux-x86_64.jar
-  netty-transport-native-kqueue-4.2.16.Final-osx-aarch_64.jar
-  netty-transport-native-kqueue-4.2.16.Final-osx-x86_64.jar
-  netty-transport-native-unix-common-4.2.16.Final.jar
-  netty-transport-rxtx-4.2.14.Final.jar
-  netty-transport-sctp-4.2.14.Final.jar
-  netty-transport-udt-4.2.14.Final.jar
-  nimbus-jose-jwt-9.37.4.jar
+  netty-resolver-4.2.17.Final.jar
+  netty-resolver-dns-4.2.16.Final.jar
+  netty-resolver-dns-classes-macos-4.2.16.Final.jar
+  netty-resolver-dns-native-macos-4.2.16.Final-osx-aarch_64.jar
+  netty-resolver-dns-native-macos-4.2.16.Final-osx-x86_64.jar
+  netty-tcnative-classes-2.0.78.Final.jar
+  netty-transport-4.2.17.Final.jar
+  netty-transport-classes-epoll-4.2.17.Final.jar
+  netty-transport-classes-io_uring-4.2.16.Final.jar
+  netty-transport-classes-kqueue-4.2.17.Final.jar
+  netty-transport-native-epoll-4.2.17.Final-linux-aarch_64.jar
+  netty-transport-native-epoll-4.2.17.Final-linux-riscv64.jar
+  netty-transport-native-epoll-4.2.17.Final-linux-x86_64.jar
+  netty-transport-native-epoll-4.2.17.Final.jar
+  netty-transport-native-io_uring-4.2.16.Final-linux-aarch_64.jar
+  netty-transport-native-io_uring-4.2.16.Final-linux-riscv64.jar
+  netty-transport-native-io_uring-4.2.16.Final-linux-x86_64.jar
+  netty-transport-native-kqueue-4.2.17.Final-osx-aarch_64.jar
+  netty-transport-native-kqueue-4.2.17.Final-osx-x86_64.jar
+  netty-transport-native-unix-common-4.2.17.Final.jar
+  netty-transport-rxtx-4.2.16.Final.jar
+  netty-transport-sctp-4.2.16.Final.jar
+  netty-transport-udt-4.2.16.Final.jar
+  nimbus-jose-jwt-10.4.jar
   objenesis-3.3.jar
   opencsv-5.12.0.jar
   opentest4j-1.3.0.jar
-  parquet-column-1.17.1.jar
-  parquet-common-1.17.1.jar
-  parquet-encoding-1.17.1.jar
+  parquet-column-1.18.0.jar
+  parquet-common-1.18.0.jar
+  parquet-encoding-1.18.0.jar
   parquet-floor-2.1.jar
-  parquet-format-structures-1.17.1.jar
-  parquet-hadoop-1.17.1.jar
-  parquet-jackson-1.17.1.jar
+  parquet-format-structures-1.18.0.jar
+  parquet-hadoop-1.18.0.jar
+  parquet-jackson-1.18.0.jar
   picocli-4.7.7.jar
   profiles-2.34.0.jar
   protocol-core-2.34.0.jar
@@ -290,7 +289,7 @@ Apache-2.0
   shiro-crypto-hash-3.0.0.jar
   shiro-event-3.0.0.jar
   shiro-lang-3.0.0.jar
-  snappy-java-1.1.10.7.jar
+  snappy-java-1.1.10.8.jar
   third-party-jackson-core-2.34.0.jar
   utils-2.34.0.jar
   utils-lite-2.34.0.jar
@@ -313,7 +312,7 @@ BSD-2-Clause
   jline-3.9.0.jar
   jsch-0.1.55.jar
   stax2-api-4.2.1.jar
-  zstd-jni-1.5.7-11.jar
+  zstd-jni-1.5.7-13.jar
 
 BSD-3-Clause
   asm-9.10.1.jar
@@ -341,7 +340,6 @@ Common Development and Distribution License Version 1.1
   jersey-json-1.22.0.jar
   jersey-server-1.19.4.jar
   jersey-servlet-1.19.4.jar
-  jsp-api-2.1.jar
   jsr311-api-1.1.1.jar
 
 Common Development and Distribution License Version 1.1 and GNU General Public License, version 2 with the Classpath Exception
@@ -379,16 +377,21 @@ Eclipse Distribution License - v 1.0
   FastInfoset-1.2.16.jar
   eclipse-collections-11.1.0.jar
   eclipse-collections-api-11.1.0.jar
+  istack-commons-runtime-3.0.12.jar
   istack-commons-runtime-3.0.8.jar
+  jakarta.activation-1.2.2.jar
   jakarta.activation-api-1.2.2.jar
   jakarta.xml.bind-api-2.3.2.jar
+  jakarta.xml.bind-api-2.3.3.jar
   jaxb-runtime-2.3.2.jar
+  jaxb-runtime-2.3.9.jar
   jersey-client-2.46.jar
   jersey-container-servlet-2.46.jar
   jersey-container-servlet-core-2.46.jar
   jersey-hk2-2.46.jar
   stax-ex-1.8.1.jar
   txw2-2.3.2.jar
+  txw2-2.3.9.jar
 
 Eclipse Public License - Version 1.0
   javax-websocket-client-impl-9.4.57.v20241219.jar
@@ -407,11 +410,13 @@ Eclipse Public License - v 1.0
   eclipse-collections-api-11.1.0.jar
 
 Eclipse Public License - v 2.0
+  aopalliance-repackaged-2.6.1.jar
   hk2-api-2.6.1.jar
   hk2-locator-2.6.1.jar
   hk2-utils-2.6.1.jar
   jakarta.annotation-api-1.3.5.jar
   jakarta.inject-2.6.1.jar
+  jakarta.servlet.jsp-api-2.3.6.jar
   jakarta.ws.rs-api-2.1.6.jar
   jersey-client-2.46.jar
   jersey-common-2.46.jar
@@ -419,14 +424,14 @@ Eclipse Public License - v 2.0
   jersey-container-servlet-core-2.46.jar
   jersey-hk2-2.46.jar
   jersey-server-2.46.jar
-  junit-jupiter-6.1.1.jar
-  junit-jupiter-api-6.1.1.jar
-  junit-jupiter-engine-6.1.1.jar
-  junit-jupiter-params-6.1.1.jar
-  junit-platform-commons-6.1.1.jar
-  junit-platform-engine-6.1.1.jar
-  junit-platform-launcher-6.1.1.jar
-  junit-platform-testkit-6.1.1.jar
+  junit-jupiter-6.1.3.jar
+  junit-jupiter-api-6.1.3.jar
+  junit-jupiter-engine-6.1.3.jar
+  junit-jupiter-params-6.1.3.jar
+  junit-platform-commons-6.1.3.jar
+  junit-platform-engine-6.1.3.jar
+  junit-platform-launcher-6.1.3.jar
+  junit-platform-testkit-6.1.3.jar
   osgi-resource-locator-1.0.3.jar
 
 Eclipse Public License, Version 2.0
@@ -447,11 +452,13 @@ GPL2 w/ CPE
   jersey-servlet-1.19.4.jar
 
 GPL2 w/ CPE
+  aopalliance-repackaged-2.6.1.jar
   hk2-api-2.6.1.jar
   hk2-locator-2.6.1.jar
   hk2-utils-2.6.1.jar
   jakarta.annotation-api-1.3.5.jar
   jakarta.inject-2.6.1.jar
+  jakarta.servlet.jsp-api-2.3.6.jar
   jakarta.ws.rs-api-2.1.6.jar
   jersey-client-2.46.jar
   jersey-container-servlet-2.46.jar
@@ -470,11 +477,11 @@ LGPL-2.1-or-later
   jna-5.19.1.jar
 
 MIT
-  bcpkix-jdk18on-1.84.jar
-  bcprov-jdk18on-1.84.jar
-  bcutil-jdk18on-1.84.jar
+  bcpkix-jdk18on-1.85.jar
+  bcprov-jdk18on-1.85.jar
+  bcutil-jdk18on-1.85.jar
   duct-tape-1.0.8.jar
-  java-jwt-4.5.2.jar
+  java-jwt-4.6.0.jar
   jersey-client-2.46.jar
   jersey-container-servlet-2.46.jar
   jersey-container-servlet-core-2.46.jar

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ subprojects {
     testImplementation('org.junit.jupiter:junit-jupiter')
 
     // We want the same netty version as other neo4j dependencies, are there better ways than to keep this in sync?
-    implementation(platform('io.netty:netty-bom:4.2.14.Final'))
+    implementation(platform('io.netty:netty-bom:4.2.16.Final'))
 
     testRuntimeOnly('org.junit.platform:junit-platform-launcher')
 

--- a/core/src/main/java/apoc/trigger/TriggerHandlerNewProcedures.java
+++ b/core/src/main/java/apoc/trigger/TriggerHandlerNewProcedures.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.neo4j.graphdb.ConstraintViolationException;
+import org.neo4j.graphdb.MultipleFoundException;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
@@ -144,7 +145,15 @@ public class TriggerHandlerNewProcedures {
     }
 
     public static void setLastUpdate(GraphDatabaseAPI db, String databaseName, Transaction tx, int retryNumber) {
-        Node node = tx.findNode(SystemLabels.ApocTriggerMeta, SystemPropertyKeys.database.name(), databaseName);
+        Node node;
+        try {
+            node = tx.findNode(SystemLabels.ApocTriggerMeta, SystemPropertyKeys.database.name(), databaseName);
+        } catch (MultipleFoundException e) {
+            // This can happen if the triggerConstraint uniqueness constraint wasn't in place yet
+            // (e.g. an older APOC version, or a cluster startup race) and duplicate meta nodes were created.
+            // Clean up the duplicates, keeping a single node, and continue updating that one.
+            node = deleteDuplicateTriggerMetaNodes(databaseName, tx);
+        }
         if (node == null) {
             try {
                 node = tx.createNode(SystemLabels.ApocTriggerMeta);
@@ -164,5 +173,20 @@ public class TriggerHandlerNewProcedures {
         }
         final long value = System.currentTimeMillis();
         node.setProperty(SystemPropertyKeys.lastUpdated.name(), value);
+    }
+
+    private static Node deleteDuplicateTriggerMetaNodes(String databaseName, Transaction tx) {
+        ResourceIterator<Node> nodes =
+                tx.findNodes(SystemLabels.ApocTriggerMeta, SystemPropertyKeys.database.name(), databaseName);
+        Node nodeToKeep = null;
+        while (nodes.hasNext()) {
+            Node node = nodes.next();
+            if (nodeToKeep == null) {
+                nodeToKeep = node;
+            } else {
+                node.delete();
+            }
+        }
+        return nodeToKeep;
     }
 }

--- a/core/src/test/java/apoc/trigger/TriggerHandlerNewProceduresTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerHandlerNewProceduresTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package apoc.trigger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import apoc.SystemLabels;
+import apoc.SystemPropertyKeys;
+import com.neo4j.test.extension.ImpermanentEnterpriseDbmsExtension;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.test.extension.Inject;
+
+@ImpermanentEnterpriseDbmsExtension
+class TriggerHandlerNewProceduresTest {
+
+    @Inject
+    GraphDatabaseService db;
+
+    @Test
+    void setLastUpdateRecoversWhenMultipleMetaNodesExistForSameDatabase() {
+        GraphDatabaseAPI dbApi = (GraphDatabaseAPI) db;
+        String databaseName = "neo4j";
+
+        // simulate the edge case where duplicate ApocTriggerMeta nodes exist for the same database name,
+        // e.g. because the triggerConstraint uniqueness constraint wasn't yet in place
+        try (Transaction tx = db.beginTx()) {
+            for (int i = 0; i < 3; i++) {
+                Node node = tx.createNode(SystemLabels.ApocTriggerMeta);
+                node.setProperty(SystemPropertyKeys.database.name(), databaseName);
+            }
+            tx.commit();
+        }
+
+        try (Transaction tx = db.beginTx()) {
+            TriggerHandlerNewProcedures.setLastUpdate(dbApi, databaseName, tx);
+            tx.commit();
+        }
+
+        try (Transaction tx = db.beginTx()) {
+            List<Node> nodes =
+                    tx
+                            .findNodes(SystemLabels.ApocTriggerMeta, SystemPropertyKeys.database.name(), databaseName)
+                            .stream()
+                            .toList();
+            assertEquals(1, nodes.size());
+            assertTrue(nodes.get(0).hasProperty(SystemPropertyKeys.lastUpdated.name()));
+        }
+    }
+}

--- a/core/src/test/java/apoc/trigger/TriggerHandlerNewProceduresTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerHandlerNewProceduresTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import apoc.SystemLabels;
 import apoc.SystemPropertyKeys;
-import com.neo4j.test.extension.ImpermanentEnterpriseDbmsExtension;
+import com.neo4j.test.extension.EnterpriseDbmsExtension;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -32,7 +32,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.extension.Inject;
 
-@ImpermanentEnterpriseDbmsExtension
+@EnterpriseDbmsExtension
 class TriggerHandlerNewProceduresTest {
 
     @Inject
@@ -40,7 +40,6 @@ class TriggerHandlerNewProceduresTest {
 
     @Test
     void setLastUpdateRecoversWhenMultipleMetaNodesExistForSameDatabase() {
-        GraphDatabaseAPI dbApi = (GraphDatabaseAPI) db;
         String databaseName = "neo4j";
 
         // simulate the edge case where duplicate ApocTriggerMeta nodes exist for the same database name,
@@ -54,7 +53,7 @@ class TriggerHandlerNewProceduresTest {
         }
 
         try (Transaction tx = db.beginTx()) {
-            TriggerHandlerNewProcedures.setLastUpdate(dbApi, databaseName, tx);
+            TriggerHandlerNewProcedures.setLastUpdate((GraphDatabaseAPI) db, databaseName, tx);
             tx.commit();
         }
 
@@ -67,5 +66,8 @@ class TriggerHandlerNewProceduresTest {
             assertEquals(1, nodes.size());
             assertTrue(nodes.get(0).hasProperty(SystemPropertyKeys.lastUpdated.name()));
         }
+
+        // Cleanup
+        db.executeTransactionally("MATCH (n) DETACH DELETE n");
     }
 }

--- a/core/src/test/java/apoc/warmup/WarmupTest.java
+++ b/core/src/test/java/apoc/warmup/WarmupTest.java
@@ -145,6 +145,7 @@ class WarmupTest {
     private static void prepareData(GraphDatabaseService database) {
         TestUtil.registerProcedure(database, Warmup.class);
         // Create enough nodes and relationships to span 2 pages
+        database.executeTransactionally("MATCH (n) DETACH DELETE n");
         database.executeTransactionally("CREATE CONSTRAINT FOR (f:Foo) REQUIRE f.foo IS UNIQUE");
         database.executeTransactionally(
                 "UNWIND range(1, 300) AS i CREATE (n:Foo {foo:i})-[:KNOWS {bar:2}]->(m {foobar:3, array:range(1,100)})");


### PR DESCRIPTION
If the constraint has failed and somehow there are 2 metadata trigger nodes, introduce a recovery step of deleting them and updating the remaining.

Also bumped netty as sempgrep failed