### PR TITLE
build: use assignment syntax for Gradle DSL properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ allprojects {
       mavenCentral()
     }
     maven {
-      url "https://repo.gradle.org/gradle/libs-releases"
+      url = "https://repo.gradle.org/gradle/libs-releases"
     }
     mavenLocal()
   }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -109,7 +109,7 @@ publishing {
   }
   publications {
     shadow(MavenPublication) { publication ->
-      artifactId("apoc-common")
+      artifactId = "apoc-common"
       artifact(mySourcesJar)
       artifact(myJavadocJar)
       artifact(testJar)

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -133,7 +133,7 @@ publishing {
   }
   publications {
     shadow(MavenPublication) { publication ->
-      artifactId("apoc-core")
+      artifactId = "apoc-core"
       artifact(mySourcesJar)
       artifact(myJavadocJar)
 

--- a/licenses-3rdparties.gradle
+++ b/licenses-3rdparties.gradle
@@ -162,7 +162,7 @@ tasks.check.dependsOn tasks.validateLicenses
 
 tasks.register("generateLicensesFiles") {
   group = 'license'
-  description 'Generates a LICENSES and NOTICE file with 3rd-party dependency license information'
+  description = 'Generates a LICENSES and NOTICE file with 3rd-party dependency license information'
 
   dependsOn tasks.downloadLicenses, tasks.validateLicenses
 

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -67,7 +67,7 @@ publishing {
   }
   publications {
     shadow(MavenPublication) { publication ->
-      artifactId("apoc-processor")
+      artifactId = "apoc-processor"
       artifact(mySourcesJar)
       artifact(myJavadocJar)
 

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -79,7 +79,7 @@ publishing {
   }
   publications {
     shadow(MavenPublication) { publication ->
-      artifactId("apoc-test-utils")
+      artifactId = "apoc-test-utils"
       artifact(mySourcesJar)
       artifact(myJavadocJar)
 


### PR DESCRIPTION
First of batch of PRs to resolve gradle deprecation warnings (make upgrade to Gradle 9 possible)

Gradle 8.13 deprecates the Groovy DSL space-assignment (`propName value`) and method-call property syntax (`propName(value)`). 

Convert the six places we used them.
